### PR TITLE
fix: update ci for windows binary build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,14 @@ jobs:
             node_platform: linux
             node_arch: arm64
             runner: ubuntu-latest
+          - goos: windows
+            goarch: amd64
+            cc: x86_64-w64-mingw32-gcc
+            cgo_enabled: 1
+            node_platform: win32
+            node_arch: x64
+            runner: windows-latest
           # FIXME: if you need this, fix the build
-          # - goos: windows
-          #   goarch: amd64
-          #   cc: x86_64-w64-mingw32-gcc
-          #   node_platform: win32
-          #   node_arch: x64
-          #   runner: ubuntu-latest
           # - goos: windows
           #   goarch: arm64
           #   cc: aarch64-w64-mingw32-gcc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.24-bullseye
+
+# Install mingw-w64 for cross-compilation
+RUN apt-get update && apt-get install -y gcc-mingw-w64-x86-64
+
+# Set environment variables for cross-compilation
+ENV GOOS=windows
+ENV GOARCH=amd64
+ENV CGO_ENABLED=1
+ENV CC=x86_64-w64-mingw32-gcc
+
+WORKDIR /app
+COPY . .
+
+RUN go build -o cem.exe .

--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ install the package first.
 - `--exclude` / `-e`: Specify patterns to exclude from the manifest.
 - `--output` / `-o`: Write the manifest to a file instead of stdout.
 
+
+## Local Windows Build Using Podman
+
+Running podman will output a cem.exe file in the root directory
+
+```sh
+podman build -t cem-windows .
+podman run --rm -v $(pwd):/output:Z cem-windows cp cem.exe /output/
+```
+
 ## License
 
 This program is free software: you can redistribute it and/or modify it under the terms of the [GNU General Public License v3.0](https://www.gnu.org/licenses/gpl-3.0.html).

--- a/scripts/targets.js
+++ b/scripts/targets.js
@@ -4,8 +4,8 @@ export const targets = [
   { name: "linux-arm64", os: "linux", cpu: "arm64", ext: "" },
   { name: "darwin-x64", os: "darwin", cpu: "x64", ext: "" },
   { name: "darwin-arm64", os: "darwin", cpu: "arm64", ext: "" },
+  { name: "windows-amd64", os: "windows", cpu: "amd64", ext: ".exe" },
   // FIXME: if you need this, fix the build
-  // { name: "win32-x64", os: "win32", cpu: "x64", ext: ".exe" },
-  // { name: "win32-arm64", os: "win32", cpu: "arm64", ext: ".exe" }
+  //{ name: "win32-arm64", os: "windows", cpu: "arm64", ext: ".exe" }
 ];
 


### PR DESCRIPTION
## What I did

- Added a `Dockerfile` for cross-compilation testing 
- Added "Local Windows Build using Podman" section to the readme with instructions to run podman and generate a Windows binary.
- Updated targets.js to include the Windows build.  
- Updated Github CI release workflow with corrected build info.