### PR TITLE
feat: customElements.define support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,7 @@
       "mode": "test",
       "program": "${workspaceFolder}",
       "args": [
+        "test",
         "-run",
         "TestFixture_${input:fixtureName}"
       ]
@@ -22,10 +23,9 @@
         "order": 0
       },
       "args": [
+        ".",
         "generate",
-        "--exclude",
-        "'../redhat-ux/red-hat-design-system/elements/*/*.d.ts'",
-        "../redhat-ux/red-hat-design-system/elements/*/*.ts"
+        "generate/test-fixtures/*.ts"
       ]
     },
     {
@@ -38,6 +38,7 @@
         "order": 1
       },
       "args": [
+        ".",
         "generate",
         "${input:generate}"
       ]
@@ -48,7 +49,7 @@
       "id": "generate",
       "type": "promptString",
       "description": "Arguments...",
-      "default": "--exclude '../redhat-ux/red-hat-design-system/elements/*/*.d.ts' ../redhat-ux/red-hat-design-system/elements/*/*.ts"
+      "default": "generate/test-fixtures/*.ts"
     },
     {
       "id": "fixtureName",

--- a/generate/classDeclarations.go
+++ b/generate/classDeclarations.go
@@ -208,9 +208,9 @@ func (mp *ModuleProcessor) generateLitElementClassDeclaration(
 
 	jsdoc, ok := captures["class.jsdoc"]
 	if (ok && len(jsdoc) > 0) {
-		classInfo, error := NewClassInfo(jsdoc[0].Text, mp.queryManager)
-		if error != nil {
-			errs = errors.Join(errs, error)
+		classInfo, err := NewClassInfo(jsdoc[0].Text, mp.queryManager)
+		if err != nil {
+			errs = errors.Join(errs, err)
 		} else {
 			classInfo.MergeToCustomElementDeclaration(declaration)
 		}

--- a/generate/classDeclarations.go
+++ b/generate/classDeclarations.go
@@ -3,6 +3,7 @@ package generate
 import (
 	"errors"
 	"regexp"
+	"slices"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -12,32 +13,32 @@ import (
 	ts "github.com/tree-sitter/go-tree-sitter"
 )
 
-func generateClassDeclaration(
-	queryManager *QueryManager,
-	captures CaptureMap,
-	root *ts.Node,
-	code []byte,
-) (declaration M.Declaration, err error) {
-	_, isCustomElement := captures["customElement"]
+func (mp *ModuleProcessor) generateClassDeclaration(captures CaptureMap) (declaration M.Declaration, errs error) {
+	_, hasCustomElementDecorator := captures["customElement"]
+	isHTMLElement := false
+	superClassNameNodes, hasSuperClass := captures["superclass.name"]
+	if hasSuperClass {
+		isHTMLElement = superClassNameNodes[0].Text == "HTMLElement"
+	}
+	isCustomElement := hasCustomElementDecorator || isHTMLElement
 	classDeclarationCaptures, hasClassDeclaration := captures["class.declaration"]
 	if (hasClassDeclaration && len(classDeclarationCaptures) > 0) {
 		classDeclarationNodeId := classDeclarationCaptures[0].NodeId
-		classDeclarationNode := GetDescendantById(root, classDeclarationNodeId)
-		if isCustomElement {
-			return generateCustomElementClassDeclaration(queryManager, captures, root, classDeclarationNode, code)
+		classDeclarationNode := GetDescendantById(mp.root, classDeclarationNodeId)
+		if isHTMLElement {
+			return mp.generateHTMLElementClassDeclaration(captures, classDeclarationNode)
+		} else if isCustomElement {
+			return mp.generateLitElementClassDeclaration(captures, classDeclarationNode)
 		} else {
-			return generateCommonClassDeclaration(queryManager, captures, root, classDeclarationNode, code, isCustomElement)
+			return mp.generateCommonClassDeclaration(captures, classDeclarationNode, isCustomElement)
 		}
 	}
-	return nil, errors.New("Could not find class declaration")
+	return nil, errors.Join(errs, errors.New("Could not find class declaration"))
 }
 
-func generateCommonClassDeclaration(
-	queryManager *QueryManager,
+func (mp *ModuleProcessor) generateCommonClassDeclaration(
 	captures CaptureMap,
-	root *ts.Node,
 	classDeclarationNode *ts.Node,
-	code []byte,
 	isCustomElement bool,
 ) (declaration *M.ClassDeclaration, errs error) {
 	className, ok := captures["class.name"]
@@ -53,14 +54,33 @@ func generateCommonClassDeclaration(
 		},
 	}
 
-	err, members := getClassMembersFromClassDeclarationNode(
-		queryManager,
-		code,
-		declaration.ClassLike.Name,
-		root,
-		classDeclarationNode,
-		isCustomElement,
-	)
+	var superclassName string
+	superClassNameNodes, ok := captures["superclass.name"]
+	if (ok && len(superClassNameNodes) > 0) {
+		superclassName = superClassNameNodes[0].Text
+		pkg := ""
+		module := ""
+		switch superclassName {
+		case
+			"Event",
+			"CustomEvent",
+			"ErrorEvent":
+		  pkg = "global:"
+		case "HTMLElement":
+			pkg = "global:"
+			isCustomElement = true
+		case "LitElement":
+			pkg = "lit"
+		case "ReactiveElement":
+			pkg = "@lit/reactive-element"
+		// TODO: compute package and module
+		// default:
+		}
+		declaration.Superclass = M.NewReference(superclassName, pkg, module)
+	}
+
+	members, err :=
+		mp.getClassMembersFromClassDeclarationNode(declaration.ClassLike.Name, classDeclarationNode, superclassName)
 	if err != nil {
 		errs = errors.Join(errs, err)
 	}
@@ -69,33 +89,11 @@ func generateCommonClassDeclaration(
 		declaration.Members = append(declaration.Members, method)
 	}
 
-	superClassName, ok := captures["superclass.name"]
-	if (ok && len(superClassName) > 0) {
-		name := superClassName[0].Text
-		pkg := ""
-		module := ""
-		switch name {
-		case
-			"Event",
-			"CustomEvent",
-			"ErrorEvent",
-			"HTMLElement":
-		  pkg = "global:"
-		case "LitElement":
-			pkg = "lit"
-		case "ReactiveElement":
-			pkg = "@lit/reactive-element"
-		// TODO: compute package and module
-		// default:
-		}
-		declaration.Superclass = M.NewReference(name, pkg, module)
-	}
-
 	jsdoc, ok := captures["class.jsdoc"]
 	if (ok && len(jsdoc) > 0) {
-		err, info := NewClassInfo(jsdoc[0].Text, queryManager)
+		info, err := NewClassInfo(jsdoc[0].Text, mp.queryManager)
 		if err != nil {
-			errs = errors.Join(errs, err)
+			mp.errors = errors.Join(mp.errors, err)
 		} else {
 			info.MergeToClassDeclaration(declaration)
 		}
@@ -104,69 +102,100 @@ func generateCommonClassDeclaration(
 	return declaration, nil
 }
 
-func generateCustomElementClassDeclaration(
-	queryManager *QueryManager,
+func (mp *ModuleProcessor) generateHTMLElementClassDeclaration(
 	captures CaptureMap,
-	root *ts.Node,
 	classDeclarationNode *ts.Node,
-	code []byte,
 ) (declaration *M.CustomElementDeclaration, errs error) {
-	classDeclaration, err := generateCommonClassDeclaration(
-		queryManager,
-		captures,
-		root,
-		classDeclarationNode,
-		code,
-		true,
-	)
+	classDeclaration, err := mp.generateCommonClassDeclaration(captures, classDeclarationNode, true)
 	if err != nil {
 		errs = errors.Join(errs, err)
 	}
 
 	declaration = &M.CustomElementDeclaration{
 		ClassDeclaration: *classDeclaration,
+		CustomElement: M.CustomElement{
+			CustomElement: true,
+		},
+	}
+
+	for _, name := range captures["observedAttributes.attributeName"] {
+		declaration.CustomElement.Attributes = append(declaration.CustomElement.Attributes, M.Attribute{
+			Name: name.Text,
+			StartByte: name.StartByte,
+		})
+	}
+
+	jsdoc, ok := captures["class.jsdoc"]
+	if (ok && len(jsdoc) > 0) {
+		info, err := NewClassInfo(jsdoc[0].Text, mp.queryManager)
+		if err != nil {
+			mp.errors = errors.Join(mp.errors, err)
+		} else {
+			info.MergeToCustomElementDeclaration(declaration)
+		}
+	}
+
+	slices.SortStableFunc(declaration.Attributes, func(a M.Attribute, b M.Attribute) int {
+		return int(a.StartByte - b.StartByte)
+	})
+
+	return declaration, errs
+}
+
+
+
+func (mp *ModuleProcessor) generateLitElementClassDeclaration(
+	captures CaptureMap,
+	classDeclarationNode *ts.Node,
+) (declaration *M.CustomElementDeclaration, errs error) {
+	classDeclaration, err := mp.generateCommonClassDeclaration(captures, classDeclarationNode, true)
+	if err != nil {
+		errs = errors.Join(errs, err)
+	}
+
+	declaration = &M.CustomElementDeclaration{
+		ClassDeclaration: *classDeclaration,
+		CustomElement: M.CustomElement{
+			CustomElement: true,
+		},
 	}
 
 	tagNameNodes, ok := captures["tag-name"]
-	if (!ok || len(tagNameNodes) < 1) {
-		errs = errors.Join(errs, &NoCaptureError{ "tag-name", "customElementDeclaration"  })
-	} else {
-
+	if (ok && len(tagNameNodes) > 0) {
 		tagName := tagNameNodes[0].Text
-
 		if (tagName != "") {
-			declaration.CustomElement = M.CustomElement{
-				CustomElement: true,
-				TagName:       tagName,
-			}
-
-			declaration.CustomElement.Attributes = A.Chain(func(member M.ClassMember) []M.Attribute {
-				field, ok := (member).(M.CustomElementField)
-				if (ok && field.Attribute != "") {
-					return []M.Attribute{{
-						Name:        field.Attribute,
-						Summary:     field.Summary,
-						Description: field.Description,
-						Deprecated:  field.Deprecated,
-						Default:     field.Default,
-						Type:        field.Type,
-						FieldName:   field.Name,
-					}}
-				} else {
-					return []M.Attribute{}
-				}
-			})(declaration.Members)
+			declaration.CustomElement.TagName = tagName
 		}
+	} else {
+		errs = errors.Join(errs, &NoCaptureError{ "tag-name", "customElementDeclaration"  })
 	}
+
+	declaration.CustomElement.Attributes = A.Chain(func(member M.ClassMember) []M.Attribute {
+		field, ok := (member).(M.CustomElementField)
+		if (ok && field.Attribute != "") {
+			return []M.Attribute{{
+				Name:        field.Attribute,
+				Summary:     field.Summary,
+				Description: field.Description,
+				Deprecated:  field.Deprecated,
+				Default:     field.Default,
+				Type:        field.Type,
+				FieldName:   field.Name,
+				StartByte:   field.StartByte,
+			}}
+		} else {
+			return []M.Attribute{}
+		}
+	})(declaration.Members)
 
 	renderTemplateNodes, hasRenderTemplate := captures["render.template"]
 	if hasRenderTemplate {
 		renderTemplateNodeId := renderTemplateNodes[0].NodeId
-		renderTemplateNode := GetDescendantById(root, renderTemplateNodeId)
+		renderTemplateNode := GetDescendantById(mp.root, renderTemplateNodeId)
 		if renderTemplateNode != nil {
-			htmlSource := renderTemplateNode.Utf8Text(code)
+			htmlSource := renderTemplateNode.Utf8Text(mp.code)
 			if htmlSource != "" {
-				htmlSlots, htmlParts, htmlErr := analyzeHtmlSlotsAndParts(queryManager, htmlSource)
+				htmlSlots, htmlParts, htmlErr := analyzeHtmlSlotsAndParts(mp.queryManager, htmlSource)
 				if htmlErr != nil {
 					errs = errors.Join(errs, htmlErr)
 				}
@@ -179,13 +208,17 @@ func generateCustomElementClassDeclaration(
 
 	jsdoc, ok := captures["class.jsdoc"]
 	if (ok && len(jsdoc) > 0) {
-		error, classInfo := NewClassInfo(jsdoc[0].Text, queryManager)
+		classInfo, error := NewClassInfo(jsdoc[0].Text, mp.queryManager)
 		if error != nil {
 			errs = errors.Join(errs, error)
 		} else {
 			classInfo.MergeToCustomElementDeclaration(declaration)
 		}
 	}
+
+	slices.SortStableFunc(declaration.Attributes, func(a M.Attribute, b M.Attribute) int {
+		return int(a.StartByte - b.StartByte)
+	})
 
 	return declaration, errs
 }

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -111,7 +111,9 @@ func Generate(args GenerateArgs) (*string, error) {
 					continue
 				}
 
-				err, module := generateModule(file, code, queryManager)
+				mp := NewModuleProcessor(file, code, queryManager)
+				module, err := mp.Collect()
+				mp.Close()
 				if err != nil {
 					errs = errors.Join(errs, errors.New(fmt.Sprintf("Problem generating module %s", file)), err)
 					continue

--- a/generate/modules.go
+++ b/generate/modules.go
@@ -114,8 +114,7 @@ func (mp *ModuleProcessor) Collect() (module *M.Module, errors error) {
 }
 
 func (mp *ModuleProcessor) processVariables() {
-	queryName := "variableDeclaration"
-	qm, err := NewQueryMatcher(mp.queryManager, "typescript", queryName)
+	qm, err := NewQueryMatcher(mp.queryManager, "typescript", "variableDeclaration")
 	if err != nil {
 		mp.errors = errors.Join(mp.errors, err)
 		return
@@ -132,8 +131,7 @@ func (mp *ModuleProcessor) processVariables() {
 }
 
 func (mp *ModuleProcessor) processFunctions() {
-	queryName := "functionDeclaration"
-	qm, err := NewQueryMatcher(mp.queryManager, "typescript", queryName)
+	qm, err := NewQueryMatcher(mp.queryManager, "typescript",  "functionDeclaration")
 	if err != nil {
 		mp.errors = errors.Join(mp.errors, err)
 		return
@@ -150,8 +148,7 @@ func (mp *ModuleProcessor) processFunctions() {
 }
 
 func (mp *ModuleProcessor) processClassDeclarations() {
-	queryName := "classDeclaration"
-	qm, err := NewQueryMatcher(mp.queryManager, "typescript", queryName)
+	qm, err := NewQueryMatcher(mp.queryManager, "typescript", "classDeclaration")
 	if err != nil {
 		mp.errors = errors.Join(mp.errors, err)
 		return

--- a/generate/modules.go
+++ b/generate/modules.go
@@ -61,7 +61,7 @@ func ammendStylesMapFromSource(
 }
 
 // ModuleProcessor is responsible for parsing a typescript module (file)
-// and populating it's associated custom element manifest Module object
+// and populating its associated custom element manifest Module object
 // because parsing involves tree sitter objects which are written in C
 // we need to free those resources when finished with them, so ModuleProcessor
 // is also responsible for closing its associated C resources.

--- a/generate/queries/typescript/classDeclaration.scm
+++ b/generate/queries/typescript/classDeclaration.scm
@@ -44,25 +44,76 @@
           value: (string
             (string_fragment) @type) (#eq? @type "css"))))))
 
-( ; non-custom element class
+( ; exported non-litelement class
   ;
   ; example:
   ; ```ts
-  ; class Whatever extends Thing {}
+  ; export class Whatever extends Thing {}
   ; ```
   (comment)* @class.jsdoc . (#match? @class.jsdoc "^/\\*\\*")
   (export_statement
-    (decorator
-      (call_expression
-        function: (identifier) @class.decorator.name
-        (#not-eq? @class.decorator.name "customElement"))) *
     declaration: (class_declaration
       name: (_) @class.name
+      (#not-eq? @class.name "LitElement")
       (class_heritage
         (extends_clause
-          value: (identifier) @superclass.name))?) @class.declaration)) @class
+          value: (identifier) @superclass.name))?
+      body: (class_body
+        ; static observedAttributes = ['a', 'b']
+        (public_field_definition
+          "static"
+          name: (property_identifier) @observedAttributes.fieldName (#eq? @observedAttributes.fieldName "observedAttributes")
+          value: (array
+            (string
+              (string_fragment) @observedAttributes.attributeName)))? @observedAttributes
 
-( ; exported custom element class
+        ; static get observedAttributes() { return ['a', 'b']; }
+        (method_definition
+          "static"
+          "get"
+          name: (property_identifier) @observedAttributes.fieldName
+          parameters: (formal_parameters)
+          body: (statement_block
+            (return_statement
+              (array
+                (string
+                  (string_fragment) @observedAttributes.attributeName)))))? @observedAttributes)) @class.declaration)) @class
+
+( ; non-exported non-litelement class
+  ;
+  ; example:
+  ; ```ts
+  ; export class Whatever extends Thing {}
+  ; ```
+  (comment)* @class.jsdoc . (#match? @class.jsdoc "^/\\*\\*")
+  (class_declaration
+    name: (_) @class.name
+    (#not-eq? @class.name "LitElement")
+    (class_heritage
+      (extends_clause
+        value: (identifier) @superclass.name))?
+    body: (class_body
+      ; static observedAttributes = ['a', 'b']
+      (public_field_definition
+        "static"
+        name: (property_identifier) @observedAttributes.fieldName (#eq? @observedAttributes.fieldName "observedAttributes")
+        value: (array
+          (string
+            (string_fragment) @observedAttributes.attributeName)))? @observedAttributes
+
+      ; static get observedAttributes() { return ['a', 'b']; }
+      (method_definition
+        "static"
+        "get"
+        name: (property_identifier) @observedAttributes.fieldName
+        parameters: (formal_parameters)
+        body: (statement_block
+          (return_statement
+            (array
+              (string
+                (string_fragment) @observedAttributes.attributeName)))))? @observedAttributes)) @class.declaration) @class
+
+( ; exported litelement class
   ;
   ; example:
   ; ```ts
@@ -111,7 +162,7 @@
                         (string_fragment) @render.template)))))?)
       ) @class.declaration)) @customElement @class
 
-( ; non-exported custom element class
+( ; non-exported litelement class
   ;
   ; example:
   ; ```ts

--- a/generate/queries/typescript/classDeclaration.scm
+++ b/generate/queries/typescript/classDeclaration.scm
@@ -1,3 +1,30 @@
+( ; non-style import statement
+  ; we'll need these to match up class declarations to element definitions
+  (import_statement
+    (import_clause [
+      ; Default imports
+      ; NB: we're not doing any introspection or cross-file compilation here.
+      ; we just take the default import name at face value
+      ; so if you do `export default class MyClass {}`, but then
+      ; but `import HerClass from './my-class.js';`
+      ; then the declaration name will be HerClass
+      ; TODO: after processing all files, we can cross-reference default exports
+      ; and fix this
+      (identifier) @import.binding @import.name
+      ; Named imports with no alias binding
+      (named_imports
+        (import_specifier
+          name: (identifier) @import.binding @import.name
+          !alias))
+      ; Named imports with alias binding
+      (named_imports
+          (import_specifier
+            name: (identifier) @import.name
+            alias: (identifier) @import.binding))
+    ])
+    source: (string
+              (string_fragment) @import.spec (#not-match? @import.spec "\..*\.css$")))) @import
+
 ( ; style import import_statement (no attribute)
   (import_clause
     (identifier) @styleImport.binding)
@@ -131,4 +158,3 @@
                           (string_fragment) @style.string (#eq? @func "css")))
                      ] @customElement.styles (#eq? @_fieldname "styles"))?)
     ) @class.declaration) @customElement @class
-

--- a/generate/queries/typescript/exports.scm
+++ b/generate/queries/typescript/exports.scm
@@ -33,3 +33,13 @@
                      name: (identifier) @declaration.name
                      value: (_ parameters: (_)) @declaration.function))
                ] @declaration) @export
+
+( ; customElements.define('tag-name', Class);
+ call_expression
+  function: (member_expression
+    object: (identifier) @ce.namespace (#eq? @ce.namespace "customElements")
+    property: (property_identifier) @ce.methodname) (#eq? @ce.methodname "define")
+  arguments: (arguments
+    (string
+      (string_fragment) @ce.tagName)
+    (identifier) @ce.className)) @ce

--- a/generate/test-fixtures/vanilla-attributes.ts
+++ b/generate/test-fixtures/vanilla-attributes.ts
@@ -1,0 +1,9 @@
+/** @customElement vanilla-attributes */
+class VanillaAttributes extends HTMLElement {
+  static observedAttributes = ['a', 'b'];
+  static get observedAttributes() {
+    return ['c'];
+  }
+}
+
+customElements.define('vanilla-attributes', VanillaAttributes);

--- a/generate/test-fixtures/vanilla-declare.ts
+++ b/generate/test-fixtures/vanilla-declare.ts
@@ -1,0 +1,1 @@
+export class VanillaElement extends HTMLElement {}

--- a/generate/test-fixtures/vanilla-define.ts
+++ b/generate/test-fixtures/vanilla-define.ts
@@ -1,0 +1,7 @@
+import { VanillaElement } from './vanilla-declare.js';
+import { VanillaElement as NamedBindingElement } from './vanilla-declare.js';
+import DefaultImportElement from './vanilla-declare.js';
+
+customElements.define('vanilla-element', VanillaElement);
+customElements.define('vanilla-element-named', NamedBindingElement);
+customElements.define('vanilla-element-default', DefaultImportElement);

--- a/generate/test-golden/class-exports.json
+++ b/generate/test-golden/class-exports.json
@@ -32,22 +32,6 @@
       ],
       "exports": [
         {
-          "kind": "js",
-          "name": "ClassExported",
-          "declaration": {
-            "name": "ClassExported",
-            "module": "test-fixtures/class-exports.js"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "ClassExportedCe",
-          "declaration": {
-            "name": "ClassExportedCe",
-            "module": "test-fixtures/class-exports.js"
-          }
-        },
-        {
           "kind": "custom-element-definition",
           "name": "class-ce",
           "declaration": {
@@ -56,8 +40,24 @@
           }
         },
         {
+          "kind": "js",
+          "name": "ClassExported",
+          "declaration": {
+            "name": "ClassExported",
+            "module": "test-fixtures/class-exports.js"
+          }
+        },
+        {
           "kind": "custom-element-definition",
           "name": "class-exported-ce",
+          "declaration": {
+            "name": "ClassExportedCe",
+            "module": "test-fixtures/class-exports.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "ClassExportedCe",
           "declaration": {
             "name": "ClassExportedCe",
             "module": "test-fixtures/class-exports.js"

--- a/generate/test-golden/export-class.json
+++ b/generate/test-golden/export-class.json
@@ -22,6 +22,10 @@
             "name": "Simple"
           },
           "kind": "class"
+        },
+        {
+          "name": "Foo",
+          "kind": "class"
         }
       ],
       "exports": [

--- a/generate/test-golden/jsdoc-attr.json
+++ b/generate/test-golden/jsdoc-attr.json
@@ -25,6 +25,13 @@
           "tagName": "jsdoc-attr",
           "attributes": [
             {
+              "name": "classattr",
+              "type": {
+                "text": "string"
+              },
+              "fieldName": "classAttr"
+            },
+            {
               "name": "attr"
             },
             {
@@ -85,13 +92,6 @@
               "type": {
                 "text": "number"
               }
-            },
-            {
-              "name": "classattr",
-              "type": {
-                "text": "string"
-              },
-              "fieldName": "classAttr"
             }
           ],
           "customElement": true

--- a/generate/test-golden/static-styles.json
+++ b/generate/test-golden/static-styles.json
@@ -15,20 +15,7 @@
           "tagName": "static-styles",
           "cssProperties": [
             {
-              "name": "--deprecated",
-              "deprecated": "reason"
-            },
-            {
-              "name": "--has-default",
-              "default": "0, red, green"
-            },
-            {
               "name": "--in-attribute-import"
-            },
-            {
-              "name": "--in-attribute-import-description",
-              "summary": "summary",
-              "description": "in-attribute-import-description"
             },
             {
               "name": "--in-non-attribute-import",
@@ -41,6 +28,19 @@
             {
               "name": "--tagged-template-in-style-array",
               "description": "tagged-template-in-style-array"
+            },
+            {
+              "name": "--has-default",
+              "default": "0, red, green"
+            },
+            {
+              "name": "--in-attribute-import-description",
+              "summary": "summary",
+              "description": "in-attribute-import-description"
+            },
+            {
+              "name": "--deprecated",
+              "deprecated": "reason"
             },
             {
               "name": "--token-color",

--- a/generate/test-golden/vanilla-attributes.json
+++ b/generate/test-golden/vanilla-attributes.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": "1.0.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "test-fixtures/vanilla-attributes.js",
+      "declarations": [
+        {
+          "name": "VanillaAttributes",
+          "superclass": {
+            "name": "HTMLElement",
+            "package": "global:"
+          },
+          "kind": "class",
+          "tagName": "vanilla-attributes",
+          "attributes": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            },
+            {
+              "name": "c"
+            }
+          ],
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "vanilla-attributes",
+          "declaration": {
+            "name": "VanillaAttributes",
+            "module": "test-fixtures/vanilla-attributes.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/generate/test-golden/vanilla-declare.json
+++ b/generate/test-golden/vanilla-declare.json
@@ -1,0 +1,29 @@
+{
+  "schemaVersion": "1.0.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "test-fixtures/vanilla-declare.js",
+      "declarations": [
+        {
+          "name": "VanillaElement",
+          "superclass": {
+            "name": "HTMLElement",
+            "package": "global:"
+          },
+          "kind": "class"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "VanillaElement",
+          "declaration": {
+            "name": "VanillaElement",
+            "module": "test-fixtures/vanilla-declare.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/generate/test-golden/vanilla-declare.json
+++ b/generate/test-golden/vanilla-declare.json
@@ -11,10 +11,19 @@
             "name": "HTMLElement",
             "package": "global:"
           },
-          "kind": "class"
+          "kind": "class",
+          "customElement": true
         }
       ],
       "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "",
+          "declaration": {
+            "name": "VanillaElement",
+            "module": "test-fixtures/vanilla-declare.js"
+          }
+        },
         {
           "kind": "js",
           "name": "VanillaElement",

--- a/generate/test-golden/vanilla-define.json
+++ b/generate/test-golden/vanilla-define.json
@@ -11,8 +11,7 @@
           "declaration": {
             "name": "VanillaElement",
             "module": "./vanilla-declare.js"
-          },
-          "deprecated": null
+          }
         },
         {
           "kind": "custom-element-definition",
@@ -20,8 +19,7 @@
           "declaration": {
             "name": "VanillaElement",
             "module": "./vanilla-declare.js"
-          },
-          "deprecated": null
+          }
         },
         {
           "kind": "custom-element-definition",
@@ -29,8 +27,7 @@
           "declaration": {
             "name": "DefaultImportElement",
             "module": "./vanilla-declare.js"
-          },
-          "deprecated": null
+          }
         }
       ]
     }

--- a/generate/test-golden/vanilla-define.json
+++ b/generate/test-golden/vanilla-define.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "test-fixtures/vanilla-define.js",
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "vanilla-element",
+          "declaration": {
+            "name": "VanillaElement",
+            "module": "./vanilla-declare.js"
+          },
+          "deprecated": null
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "vanilla-element-named",
+          "declaration": {
+            "name": "VanillaElement",
+            "module": "./vanilla-declare.js"
+          },
+          "deprecated": null
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "vanilla-element-default",
+          "declaration": {
+            "name": "DefaultImportElement",
+            "module": "./vanilla-declare.js"
+          },
+          "deprecated": null
+        }
+      ]
+    }
+  ]
+}

--- a/generate/treesitter.go
+++ b/generate/treesitter.go
@@ -175,6 +175,7 @@ type QueryMatcher struct {
 }
 
 func (qm QueryMatcher) Close() {
+	// NOTE: we don't close queries here, only at the end of execution in QueryManager.Close
 	qm.cursor.Close()
 }
 

--- a/generate/treesitter.go
+++ b/generate/treesitter.go
@@ -175,7 +175,6 @@ type QueryMatcher struct {
 }
 
 func (qm QueryMatcher) Close() {
-	// qm.query.Close()
 	qm.cursor.Close()
 }
 
@@ -189,8 +188,8 @@ func NewQueryMatcher(
 		return nil, error
 	}
 	cursor := ts.NewQueryCursor()
-	thing := QueryMatcher{ query, cursor }
-	return &thing, nil
+	qm := QueryMatcher{ query, cursor }
+	return &qm, nil
 }
 
 func (q QueryMatcher) AllQueryMatches(node *ts.Node, text []byte) iter.Seq[*ts.QueryMatch] {
@@ -208,34 +207,14 @@ func (q QueryMatcher) AllQueryMatches(node *ts.Node, text []byte) iter.Seq[*ts.Q
 	}
 }
 
-func (q QueryMatcher) GetCapturesFromMatch(match *ts.QueryMatch, code []byte) CaptureMap {
-	names := q.query.CaptureNames()
-	captures := make(CaptureMap)
-	for _, capture := range match.Captures {
-		name := names[capture.Index]
-		_, ok := captures[name]
-		if !ok {
-			captures[name] = make([]CaptureInfo, 0)
-		}
-		text := capture.Node.Utf8Text(code)
-		captures[name] = append(captures[name], CaptureInfo{
-			NodeId: int(capture.Node.Id()),
-			Text: text,
-			StartByte: capture.Node.StartByte(),
-			EndByte: capture.Node.EndByte(),
-		})
-	}
-	return captures
-}
-
-// ParentIterator returns an iterator over unique parent node captures as identified by the given parent capture name.
+// ParentCaptures returns an iterator over unique parent node captures as identified by the given parent capture name.
 // For each unique parent node (e.g., a field or method), it aggregates all captures from all query matches sharing 
 // that parent node into a single CaptureMap. This allows you to collect all related captures (such as attributes, 
 // decorators, etc.) for each parent node in the source AST.
 //
 // Example usage:
 //
-//   for captures := range matcher.ParentIterator(root, code, "field") {
+//   for captures := range matcher.ParentCaptures(root, code, "field") {
 //     // captures represents the captured nodes for a single field
 //     addFieldToDeclaration(captures, declaration)
 //   }

--- a/generate/treesitter.go
+++ b/generate/treesitter.go
@@ -274,6 +274,8 @@ func (q *QueryMatcher) ParentCaptures(root *ts.Node, code []byte, parentCaptureN
 			ci := CaptureInfo{
 				NodeId: int(cap.Node.Id()),
 				Text:   text,
+				StartByte: cap.Node.StartByte(),
+				EndByte: cap.Node.EndByte(),
 			}
 			if _, hasMap := parentGroups[pid].capMap[name]; !hasMap {
 				parentGroups[pid].capMap[name] = make([]CaptureInfo, 0)

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -70,6 +70,20 @@ type CustomElementExport struct {
 	Deprecated  any        `json:"deprecated,omitempty"` // bool or string
 }
 func (*CustomElementExport) isExport() {}
+func NewCustomElementExport(
+	tagName string,
+	declaration *Reference,
+	startByte uint,
+	deprecated *Deprecated,
+) *CustomElementExport {
+	return &CustomElementExport{
+		Kind: "custom-element-definition",
+		StartByte: startByte,
+		Name: tagName,
+		Declaration: declaration,
+		Deprecated: deprecated,
+	}
+}
 
 // Declaration is a union of several types.
 type Declaration interface {

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -49,6 +49,7 @@ type JavaScriptModule struct {
 // Export is a union type: JavaScriptExport or CustomElementExport.
 type Export interface {
 	isExport()
+	GetStartByte() uint
 }
 
 // JavaScriptExport represents a JS export.
@@ -60,6 +61,9 @@ type JavaScriptExport struct {
 	Deprecated  any        `json:"deprecated,omitempty"` // bool or string
 }
 func (*JavaScriptExport) isExport() {}
+func (e *JavaScriptExport) GetStartByte() uint {
+	return e.StartByte
+}
 
 // CustomElementExport represents a custom element definition.
 type CustomElementExport struct {
@@ -70,19 +74,25 @@ type CustomElementExport struct {
 	Deprecated  any        `json:"deprecated,omitempty"` // bool or string
 }
 func (*CustomElementExport) isExport() {}
+func (e *CustomElementExport) GetStartByte() uint {
+	return e.StartByte
+}
 func NewCustomElementExport(
 	tagName string,
 	declaration *Reference,
 	startByte uint,
 	deprecated *Deprecated,
 ) *CustomElementExport {
-	return &CustomElementExport{
+	ce := &CustomElementExport{
 		Kind: "custom-element-definition",
 		StartByte: startByte,
 		Name: tagName,
 		Declaration: declaration,
-		Deprecated: deprecated,
 	}
+	if deprecated != nil {
+		ce.Deprecated = deprecated
+	}
+	return ce
 }
 
 // Declaration is a union of several types.
@@ -140,6 +150,7 @@ type Attribute struct {
 	Default       string     `json:"default,omitempty"`
 	FieldName     string     `json:"fieldName,omitempty"`
 	Deprecated    Deprecated `json:"deprecated,omitempty"` // bool or string
+	StartByte     uint       `json:"-"`
 }
 
 // Event emitted by a custom element.


### PR DESCRIPTION
adds support for customElements.define calls, with some restrictions:
1. the call must use a string value for the tag name
2. default imports may not match the declaration name, if the class declaration name is different from the import name

this last issue could be solved for some cases by cross-referencing default exports from the local package. It might fail if you import a default export from an npm package then define an element with it, using a different className binding.

Fixes #15 

What this PR doesn't do:
- observedAttributes
- tagName for defined element declarations, particularly across files