### PR TITLE
feat: project-dir flag

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -63,6 +63,11 @@
       "default": "generate/test-fixtures/*.ts"
     },
     {
+      "id": "projectDir",
+      "type": "promptString",
+      "description": "Project dir"
+    },
+    {
       "id": "fixturePattern",
       "type": "promptString",
       "description": "Pattern of fixtures to match (without extension, e.g. class-exports)"

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ For npm projects you can use `npx @pwrs/cem generate ...`.
 | `--demo-discovery-url-pattern`  | string             | Go Regexp pattern with named capture groups for generating canonical demo urls                    |
 | `--demo-discovery-url-template` | string             | URL pattern string using {groupName} syntax to interpolate named captures from the URL pattern    |
 | `--source-control-root-url`     | string             | Glob pattern for discovering demo files                                                           |
+| `--project-dir`                 | string             | Specify the project root directory to use for resolving relative paths and configuration.         |
 
 
 By default, some files (like `.d.ts` TypeScript declaration files) are excluded from the manifest.

--- a/README.md
+++ b/README.md
@@ -122,12 +122,12 @@ variables
 
 ---
 
-## Element Demos
+#### Element Demos
 
 `cem generate` supports documenting your elements' demos by linking directly
 from JSDoc, or by configurable file-system based discovery.
 
-### 1. JSDoc `@demo` Tag
+##### 1. JSDoc `@demo` Tag
 
 Add demos directly to your element class or members with the `@demo` tag:
 
@@ -144,7 +144,7 @@ class MyElement extends LitElement {
 
 Demos defined this way will always appear in your manifest for the element.
 
-### 2. Demo Discovery
+##### 2. Demo Discovery
 
 `cem` can automatically discover demos from your codebase based on your
 repository structure and configuration.

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -1,6 +1,13 @@
 package config
 
-import "github.com/spf13/viper"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/viper"
+)
 
 type DemoDiscoveryConfig struct {
 	FileGlob  string               `mapstructure:"fileGlob"`
@@ -34,25 +41,112 @@ type GenerateConfig struct {
 }
 
 type CemConfig struct {
+	projectDir           string           `mapstructure:"-"`
+	configFile           string           `mapstructure:"-"`
+	// Package name, as would appear in a package.json "name" field
+	PackageName          string           `mapstructure:"packageName"`
 	// Generate command options
-	Generate GenerateConfig        `mapstructure:"generate"`
+	Generate             GenerateConfig   `mapstructure:"generate"`
 	// Canonical public source control URL corresponding to project root on primary branch.
 	// e.g. https://github.com/bennypowers/cem/tree/main/
-	SourceControlRootUrl string    `mapstructure:"sourceControlRootUrl"`
+	SourceControlRootUrl string           `mapstructure:"sourceControlRootUrl"`
 	// Verbose logging output
-	Verbose bool                   `mapstructure:"verbose"`
+	Verbose              bool             `mapstructure:"verbose"`
 }
 
-func LoadConfig(configPath string) (*CemConfig, error) {
-    v := viper.New()
-    v.SetConfigFile(configPath)
-    v.SetConfigType("yaml")
-    if err := v.ReadInConfig(); err != nil {
-        return nil, err
-    }
-    var config CemConfig
-    if err := v.Unmarshal(&config); err != nil {
-        return nil, err
-    }
-    return &config, nil
+func (cfg *CemConfig) GetProjectDir() string { return cfg.projectDir }
+func (cfg *CemConfig) GetConfigFile() string { return cfg.configFile }
+
+func resolveProjectDir(configPath, projectDirFlag string) string {
+	if projectDirFlag != "" {
+		abs, err := expandPath(projectDirFlag)
+		if err != nil {
+			pterm.Fatal.Printf("Invalid --project-dir: %v", err)
+		}
+		return abs
+	}
+	configAbs, err := filepath.Abs(configPath)
+	if err != nil {
+		pterm.Fatal.Printf("Invalid --config: %v", err)
+	}
+	configDir := filepath.Dir(configAbs)
+	base := filepath.Base(configDir)
+	if base == ".config" || base == "config" {
+		return filepath.Dir(configDir)
+	}
+	// fallback: use current working directory
+	cwd, err := os.Getwd()
+	if err != nil {
+		pterm.Fatal.Printf("Unable to get current working directory: %v", err)
+	}
+	if !strings.HasPrefix(configAbs, cwd) {
+		pterm.Warning.Printf("Warning: --config is outside of current dir, guessing project root as %s\n", cwd)
+	}
+	return cwd
+}
+
+// expandPath expands ~, handles relative and absolute paths
+func expandPath(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	if strings.HasPrefix(path, "~") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		// Support ~/ and ~
+		if path == "~" {
+			path = home
+		} else if strings.HasPrefix(path, "~/") {
+			path = filepath.Join(home, path[2:])
+		}
+		// Note: ~user/ is not supported (Go stdlib doesn't provide this)
+	}
+	return filepath.Abs(path)
+}
+
+func LoadConfig(cfgFile string, projectDir string) (config *CemConfig, err error) {
+	v := viper.New()
+	if cfgFile != "" {
+		// Use config file from the flag.
+		cfgFile, err = expandPath(cfgFile)
+		if err != nil {
+			return nil, err
+		}
+		v.SetConfigFile(cfgFile)
+	} else {
+		// Search config in local project .config directory with name "cem.yaml"
+		cfgFile, err = expandPath(filepath.Join(projectDir, "./.config", "cem.yaml"))
+		if err != nil {
+			return nil, err
+		}
+		v.AddConfigPath(cfgFile)
+		v.SetConfigType("yaml")
+		v.SetConfigName("cem.yaml")
+	}
+	v.AutomaticEnv() // read in environment variables that match
+	v.SetConfigFile(cfgFile)
+	v.SetConfigType("yaml")
+	if err := v.ReadInConfig(); err != nil {
+		return nil, err
+	}
+	if err := v.Unmarshal(&config); err != nil {
+		return nil, err
+	}
+	if projectDir != "" {
+		projectDir, err = expandPath(projectDir)
+		if err != nil {
+			return nil, err
+		}
+	}
+	config.projectDir = resolveProjectDir(cfgFile, projectDir)
+	config.configFile = cfgFile
+	config.Generate.Output = filepath.Join(projectDir, config.Generate.Output)
+	if config.Verbose {
+		pterm.EnableDebugMessages()
+	} else {
+		pterm.DisableDebugMessages()
+	}
+	return config, nil
 }

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -121,7 +121,7 @@ func LoadConfig(cfgFile string, projectDir string) (config *CemConfig, err error
 		if err != nil {
 			return nil, err
 		}
-		v.AddConfigPath(cfgFile)
+		v.AddConfigPath(filepath.Dir(cfgFile))
 		v.SetConfigType("yaml")
 		v.SetConfigName("cem.yaml")
 	}
@@ -142,7 +142,9 @@ func LoadConfig(cfgFile string, projectDir string) (config *CemConfig, err error
 	}
 	config.projectDir = resolveProjectDir(cfgFile, projectDir)
 	config.configFile = cfgFile
-	config.Generate.Output = filepath.Join(projectDir, config.Generate.Output)
+	if !filepath.IsAbs(config.Generate.Output) {
+		config.Generate.Output = filepath.Join(projectDir, config.Generate.Output)
+	}
 	if config.Verbose {
 		pterm.EnableDebugMessages()
 	} else {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,7 +56,10 @@ func initConfig() {
 		os.Exit(1)
 	}
 	CemConfig = *cfg
-	os.Chdir(CemConfig.GetProjectDir())
+	if err := os.Chdir(CemConfig.GetProjectDir()); err != nil {
+		pterm.Error.Print("Failed to change into project directory: ", err)
+		os.Exit(1)
+	}
 	pterm.Info.Print("Using project directory: ", CemConfig.GetProjectDir(), "\n")
 	pterm.Info.Print("Using config file: ", cfg.GetConfigFile(), "\n")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,17 +18,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
-	"os"
-	"path/filepath"
-
 	"bennypowers.dev/cem/cmd/config"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var cfgFile string
-var verbose bool
+var projectDir string
 var CemConfig config.CemConfig
 
 // rootCmd represents the base command when called without any subcommands
@@ -51,41 +47,19 @@ func Execute() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	if cfgFile != "" {
-		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
-	} else {
-		// Search config in local project .config directory with name "cem.yaml"
-		viper.AddConfigPath("./.config")
-		viper.SetConfigType("yaml")
-		viper.SetConfigName("cem.yaml")
+	cfg, err := config.LoadConfig(cfgFile, projectDir)
+	if err != nil {
+		pterm.Fatal.Print(err)
 	}
-
-	viper.AutomaticEnv() // read in environment variables that match
-
-	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		if CemConfig.Verbose {
-			pterm.EnableDebugMessages()
-		} else {
-			pterm.DisableDebugMessages()
-		}
-		cwd, err := os.Getwd()
-		if err != nil {
-			cwd = ""
-		}
-		cfgpath, err := filepath.Rel(cwd, viper.ConfigFileUsed())
-		pterm.Info.Print("Using config file: ", cfgpath, "\n")
-	}
-	// Bind to struct
-	if err := viper.Unmarshal(&CemConfig); err != nil {
-		pterm.Error.Println("Unable to decode config:", err)
-	}
+	CemConfig = *cfg
+	pterm.Info.Print("Using project directory: ", CemConfig.GetProjectDir(), "\n")
+	pterm.Info.Print("Using config file: ", cfg.GetConfigFile(), "\n")
 }
 
 func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $CWD/.config/cem.yaml)")
+	rootCmd.PersistentFlags().StringVar(&projectDir, "project-dir", "", "Path to project directory (default: parent directory of .config/cem.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&CemConfig.Verbose, "verbose", "v", false, "verbose logging output")
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
+	"os"
+
 	"bennypowers.dev/cem/cmd/config"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
@@ -41,7 +43,8 @@ Supports projects written with Lit`,
 func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {
-		pterm.Fatal.Print(err)
+		pterm.Error.Print(err)
+		os.Exit(1)
 	}
 }
 
@@ -49,9 +52,11 @@ func Execute() {
 func initConfig() {
 	cfg, err := config.LoadConfig(cfgFile, projectDir)
 	if err != nil {
-		pterm.Fatal.Print(err)
+		pterm.Error.Print(err)
+		os.Exit(1)
 	}
 	CemConfig = *cfg
+	os.Chdir(CemConfig.GetProjectDir())
 	pterm.Info.Print("Using project directory: ", CemConfig.GetProjectDir(), "\n")
 	pterm.Info.Print("Using config file: ", cfg.GetConfigFile(), "\n")
 }

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -57,7 +57,7 @@ func TestGenerate(t *testing.T) {
 			}
 
 			configPath := filepath.Join(".config", "cem.yaml")
-			cfg, err := config.LoadConfig(configPath)
+			cfg, err := config.LoadConfig(configPath, ".")
 			if err != nil {
 				t.Fatalf("failed to load config: %v", err)
 			}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -19,6 +19,20 @@ type Package struct {
 	Deprecated    any       `json:"deprecated,omitempty"` // bool or string
 }
 
+func (x *Package) GetAllTagNames() (tags []string) {
+	// Write index.html
+	for _, m := range x.Modules {
+		for _, decl := range m.Declarations {
+			ced, ok := decl.(*CustomElementDeclaration)
+			if !ok || ced.TagName == "" {
+				continue
+			}
+			tags = append(tags, ced.TagName)
+		}
+	}
+	return tags
+}
+
 func NewPackage(modules []Module) Package {
 	return Package{
 		SchemaVersion: "1.0.0",
@@ -267,14 +281,14 @@ func (x ClassMethod) GetStartByte() uint { return x.StartByte }
 
 // PropertyLike is the common interface of variables, class fields, and function parameters.
 type PropertyLike struct {
-	StartByte		uint			`json:"-"`
-	Name        string    `json:"name"`
-	Summary     string   `json:"summary,omitempty"`
-	Description string   `json:"description,omitempty"`
-	Type        *Type     `json:"type,omitempty"`
-	Default     string   `json:"default,omitempty"`
-	Deprecated  Deprecated       `json:"deprecated,omitempty"` // bool or string
-	Readonly    bool     `json:"readonly,omitempty"`
+	StartByte   uint       `json:"-"`
+	Name        string     `json:"name"`
+	Summary     string     `json:"summary,omitempty"`
+	Description string     `json:"description,omitempty"`
+	Type        *Type      `json:"type,omitempty"`
+	Default     string     `json:"default,omitempty"`
+	Deprecated  Deprecated `json:"deprecated,omitempty"`
+	Readonly    bool       `json:"readonly,omitempty"`
 }
 
 // CustomElementField extends ClassField with attribute/reflects.
@@ -290,7 +304,11 @@ func (x CustomElementField) GetStartByte() uint { return x.ClassField.StartByte 
 type MixinDeclaration struct {
 	ClassLike
 	FunctionLike
-	Kind string `json:"kind"` // 'mixin'
+	Name        string     `json:"name"`
+	Summary     string     `json:"summary,omitempty"`
+	Description string     `json:"description,omitempty"`
+	Deprecated  Deprecated `json:"deprecated,omitempty"`
+	Kind string            `json:"kind"` // 'mixin'
 }
 func (*MixinDeclaration) isDeclaration() {}
 func (x *MixinDeclaration) GetStartByte() uint { return x.FunctionLike.StartByte }
@@ -298,9 +316,14 @@ func (x *MixinDeclaration) GetStartByte() uint { return x.FunctionLike.StartByte
 // CustomElementMixinDeclaration extends MixinDeclaration and CustomElement.
 type CustomElementMixinDeclaration struct {
 	MixinDeclaration
-	CustomElement
+	CustomElementDeclaration
+	Name        string     `json:"name"`
+	Summary     string     `json:"summary,omitempty"`
+	Description string     `json:"description,omitempty"`
+	Deprecated  Deprecated `json:"deprecated,omitempty"`
 }
 func (*CustomElementMixinDeclaration) isDeclaration() {}
+func (x *CustomElementMixinDeclaration) GetStartByte() uint { return x.FunctionLike.StartByte }
 
 // VariableDeclaration is a variable.
 type VariableDeclaration struct {

--- a/manifest/unmarshal.go
+++ b/manifest/unmarshal.go
@@ -1,0 +1,312 @@
+package manifest
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+)
+
+// UnmarshalPackage unmarshals a CEM manifest JSON, handling Declarations interface types and ClassMember interface types.
+// It also ensures that all slice fields are non-nil (empty slices if not present in JSON).
+func UnmarshalPackage(data []byte) (*Package, error) {
+	var raw struct {
+		SchemaVersion string            `json:"schemaVersion"`
+		Readme        *string           `json:"readme,omitempty"`
+		Modules       []json.RawMessage `json:"modules"`
+		Deprecated    any               `json:"deprecated,omitempty"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("unmarshal package prelude: %w", err)
+	}
+	pkg := &Package{
+		SchemaVersion: raw.SchemaVersion,
+		Readme:        raw.Readme,
+		Deprecated:    raw.Deprecated,
+	}
+	for _, modData := range raw.Modules {
+		var modRaw struct {
+			Kind         string            `json:"kind"`
+			Path         string            `json:"path"`
+			Summary      string            `json:"summary,omitempty"`
+			Description  string            `json:"description,omitempty"`
+			Declarations []json.RawMessage `json:"declarations,omitempty"`
+			Exports      []json.RawMessage `json:"exports,omitempty"`
+			Deprecated   any               `json:"deprecated,omitempty"`
+		}
+		if err := json.Unmarshal(modData, &modRaw); err != nil {
+			return nil, fmt.Errorf("unmarshal module: %w", err)
+		}
+		var decls []Declaration
+		for _, declData := range modRaw.Declarations {
+			// Peek at kind
+			var kindWrap struct{ Kind string `json:"kind"` }
+			if err := json.Unmarshal(declData, &kindWrap); err != nil {
+				continue
+			}
+			switch kindWrap.Kind {
+			case "class":
+				// Peek for customElement: true
+				var probe struct {
+					CustomElement bool `json:"customElement"`
+				}
+				if err := json.Unmarshal(declData, &probe); err == nil && probe.CustomElement {
+					var ce CustomElementDeclaration
+					if err := unmarshalCustomElementDeclaration(declData, &ce); err == nil {
+						decls = append(decls, &ce)
+					} else {
+						log.Printf("Failed to unmarshal custom-element (class+customElement): %v", err)
+					}
+				} else {
+					var c ClassDeclaration
+					if err := unmarshalClassDeclaration(declData, &c); err == nil {
+						decls = append(decls, &c)
+					} else {
+						log.Printf("Failed to unmarshal class: %v", err)
+					}
+				}
+			case "mixin":
+				var m MixinDeclaration
+				if err := unmarshalMixinDeclaration(declData, &m); err == nil {
+					decls = append(decls, &m)
+				} else {
+					log.Printf("Failed to unmarshal mixin: %v", err)
+				}
+			case "function":
+				var f FunctionDeclaration
+				if err := json.Unmarshal(declData, &f); err == nil {
+					ensureNonNilSlicesFunction(&f.FunctionLike)
+					decls = append(decls, &f)
+				}
+			case "variable":
+				var v VariableDeclaration
+				if err := json.Unmarshal(declData, &v); err == nil {
+					decls = append(decls, &v)
+				}
+			case "custom-element":
+				var ce CustomElementDeclaration
+				if err := unmarshalCustomElementDeclaration(declData, &ce); err == nil {
+					decls = append(decls, &ce)
+				} else {
+					log.Printf("Failed to unmarshal custom-element: %v", err)
+				}
+			case "custom-element-mixin":
+				var cem CustomElementMixinDeclaration
+				if err := unmarshalCustomElementMixinDeclaration(declData, &cem); err == nil {
+					decls = append(decls, &cem)
+				} else {
+					log.Printf("Failed to unmarshal custom-element-mixin: %v", err)
+				}
+			default:
+				// fallback: skip unknown kind
+			}
+		}
+		if decls == nil {
+			decls = []Declaration{}
+		}
+
+		// --- Exports unmarshalling ---
+		var exports []Export
+		for _, exportData := range modRaw.Exports {
+			var kindWrap struct{ Kind string `json:"kind"` }
+			if err := json.Unmarshal(exportData, &kindWrap); err != nil {
+				continue
+			}
+			switch kindWrap.Kind {
+			case "js":
+				var e JavaScriptExport
+				if err := json.Unmarshal(exportData, &e); err == nil {
+					exports = append(exports, &e)
+				} else {
+					log.Printf("Failed to unmarshal js export: %v", err)
+				}
+			// handle other export kinds as needed
+			default:
+				// fallback: skip unknown kind
+			}
+		}
+		if exports == nil {
+			exports = []Export{}
+		}
+		// --- end Exports unmarshalling ---
+
+		mod := JavaScriptModule{
+			Kind:         modRaw.Kind,
+			Path:         modRaw.Path,
+			Summary:      modRaw.Summary,
+			Description:  modRaw.Description,
+			Declarations: decls,
+			Exports:      exports,
+			Deprecated:   modRaw.Deprecated,
+		}
+		pkg.Modules = append(pkg.Modules, mod)
+	}
+	if pkg.Modules == nil {
+		pkg.Modules = []Module{}
+	}
+	return pkg, nil
+}
+
+// --- Custom unmarshalling for ClassDeclaration and subtypes ---
+
+// unmarshalClassDeclaration handles members as []interface{} of ClassMember
+func unmarshalClassDeclaration(data []byte, c *ClassDeclaration) error {
+	type Alias ClassDeclaration
+	aux := &struct {
+		Members []json.RawMessage `json:"members"`
+		*Alias
+	}{
+		Alias: (*Alias)(c),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	c.Members = nil
+	for _, m := range aux.Members {
+		member, err := unmarshalClassMember(m)
+		if err == nil && member != nil {
+			c.Members = append(c.Members, member)
+		}
+	}
+	ensureNonNilSlicesClass(&c.ClassLike)
+	return nil
+}
+
+func unmarshalMixinDeclaration(data []byte, m *MixinDeclaration) error {
+	type Alias MixinDeclaration
+	aux := &struct {
+		Members []json.RawMessage `json:"members"`
+		*Alias
+	}{
+		Alias: (*Alias)(m),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	m.Members = nil
+	for _, mm := range aux.Members {
+		member, err := unmarshalClassMember(mm)
+		if err == nil && member != nil {
+			m.Members = append(m.Members, member)
+		}
+	}
+	ensureNonNilSlicesMixin(m)
+	return nil
+}
+
+func unmarshalCustomElementDeclaration(data []byte, ce *CustomElementDeclaration) error {
+	type Alias CustomElementDeclaration
+	aux := &struct {
+		Members []json.RawMessage `json:"members"`
+		*Alias
+	}{
+		Alias: (*Alias)(ce),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	ce.Members = nil
+	for _, mm := range aux.Members {
+		member, err := unmarshalClassMember(mm)
+		if err == nil && member != nil {
+			ce.Members = append(ce.Members, member)
+		}
+	}
+	ensureNonNilSlicesCustomElement(ce)
+	return nil
+}
+
+func unmarshalCustomElementMixinDeclaration(data []byte, cem *CustomElementMixinDeclaration) error {
+	type Alias CustomElementMixinDeclaration
+	aux := &struct {
+		Members []json.RawMessage `json:"members"`
+		*Alias
+	}{
+		Alias: (*Alias)(cem),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	cem.Members = nil
+	for _, mm := range aux.Members {
+		member, err := unmarshalClassMember(mm)
+		if err == nil && member != nil {
+			cem.Members = append(cem.Members, member)
+		}
+	}
+	ensureNonNilSlicesCustomElementMixin(cem)
+	return nil
+}
+
+// unmarshalClassMember unmarshals a ClassMember from raw JSON.
+func unmarshalClassMember(data json.RawMessage) (ClassMember, error) {
+	var kindWrap struct{ Kind string `json:"kind"` }
+	if err := json.Unmarshal(data, &kindWrap); err != nil {
+		return nil, err
+	}
+	switch kindWrap.Kind {
+	case "field":
+		var f ClassField
+		if err := json.Unmarshal(data, &f); err == nil {
+			return &f, nil
+		}
+	case "method":
+		var m ClassMethod
+		if err := json.Unmarshal(data, &m); err == nil {
+			return &m, nil
+		}
+	// Add other kinds as needed
+	}
+	return nil, fmt.Errorf("unknown class member kind: %s", kindWrap.Kind)
+}
+
+// Helpers to ensure non-nil slices for all relevant structs:
+
+func ensureNonNilSlicesCustomElement(ce *CustomElementDeclaration) {
+	if ce.Attributes == nil {
+		ce.Attributes = []Attribute{}
+	}
+	if ce.Events == nil {
+		ce.Events = []Event{}
+	}
+	if ce.Slots == nil {
+		ce.Slots = []Slot{}
+	}
+	if ce.CssParts == nil {
+		ce.CssParts = []CssPart{}
+	}
+	if ce.CssProperties == nil {
+		ce.CssProperties = []CssCustomProperty{}
+	}
+	if ce.CssStates == nil {
+		ce.CssStates = []CssCustomState{}
+	}
+	if ce.Demos == nil {
+		ce.Demos = []Demo{}
+	}
+	ensureNonNilSlicesClass(&ce.ClassDeclaration.ClassLike)
+}
+
+func ensureNonNilSlicesCustomElementMixin(cem *CustomElementMixinDeclaration) {
+	ensureNonNilSlicesMixin(&cem.MixinDeclaration)
+	ensureNonNilSlicesCustomElement(&cem.CustomElementDeclaration)
+}
+
+func ensureNonNilSlicesClass(c *ClassLike) {
+	if c.Members == nil {
+		c.Members = []ClassMember{}
+	}
+	if c.Mixins == nil {
+		c.Mixins = []Reference{}
+	}
+}
+
+func ensureNonNilSlicesFunction(f *FunctionLike) {
+	if f.Parameters == nil {
+		f.Parameters = []Parameter{}
+	}
+}
+
+func ensureNonNilSlicesMixin(m *MixinDeclaration) {
+	ensureNonNilSlicesFunction(&m.FunctionLike)
+	ensureNonNilSlicesClass(&m.ClassLike)
+}

--- a/manifest/unmarshal_test.go
+++ b/manifest/unmarshal_test.go
@@ -1,0 +1,745 @@
+package manifest
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestUnmarshalPackage_ClassWithCustomElementTrue_YieldsCustomElementDeclaration(t *testing.T) {
+	manifestJSON := []byte(`
+{
+  "schemaVersion": "1.0.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/card.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "name": "MyCard",
+          "customElement": true,
+          "tagName": "my-card",
+          "members": [
+            {
+              "kind": "field",
+              "name": "foo",
+              "type": { "text": "string" }
+            }
+          ]
+        },
+        {
+          "kind": "class",
+          "name": "CardBase",
+          "members": [
+            {
+              "kind": "field",
+              "name": "bar",
+              "type": { "text": "number" }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+`)
+	pkg, err := UnmarshalPackage(manifestJSON)
+	if err != nil {
+		t.Fatalf("UnmarshalPackage failed: %v", err)
+	}
+	mod := pkg.Modules[0]
+	if len(mod.Declarations) != 2 {
+		t.Fatalf("len(Declarations) = %d, want 2", len(mod.Declarations))
+	}
+
+	// Check custom element (should be CustomElementDeclaration)
+	ce, ok := mod.Declarations[0].(*CustomElementDeclaration)
+	if !ok {
+		t.Fatalf("First Declaration is not a CustomElementDeclaration: %T", mod.Declarations[0])
+	}
+	if ce.Name != "MyCard" || ce.TagName != "my-card" {
+		t.Errorf("CustomElementDeclaration: got Name=%q, TagName=%q; want 'MyCard', 'my-card'", ce.Name, ce.TagName)
+	}
+	if len(ce.Members) != 1 {
+		t.Errorf("CustomElementDeclaration members = %+v, want 1 member", ce.Members)
+	}
+	field, ok := ce.Members[0].(*ClassField)
+	if !ok || field.Name != "foo" || field.Type == nil || field.Type.Text != "string" {
+		t.Errorf("CustomElementDeclaration first member = %+v, want field named foo of type string", ce.Members[0])
+	}
+
+	// Check base class (should be ClassDeclaration)
+	cl, ok := mod.Declarations[1].(*ClassDeclaration)
+	if !ok {
+		t.Fatalf("Second Declaration is not a ClassDeclaration: %T", mod.Declarations[1])
+	}
+	if cl.Name != "CardBase" {
+		t.Errorf("ClassDeclaration: got Name=%q, want 'CardBase'", cl.Name)
+	}
+	if len(cl.Members) != 1 {
+		t.Errorf("ClassDeclaration members = %+v, want 1 member", cl.Members)
+	}
+	field2, ok := cl.Members[0].(*ClassField)
+	if !ok || field2.Name != "bar" || field2.Type == nil || field2.Type.Text != "number" {
+		t.Errorf("ClassDeclaration first member = %+v, want field named bar of type number", cl.Members[0])
+	}
+}
+
+func TestUnmarshalPackage_CustomElement_BasicFields(t *testing.T) {
+	manifestJSON := []byte(`
+{
+  "schemaVersion": "1.0.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/rh-card.js",
+      "declarations": [
+        {
+          "kind": "custom-element",
+          "name": "RhCard",
+          "tagName": "rh-card"
+        }
+      ]
+    }
+  ]
+}
+`)
+	pkg, err := UnmarshalPackage(manifestJSON)
+	if err != nil {
+		t.Fatalf("UnmarshalPackage failed: %v", err)
+	}
+	if len(pkg.Modules) != 1 {
+		t.Fatalf("len(Modules) = %d, want 1", len(pkg.Modules))
+	}
+	mod := pkg.Modules[0]
+	if len(mod.Declarations) != 1 {
+		t.Fatalf("len(Declarations) = %d, want 1", len(mod.Declarations))
+	}
+	ce, ok := mod.Declarations[0].(*CustomElementDeclaration)
+	if !ok {
+		t.Fatalf("Declaration is not a CustomElementDeclaration")
+	}
+	if ce.TagName != "rh-card" {
+		t.Errorf("TagName = %q, want 'rh-card'", ce.TagName)
+	}
+	if ce.Name != "RhCard" {
+		t.Errorf("Name = %q, want 'RhCard'", ce.Name)
+	}
+}
+
+func TestUnmarshalPackage_CustomElement_Attributes(t *testing.T) {
+	manifestJSON := []byte(`
+{
+  "schemaVersion": "1.0.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/rh-card.js",
+      "declarations": [
+        {
+          "kind": "custom-element",
+          "name": "RhCard",
+          "tagName": "rh-card",
+          "attributes": [
+            {
+              "name": "variant",
+              "type": { "text": "\"primary\" | \"secondary\"" }
+            },
+            {
+              "name": "elevated",
+              "type": { "text": "boolean" }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+`)
+	pkg, err := UnmarshalPackage(manifestJSON)
+	if err != nil {
+		t.Fatalf("UnmarshalPackage failed: %v", err)
+	}
+	ce := pkg.Modules[0].Declarations[0].(*CustomElementDeclaration)
+	if len(ce.Attributes) != 2 {
+		t.Errorf("len(Attributes) = %d, want 2", len(ce.Attributes))
+	}
+	if ce.Attributes[0].Name != "variant" || ce.Attributes[1].Name != "elevated" {
+		t.Errorf("Attribute names = %q,%q, want %q,%q", ce.Attributes[0].Name, ce.Attributes[1].Name, "variant", "elevated")
+	}
+	if ce.Attributes[0].Type == nil || ce.Attributes[0].Type.Text != "\"primary\" | \"secondary\"" {
+		t.Errorf("First attribute type = %+v, want union", ce.Attributes[0].Type)
+	}
+	if ce.Attributes[1].Type == nil || ce.Attributes[1].Type.Text != "boolean" {
+		t.Errorf("Second attribute type = %+v, want boolean", ce.Attributes[1].Type)
+	}
+}
+
+func TestUnmarshalPackage_CustomElement_Events(t *testing.T) {
+	manifestJSON := []byte(`
+{
+  "schemaVersion": "1.0.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/rh-card.js",
+      "declarations": [
+        {
+          "kind": "custom-element",
+          "name": "RhCard",
+          "tagName": "rh-card",
+          "events": [
+            {
+              "name": "rh-card-selected",
+              "type": { "text": "CustomEvent" }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+`)
+	pkg, err := UnmarshalPackage(manifestJSON)
+	if err != nil {
+		t.Fatalf("UnmarshalPackage failed: %v", err)
+	}
+	ce := pkg.Modules[0].Declarations[0].(*CustomElementDeclaration)
+	if len(ce.Events) != 1 || ce.Events[0].Name != "rh-card-selected" {
+		t.Errorf("Events = %+v, want 1 rh-card-selected", ce.Events)
+	}
+}
+
+func TestUnmarshalPackage_CustomElement_Slots(t *testing.T) {
+	manifestJSON := []byte(`
+{
+  "schemaVersion": "1.0.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/rh-card.js",
+      "declarations": [
+        {
+          "kind": "custom-element",
+          "name": "RhCard",
+          "tagName": "rh-card",
+          "slots": [
+            {
+              "name": "",
+              "description": "Default slot"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+`)
+	pkg, err := UnmarshalPackage(manifestJSON)
+	if err != nil {
+		t.Fatalf("UnmarshalPackage failed: %v", err)
+	}
+	ce := pkg.Modules[0].Declarations[0].(*CustomElementDeclaration)
+	if len(ce.Slots) != 1 || ce.Slots[0].Description != "Default slot" {
+		t.Errorf("Slots = %+v, want 1 Default slot", ce.Slots)
+	}
+}
+
+func TestUnmarshalPackage_CustomElement_CssPartsPropertiesStates(t *testing.T) {
+	manifestJSON := []byte(`
+{
+  "schemaVersion": "1.0.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/rh-card.js",
+      "declarations": [
+        {
+          "kind": "custom-element",
+          "name": "RhCard",
+          "tagName": "rh-card",
+          "cssParts": [
+            { "name": "header", "description": "Header part" }
+          ],
+          "cssProperties": [
+            { "name": "--rh-card-color", "description": "Card color" }
+          ],
+          "cssStates": [
+            { "name": "--active", "description": "Active state" }
+          ]
+        }
+      ]
+    }
+  ]
+}
+`)
+	pkg, err := UnmarshalPackage(manifestJSON)
+	if err != nil {
+		t.Fatalf("UnmarshalPackage failed: %v", err)
+	}
+	ce := pkg.Modules[0].Declarations[0].(*CustomElementDeclaration)
+	if len(ce.CssParts) != 1 || ce.CssParts[0].Name != "header" {
+		t.Errorf("CssParts = %+v, want 1 header", ce.CssParts)
+	}
+	if len(ce.CssProperties) != 1 || ce.CssProperties[0].Name != "--rh-card-color" {
+		t.Errorf("CssProperties = %+v, want 1 --rh-card-color", ce.CssProperties)
+	}
+	if len(ce.CssStates) != 1 || ce.CssStates[0].Name != "--active" {
+		t.Errorf("CssStates = %+v, want 1 --active", ce.CssStates)
+	}
+}
+
+func TestUnmarshalPackage_CustomElement_Demos(t *testing.T) {
+	manifestJSON := []byte(`
+{
+  "schemaVersion": "1.0.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/rh-card.js",
+      "declarations": [
+        {
+          "kind": "custom-element",
+          "name": "RhCard",
+          "tagName": "rh-card",
+          "demos": [
+            { "description": "Basic demo", "url": "demo.html" }
+          ]
+        }
+      ]
+    }
+  ]
+}
+`)
+	pkg, err := UnmarshalPackage(manifestJSON)
+	if err != nil {
+		t.Fatalf("UnmarshalPackage failed: %v", err)
+	}
+	ce := pkg.Modules[0].Declarations[0].(*CustomElementDeclaration)
+	if len(ce.Demos) != 1 || ce.Demos[0].Description != "Basic demo" || ce.Demos[0].URL != "demo.html" {
+		t.Errorf("Demos = %+v, want 1 Basic demo with url demo.html", ce.Demos)
+	}
+}
+
+func TestUnmarshalPackage_CustomElement_Mixins(t *testing.T) {
+	manifestJSON := []byte(`
+{
+  "schemaVersion": "1.0.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/rh-card.js",
+      "declarations": [
+        {
+          "kind": "custom-element",
+          "name": "RhCard",
+          "tagName": "rh-card",
+          "mixins": [
+            { "name": "RhMixin", "package": "rh-mixins" }
+          ]
+        }
+      ]
+    }
+  ]
+}
+`)
+	pkg, err := UnmarshalPackage(manifestJSON)
+	if err != nil {
+		t.Fatalf("UnmarshalPackage failed: %v", err)
+	}
+	ce := pkg.Modules[0].Declarations[0].(*CustomElementDeclaration)
+	if len(ce.Mixins) != 1 || ce.Mixins[0].Name != "RhMixin" {
+		t.Errorf("Mixins = %+v, want 1 RhMixin", ce.Mixins)
+	}
+}
+
+func TestUnmarshalPackage_CustomElement_Members(t *testing.T) {
+	manifestJSON := []byte(`
+{
+  "schemaVersion": "1.0.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/rh-card.js",
+      "declarations": [
+        {
+          "kind": "custom-element",
+          "name": "RhCard",
+          "tagName": "rh-card",
+          "members": [
+            {
+              "kind": "field",
+              "name": "prop1",
+              "type": { "text": "string" }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+`)
+	pkg, err := UnmarshalPackage(manifestJSON)
+	if err != nil {
+		t.Fatalf("UnmarshalPackage failed: %v", err)
+	}
+	ce := pkg.Modules[0].Declarations[0].(*CustomElementDeclaration)
+	if len(ce.Members) != 1 {
+		t.Errorf("Members = %+v, want 1 item", ce.Members)
+	}
+	member, ok := ce.Members[0].(*ClassField)
+	if !ok {
+		t.Errorf("Member = %+v, want class field", member)
+	}
+	if member.Name != "prop1" || member.Type == nil || member.Type.Text != "string" {
+		t.Errorf("Member = %+v, want prop1: string", member)
+	}
+}
+
+func TestUnmarshalPackage_CustomElement_SliceNils(t *testing.T) {
+	manifestJSON := []byte(`
+{
+  "schemaVersion": "1.0.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/rh-card.js",
+      "declarations": [
+        {
+          "kind": "custom-element",
+          "name": "RhCard",
+          "tagName": "rh-card"
+        }
+      ]
+    }
+  ]
+}
+`)
+	pkg, err := UnmarshalPackage(manifestJSON)
+	if err != nil {
+		t.Fatalf("UnmarshalPackage failed: %v", err)
+	}
+	ce := pkg.Modules[0].Declarations[0].(*CustomElementDeclaration)
+	val := reflect.ValueOf(*ce)
+	for i := range val.NumField() {
+		field := val.Field(i)
+		ft := val.Type().Field(i)
+		if field.Kind() == reflect.Slice {
+			if field.IsNil() {
+				t.Errorf("Field %s is nil, want empty slice", ft.Name)
+			}
+		}
+	}
+}
+
+func TestUnmarshalPackage_Class(t *testing.T) {
+	manifestJSON := []byte(`
+{
+  "schemaVersion": "1.0.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/rh-card-base.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "name": "RhCardBase",
+          "members": [
+            {
+              "kind": "field",
+              "name": "baseProp",
+              "type": { "text": "number" }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+`)
+	pkg, err := UnmarshalPackage(manifestJSON)
+	if err != nil {
+		t.Fatalf("UnmarshalPackage failed: %v", err)
+	}
+	mod := pkg.Modules[0]
+	c, ok := mod.Declarations[0].(*ClassDeclaration)
+	if !ok {
+		t.Fatalf("Declaration is not a ClassDeclaration")
+	}
+	if c.Name != "RhCardBase" {
+		t.Errorf("Name = %q, want 'RhCardBase'", c.Name)
+	}
+	if len(c.Members) != 1 {
+		t.Errorf("Members = %+v, want 1 member", c.Members)
+	}
+	member, ok := c.Members[0].(*ClassField)
+	if !ok {
+		t.Errorf("Member = %+v, want class field", member)
+	}
+	if member.Name != "baseProp" || member.Type.Text != "number" {
+		t.Errorf("Member = %+v, want baseProp: number", member)
+	}
+	if c.Members == nil || c.Mixins == nil {
+		t.Errorf("ClassDeclaration slice fields must not be nil")
+	}
+}
+
+func TestUnmarshalPackage_Mixin(t *testing.T) {
+	manifestJSON := []byte(`
+{
+  "schemaVersion": "1.0.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/rh-mixin.js",
+      "declarations": [
+        {
+          "kind": "mixin",
+          "name": "RhMixin",
+          "members": [
+            {
+              "kind": "field",
+              "name": "mixinProp",
+              "type": { "text": "boolean" }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+`)
+	pkg, err := UnmarshalPackage(manifestJSON)
+	if err != nil {
+		t.Fatalf("UnmarshalPackage failed: %v", err)
+	}
+	mod := pkg.Modules[0]
+	m, ok := mod.Declarations[0].(*MixinDeclaration)
+	if !ok {
+		t.Fatalf("Declaration is not a MixinDeclaration")
+	}
+	if m.Name != "RhMixin" {
+		t.Errorf("Name = %+v, want 'RhMixin'", m)
+	}
+	if len(m.Members) != 1 {
+		t.Errorf("Members = %+v, want 1 member", m.Members)
+	}
+	member, ok := m.Members[0].(*ClassField)
+	if !ok {
+		t.Errorf("Member = %+v, want class field", member)
+	}
+	if member.Name != "mixinProp" || member.Type == nil || member.Type.Text != "boolean" {
+		t.Errorf("Members = %+v, want 1 mixinProp boolean", m.Members)
+	}
+	if m.Members == nil || m.Mixins == nil {
+		t.Errorf("MixinDeclaration slice fields must not be nil")
+	}
+}
+
+func TestUnmarshalPackage_Function(t *testing.T) {
+	manifestJSON := []byte(`
+{
+  "schemaVersion": "1.0.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/functions.js",
+      "declarations": [
+        {
+          "kind": "function",
+          "name": "helperFn",
+          "parameters": [
+            { "name": "x", "type": { "text": "number" } }
+          ]
+        }
+      ]
+    }
+  ]
+}
+`)
+	pkg, err := UnmarshalPackage(manifestJSON)
+	if err != nil {
+		t.Fatalf("UnmarshalPackage failed: %v", err)
+	}
+	mod := pkg.Modules[0]
+	fn, ok := mod.Declarations[0].(*FunctionDeclaration)
+	if !ok {
+		t.Fatalf("Declaration is not a FunctionDeclaration")
+	}
+	if fn.Name != "helperFn" {
+		t.Errorf("Name = %q, want 'helperFn'", fn.Name)
+	}
+	if len(fn.Parameters) != 1 || fn.Parameters[0].Name != "x" || fn.Parameters[0].Type == nil || fn.Parameters[0].Type.Text != "number" {
+		t.Errorf("Parameters = %+v, want 1 x number", fn.Parameters)
+	}
+	if fn.Parameters == nil {
+		t.Errorf("FunctionDeclaration.Parameters must not be nil")
+	}
+}
+
+func TestUnmarshalPackage_Variable(t *testing.T) {
+	manifestJSON := []byte(`
+{
+  "schemaVersion": "1.0.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/vars.js",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "CONST_VAL",
+          "type": { "text": "string" }
+        }
+      ]
+    }
+  ]
+}
+`)
+	pkg, err := UnmarshalPackage(manifestJSON)
+	if err != nil {
+		t.Fatalf("UnmarshalPackage failed: %v", err)
+	}
+	mod := pkg.Modules[0]
+	v, ok := mod.Declarations[0].(*VariableDeclaration)
+	if !ok {
+		t.Fatalf("Declaration is not a VariableDeclaration")
+	}
+	if v.Name != "CONST_VAL" {
+		t.Errorf("Name = %q, want 'CONST_VAL'", v.Name)
+	}
+	if v.Type == nil || v.Type.Text != "string" {
+		t.Errorf("Type = %+v, want string", v.Type)
+	}
+}
+
+func TestUnmarshalPackage_CustomElementMixin(t *testing.T) {
+	manifestJSON := []byte(`
+{
+  "schemaVersion": "1.0.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/cem.js",
+      "declarations": [
+        {
+          "kind": "custom-element-mixin",
+          "name": "RhCustomElementMixin",
+          "members": [
+            {
+              "kind": "field",
+              "name": "cemProp",
+              "type": { "text": "boolean" }
+            }
+          ],
+          "attributes": [
+            { "name": "cem-attr", "type": { "text": "string" } }
+          ]
+        }
+      ]
+    }
+  ]
+}
+`)
+	pkg, err := UnmarshalPackage(manifestJSON)
+	if err != nil {
+		t.Fatalf("UnmarshalPackage failed: %v", err)
+	}
+	mod := pkg.Modules[0]
+	cem, ok := mod.Declarations[0].(*CustomElementMixinDeclaration)
+	if !ok {
+		t.Fatalf("Declaration is not a CustomElementMixinDeclaration")
+	}
+	if cem.Name != "RhCustomElementMixin" {
+		t.Errorf("Name = %q, want 'RhCustomElementMixin'", cem.FunctionLike.Name)
+	}
+	if len(cem.Members) != 1 {
+		t.Errorf("Members = %+v, want 1 item", cem.Members)
+	}
+	member, ok := cem.Members[0].(*ClassField)
+	if !ok {
+		t.Errorf("Member = %+v, want class field", member)
+	}
+	if member.Name != "cemProp" {
+		t.Errorf("Members = %+v, want 1 cemProp", cem.Members)
+	}
+	if cem.Attributes == nil || cem.Members == nil || cem.Mixins == nil {
+		t.Errorf("CustomElementMixinDeclaration slice fields must not be nil")
+	}
+	if len(cem.Attributes) != 1 || cem.Attributes[0].Name != "cem-attr" {
+		t.Errorf("Attributes = %+v, want 1 cem-attr", cem.Attributes)
+	}
+}
+
+func TestUnmarshalPackage_EmptySlices(t *testing.T) {
+	manifestJSON := []byte(`
+{
+  "schemaVersion": "1.0.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/empty.js",
+      "declarations": [
+        {
+          "kind": "custom-element",
+          "name": "EmptyElem",
+          "tagName": "empty-elem"
+        }
+      ]
+    }
+  ]
+}
+`)
+	pkg, err := UnmarshalPackage(manifestJSON)
+	if err != nil {
+		t.Fatalf("UnmarshalPackage failed: %v", err)
+	}
+	mod := pkg.Modules[0]
+	ce, ok := mod.Declarations[0].(*CustomElementDeclaration)
+	if !ok {
+		t.Fatalf("Declaration is not a CustomElementDeclaration")
+	}
+	// All slices should be non-nil and empty
+	val := reflect.ValueOf(*ce)
+	for i := range val.NumField() {
+		field := val.Field(i)
+		ft := val.Type().Field(i)
+		if field.Kind() == reflect.Slice {
+			if field.IsNil() {
+				t.Errorf("Field %s is nil, want empty slice", ft.Name)
+			}
+		}
+	}
+}
+
+func TestUnmarshalPackage_InvalidJSON(t *testing.T) {
+	_, err := UnmarshalPackage([]byte(`{invalid}`))
+	if err == nil {
+		t.Fatal("expected error for invalid json, got nil")
+	}
+}
+
+func TestUnmarshalPackage_UnknownKind(t *testing.T) {
+	manifestJSON := []byte(`
+{
+  "schemaVersion": "1.0.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/unknown.js",
+      "declarations": [
+        { "kind": "not-a-real-kind", "foo": "bar" }
+      ]
+    }
+  ]
+}
+`)
+	pkg, err := UnmarshalPackage(manifestJSON)
+	if err != nil {
+		t.Fatalf("UnmarshalPackage failed: %v", err)
+	}
+	mod := pkg.Modules[0]
+	if len(mod.Declarations) != 0 {
+		t.Errorf("len(Declarations) = %d, want 0 for unknown kind", len(mod.Declarations))
+	}
+}


### PR DESCRIPTION
Adds a global `--project-dir` flag, which determines where to find the config file (unless specified) and the working directory for file IO