### PR TITLE
fix(generate): comment parsing

### DIFF
--- a/generate/classDeclarations.go
+++ b/generate/classDeclarations.go
@@ -18,6 +18,7 @@ package generate
 
 import (
 	"errors"
+	"fmt"
 	"slices"
 
 	Q "bennypowers.dev/cem/generate/queries"
@@ -332,7 +333,7 @@ func (mp *ModuleProcessor) generateLitElementClassDeclaration(
 					if htmlSource != "" {
 						htmlSlots, htmlParts, htmlErr := mp.processRenderTemplate(htmlSource, uint(offset))
 						if htmlErr != nil {
-							errs = errors.Join(errs, htmlErr)
+							errs = errors.Join(errs, fmt.Errorf("module %q: %w", mp.file, htmlErr))
 						}
 						for _, slot := range htmlSlots {
 							declaration.AddOrUpdateSlot(slot)

--- a/generate/html.go
+++ b/generate/html.go
@@ -18,6 +18,7 @@ package generate
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -86,14 +87,14 @@ func (mp *ModuleProcessor) processRenderTemplate(
 				// YAML comment: parse for both slot and part documentation
 				slotDoc, err := parseYamlComment(commentText, "slot")
 				if err != nil {
-					errs = errors.Join(errs, err)
+					errs = errors.Join(errs, fmt.Errorf("slot %q: %w", slot.Name, err))
 				}
 				slot.Description = slotDoc.Description
 				slot.Summary = slotDoc.Summary
 				slot.Deprecated = M.NewDeprecated(slotDoc.Deprecated)
 				partDoc, err := parseYamlComment(commentText, "part")
 				if err != nil {
-					errs = errors.Join(errs, err)
+					errs = errors.Join(errs, fmt.Errorf("part %v: %w", partNames, err))
 				}
 				for _, partName := range partNames {
 					part := M.NewCssPart(
@@ -145,7 +146,7 @@ func (mp *ModuleProcessor) processRenderTemplate(
 				if comment, ok := captureMap["comment"]; ok && len(comment) > 0 {
 					yamlDoc, err := parseYamlComment(comment[0].Text, "part")
 					if err != nil {
-						errs = errors.Join(errs, err)
+						errs = errors.Join(errs, fmt.Errorf("part %q: %w", partName, err))
 					}
 					part := M.NewCssPart(
 						partNameNode.StartByte+offset,
@@ -173,6 +174,7 @@ func getInnerComment(comment string) string {
 	}
 	return dedentYaml(inner)
 }
+
 func isYamlComment(comment string) bool {
 	return strings.Contains(comment, ":")
 }

--- a/generate/html.go
+++ b/generate/html.go
@@ -176,7 +176,20 @@ func getInnerComment(comment string) string {
 }
 
 func isYamlComment(comment string) bool {
-	return strings.Contains(comment, ":")
+	var m map[string]any
+	err := yaml.Unmarshal([]byte(comment), &m)
+	if err != nil || len(m) == 0 {
+		return false
+	}
+
+	for k := range m {
+		switch k {
+		case "description", "summary", "deprecated", "slot", "part":
+			return true
+		}
+	}
+
+	return false
 }
 
 func parseYamlComment(comment string, kind string) (HtmlDocYaml, error) {

--- a/generate/test/fixtures/project-html/golden/class-render-markdown-comment.json
+++ b/generate/test/fixtures/project-html/golden/class-render-markdown-comment.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/class-render-markdown-comment.js",
+      "declarations": [
+        {
+          "name": "ClassRenderMarkdownComment",
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "kind": "class",
+          "tagName": "class-render-markdown-comment",
+          "slots": [
+            {
+              "name": "",
+              "description": "this comment contains a colon: it could easily break naive parsing"
+            }
+          ],
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "class-render-markdown-comment",
+          "declaration": {
+            "name": "ClassRenderMarkdownComment",
+            "module": "src/class-render-markdown-comment.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "ClassRenderMarkdownComment",
+          "declaration": {
+            "name": "ClassRenderMarkdownComment",
+            "module": "src/class-render-markdown-comment.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/generate/test/fixtures/project-html/src/class-render-markdown-comment.ts
+++ b/generate/test/fixtures/project-html/src/class-render-markdown-comment.ts
@@ -1,0 +1,12 @@
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('class-render-markdown-comment')
+export class ClassRenderMarkdownComment extends LitElement {
+  render() {
+    return html`
+      <!-- this comment contains a colon: it could easily break naive parsing -->
+      <slot></slot>
+    `;
+  }
+}


### PR DESCRIPTION
HTML markdown comments that contain `:` could be mistaken for yaml and poorly parsed. This change detects such comments more accurately and improves error handling