### PR TITLE
feat(manifest): add comprehensive marshal/unmarshal round-trip tests

### DIFF
--- a/manifest/fixtures/marshal-roundtrip-comprehensive.json
+++ b/manifest/fixtures/marshal-roundtrip-comprehensive.json
@@ -8,6 +8,76 @@
       "declarations": [
         {
           "kind": "class",
+          "customElement": true,
+          "description": "A test custom element",
+          "name": "TestElement",
+          "tagName": "test-element",
+          "members": [
+            {
+              "kind": "field",
+              "name": "testField",
+              "type": {
+                "text": "string"
+              },
+              "attribute": "test-field",
+              "reflects": true
+            }
+          ],
+          "attributes": [
+            {
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false"
+            }
+          ],
+          "events": [
+            {
+              "name": "test-event",
+              "type": {
+                "text": "CustomEvent"
+              },
+              "description": "Fired when test occurs"
+            }
+          ],
+          "slots": [
+            {
+              "name": "",
+              "description": "Default slot content"
+            }
+          ],
+          "cssParts": [
+            {
+              "name": "button",
+              "description": "The button part"
+            }
+          ],
+          "cssProperties": [
+            {
+              "name": "--test-color",
+              "description": "Main color",
+              "default": "blue"
+            }
+          ],
+          "cssStates": [
+            {
+              "name": "--active",
+              "description": "When element is active"
+            }
+          ]
+        },
+        {
+          "kind": "class",
+          "customElement": true,
+          "description": "A deprecated custom element",
+          "name": "DeprecatedElement",
+          "tagName": "deprecated-element",
+          "deprecated": "Use TestElement instead",
+          "members": []
+        },
+        {
+          "kind": "class",
           "description": "A test class",
           "name": "TestClass",
           "members": [

--- a/manifest/fixtures/marshal_roundtrip_comprehensive.json
+++ b/manifest/fixtures/marshal_roundtrip_comprehensive.json
@@ -1,0 +1,179 @@
+{
+  "schemaVersion": "2.1.0",
+  "readme": "",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "test.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "A test class",
+          "name": "TestClass",
+          "members": [
+            {
+              "kind": "field",
+              "name": "testField",
+              "type": {
+                "text": "string"
+              }
+            }
+          ]
+        },
+        {
+          "kind": "mixin",
+          "description": "A test mixin",
+          "name": "TestMixin",
+          "members": [
+            {
+              "kind": "field",
+              "name": "mixinField",
+              "type": {
+                "text": "number"
+              }
+            }
+          ]
+        },
+        {
+          "kind": "mixin",
+          "description": "A deprecated mixin",
+          "name": "DeprecatedMixin",
+          "deprecated": true,
+          "members": []
+        },
+        {
+          "kind": "mixin",
+          "description": "A mixin deprecated with reason",
+          "name": "DeprecatedReasonMixin",
+          "deprecated": "Use NewMixin instead",
+          "members": []
+        },
+        {
+          "kind": "mixin",
+          "customElement": true,
+          "description": "A custom element mixin",
+          "name": "TestCustomElementMixin",
+          "members": []
+        },
+        {
+          "kind": "mixin",
+          "customElement": true,
+          "description": "A deprecated custom element mixin",
+          "name": "DeprecatedCustomElementMixin",
+          "deprecated": true,
+          "members": []
+        },
+        {
+          "kind": "mixin",
+          "customElement": true,
+          "description": "A custom element mixin deprecated with reason",
+          "name": "DeprecatedReasonCustomElementMixin",
+          "deprecated": "Custom element mixins are deprecated",
+          "members": []
+        },
+        {
+          "kind": "function",
+          "description": "A test function",
+          "name": "testFunction",
+          "parameters": [
+            {
+              "name": "param1",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "name": "param2",
+              "type": {
+                "text": "number"
+              },
+              "optional": true
+            }
+          ],
+          "return": {
+            "type": {
+              "text": "boolean"
+            }
+          }
+        },
+        {
+          "kind": "function",
+          "description": "A deprecated function",
+          "name": "deprecatedFunction",
+          "deprecated": true,
+          "parameters": [],
+          "return": {
+            "type": {
+              "text": "void"
+            }
+          }
+        },
+        {
+          "kind": "function",
+          "description": "A function deprecated with reason",
+          "name": "deprecatedReasonFunction",
+          "deprecated": "Use newFunction instead",
+          "parameters": [
+            {
+              "name": "deprecatedParam",
+              "type": {
+                "text": "string"
+              },
+              "deprecated": true
+            },
+            {
+              "name": "deprecatedReasonParam",
+              "type": {
+                "text": "number"
+              },
+              "deprecated": "No longer used"
+            }
+          ],
+          "return": {
+            "type": {
+              "text": "void"
+            }
+          }
+        },
+        {
+          "kind": "variable",
+          "description": "A test variable",
+          "name": "testVariable",
+          "type": {
+            "text": "Array<string>"
+          },
+          "default": "[\"default\", \"values\"]"
+        },
+        {
+          "kind": "variable",
+          "description": "A deprecated variable",
+          "name": "deprecatedVariable",
+          "deprecated": true,
+          "type": {
+            "text": "string"
+          }
+        },
+        {
+          "kind": "variable",
+          "description": "A variable deprecated with reason",
+          "name": "deprecatedReasonVariable",
+          "deprecated": "No longer supported",
+          "type": {
+            "text": "string"
+          }
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "testExport",
+          "declaration": {
+            "name": "testFunction",
+            "module": "test.js"
+          }
+        }
+      ]
+    }
+  ],
+  "deprecated": "Package is deprecated, use new-package instead"
+}

--- a/manifest/marshal_roundtrip_test.go
+++ b/manifest/marshal_roundtrip_test.go
@@ -1,0 +1,212 @@
+package manifest
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMarshalUnmarshalRoundTrip tests that we can unmarshal a comprehensive JSON
+// manifest and then marshal it back to JSON without losing any data.
+func TestMarshalUnmarshalRoundTrip(t *testing.T) {
+	// Load the comprehensive golden file
+	goldenPath := filepath.Join("fixtures", "marshal_roundtrip_comprehensive.json")
+	originalJSON, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("Failed to read golden file: %v", err)
+	}
+
+	// Unmarshal into Package struct
+	var pkg Package
+	if err := json.Unmarshal(originalJSON, &pkg); err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	// Marshal back to JSON
+	roundTripJSON, err := json.Marshal(&pkg)
+	if err != nil {
+		t.Fatalf("Failed to marshal back to JSON: %v", err)
+	}
+
+	// Parse both JSONs for comparison (to handle formatting differences)
+	var originalData, roundTripData interface{}
+
+	if err := json.Unmarshal(originalJSON, &originalData); err != nil {
+		t.Fatalf("Failed to parse original JSON: %v", err)
+	}
+
+	if err := json.Unmarshal(roundTripJSON, &roundTripData); err != nil {
+		t.Fatalf("Failed to parse round-trip JSON: %v", err)
+	}
+
+	// Compare the data structures
+	if !deepEqualIgnoreOmitEmpty(originalData, roundTripData) {
+		t.Errorf("Round-trip failed.\nOriginal JSON:\n%s\n\nRound-trip JSON:\n%s",
+			string(originalJSON), string(roundTripJSON))
+	}
+}
+
+// TestMarshalUnmarshalSpecificCases tests specific edge cases and deprecation forms
+func TestMarshalUnmarshalSpecificCases(t *testing.T) {
+	testCases := []struct {
+		name     string
+		jsonData string
+	}{
+		{
+			name: "PackageDeprecatedBool",
+			jsonData: `{
+				"schemaVersion": "2.1.0",
+				"deprecated": true,
+				"modules": []
+			}`,
+		},
+		{
+			name: "PackageDeprecatedReason",
+			jsonData: `{
+				"schemaVersion": "2.1.0", 
+				"deprecated": "Use new-package instead",
+				"modules": []
+			}`,
+		},
+		{
+			name: "FunctionParameterDeprecated",
+			jsonData: `{
+				"schemaVersion": "2.1.0",
+				"modules": [{
+					"kind": "javascript-module",
+					"path": "test.js",
+					"declarations": [{
+						"kind": "function",
+						"name": "testFn",
+						"parameters": [{
+							"name": "param1",
+							"deprecated": true,
+							"type": {"text": "string"}
+						}, {
+							"name": "param2", 
+							"deprecated": "Use param3 instead",
+							"type": {"text": "number"}
+						}]
+					}],
+					"exports": []
+				}]
+			}`,
+		},
+		{
+			name: "EmptySlicesNotNil",
+			jsonData: `{
+				"schemaVersion": "2.1.0",
+				"modules": [{
+					"kind": "javascript-module",
+					"path": "test.js"
+				}]
+			}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Unmarshal
+			var pkg Package
+			if err := json.Unmarshal([]byte(tc.jsonData), &pkg); err != nil {
+				t.Fatalf("Failed to unmarshal: %v", err)
+			}
+
+			// Marshal back
+			roundTripJSON, err := json.Marshal(&pkg)
+			if err != nil {
+				t.Fatalf("Failed to marshal: %v", err)
+			}
+
+			// Parse for comparison
+			var originalData, roundTripData interface{}
+			if err := json.Unmarshal([]byte(tc.jsonData), &originalData); err != nil {
+				t.Fatalf("Failed to parse original: %v", err)
+			}
+			if err := json.Unmarshal(roundTripJSON, &roundTripData); err != nil {
+				t.Fatalf("Failed to parse round-trip: %v", err)
+			}
+
+			// Verify round-trip equality
+			if !deepEqualIgnoreOmitEmpty(originalData, roundTripData) {
+				t.Errorf("Round-trip failed for %s.\nOriginal: %s\nRound-trip: %s",
+					tc.name, tc.jsonData, string(roundTripJSON))
+			}
+
+			// For empty slices test, ensure slices are not nil after unmarshal
+			if tc.name == "EmptySlicesNotNil" {
+				if pkg.Modules[0].Declarations == nil {
+					t.Error("Declarations slice should not be nil after unmarshal")
+				}
+				if pkg.Modules[0].Exports == nil {
+					t.Error("Exports slice should not be nil after unmarshal")
+				}
+			}
+		})
+	}
+}
+
+// deepEqualIgnoreOmitEmpty compares JSON structures while ignoring empty arrays/slices
+// that would be omitted due to omitempty tags
+func deepEqualIgnoreOmitEmpty(a, b interface{}) bool {
+	// Normalize both structures to handle omitempty differences
+	aNorm := normalizeOmitEmpty(a)
+	bNorm := normalizeOmitEmpty(b)
+
+	// Marshal to get canonical representation
+	aJSON, err := json.Marshal(aNorm)
+	if err != nil {
+		return false
+	}
+	bJSON, err := json.Marshal(bNorm)
+	if err != nil {
+		return false
+	}
+
+	return string(aJSON) == string(bJSON)
+}
+
+// normalizeOmitEmpty recursively removes empty slices and arrays to simulate omitempty behavior
+func normalizeOmitEmpty(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		result := make(map[string]interface{})
+		for k, v := range val {
+			normalized := normalizeOmitEmpty(v)
+			// Only include non-empty values
+			if !isEmpty(normalized) {
+				result[k] = normalized
+			}
+		}
+		return result
+	case []interface{}:
+		if len(val) == 0 {
+			return nil // Empty slices become nil to match omitempty
+		}
+		result := make([]interface{}, len(val))
+		for i, v := range val {
+			result[i] = normalizeOmitEmpty(v)
+		}
+		return result
+	default:
+		return val
+	}
+}
+
+// isEmpty checks if a value should be considered empty for omitempty purposes
+func isEmpty(v interface{}) bool {
+	if v == nil {
+		return true
+	}
+	switch val := v.(type) {
+	case []interface{}:
+		return len(val) == 0
+	case map[string]interface{}:
+		return len(val) == 0
+	case string:
+		return val == ""
+	default:
+		return false
+	}
+}

--- a/manifest/marshal_roundtrip_test.go
+++ b/manifest/marshal_roundtrip_test.go
@@ -11,7 +11,7 @@ import (
 // manifest and then marshal it back to JSON without losing any data.
 func TestMarshalUnmarshalRoundTrip(t *testing.T) {
 	// Load the comprehensive golden file
-	goldenPath := filepath.Join("fixtures", "marshal_roundtrip_comprehensive.json")
+	goldenPath := filepath.Join("fixtures", "marshal-roundtrip-comprehensive.json")
 	originalJSON, err := os.ReadFile(goldenPath)
 	if err != nil {
 		t.Fatalf("Failed to read golden file: %v", err)

--- a/manifest/mixin.go
+++ b/manifest/mixin.go
@@ -224,7 +224,8 @@ func (x *CustomElementMixinDeclaration) GetStartByte() uint { return x.FunctionL
 func (m *CustomElementMixinDeclaration) UnmarshalJSON(data []byte) error {
 	type Rest CustomElementMixinDeclaration
 	aux := &struct {
-		Members []json.RawMessage `json:"members"`
+		Members    []json.RawMessage `json:"members"`
+		Deprecated json.RawMessage   `json:"deprecated"`
 		*Rest
 	}{
 		Rest: (*Rest)(m),
@@ -233,6 +234,16 @@ func (m *CustomElementMixinDeclaration) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
+
+	// Handle deprecated field
+	if len(aux.Deprecated) > 0 && string(aux.Deprecated) != "null" {
+		var dep Deprecated
+		if !decodeDeprecatedField(&dep, aux.Deprecated) {
+			return fmt.Errorf("invalid type for deprecated field")
+		}
+		m.Deprecated = dep
+	}
+
 	m.Members = nil
 	for _, mem := range aux.Members {
 		member, err := unmarshalClassMember(mem)

--- a/manifest/module.go
+++ b/manifest/module.go
@@ -90,6 +90,9 @@ func (m *Module) UnmarshalJSON(data []byte) error {
 		}
 		m.Exports = append(m.Exports, export)
 	}
+	if m.Exports == nil {
+		m.Exports = []Export{}
+	}
 
 	return nil
 }

--- a/manifest/package.go
+++ b/manifest/package.go
@@ -87,13 +87,23 @@ func (p *Package) Clone() *Package {
 func (x *Package) UnmarshalJSON(data []byte) error {
 	type Rest Package
 	aux := &struct {
-		Modules []json.RawMessage `json:"modules"`
+		Modules    []json.RawMessage `json:"modules"`
+		Deprecated json.RawMessage   `json:"deprecated"`
 		*Rest
 	}{
 		Rest: (*Rest)(x),
 	}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
+	}
+
+	// Handle deprecated field
+	if len(aux.Deprecated) > 0 && string(aux.Deprecated) != "null" {
+		var dep Deprecated
+		if !decodeDeprecatedField(&dep, aux.Deprecated) {
+			return fmt.Errorf("invalid type for deprecated field")
+		}
+		x.Deprecated = dep
 	}
 
 	x.Modules = nil


### PR DESCRIPTION
## Summary
- Add comprehensive JSON marshal/unmarshal round-trip tests for all CEM declaration types
- Fix Package, Module, and CustomElementMixinDeclaration UnmarshalJSON to handle deprecated fields
- Test all deprecation forms (none/bool/reason) for Package, Mixin, CustomElementMixin, Function, Variable
- Include comprehensive CustomElementDeclaration with attributes, events, slots, CSS parts/properties/states

## Test Coverage
- **Package**: deprecated (none/bool/reason)
- **CustomElementDeclaration**: with full web component features + deprecation
- **ClassDeclaration**: basic and member testing
- **MixinDeclaration**: all deprecation forms
- **CustomElementMixinDeclaration**: all deprecation forms  
- **FunctionDeclaration**: all deprecation forms + parameter deprecation
- **VariableDeclaration**: all deprecation forms
- **Edge cases**: empty slices, parameter deprecation, round-trip fidelity

## Changes
- Add `marshal_roundtrip_test.go` with comprehensive round-trip testing
- Add `marshal-roundtrip-comprehensive.json` fixture with realistic CEM structure
- Fix `Package.UnmarshalJSON()` to handle deprecated field properly
- Fix `Module.UnmarshalJSON()` to ensure empty exports slice consistency
- Fix `CustomElementMixinDeclaration.UnmarshalJSON()` to handle deprecated field

🤖 Generated with [Claude Code](https://claude.ai/code)

Assisted-By: Claude <noreply@anthropic.com>