### PR TITLE
fix(lsp): don't throw diagnostics for custom-elements in ts comments

### DIFF
--- a/lsp/methods/textDocument/publishDiagnostics/test-fixtures/tag-diagnostics/jsdoc-example.ts
+++ b/lsp/methods/textDocument/publishDiagnostics/test-fixtures/tag-diagnostics/jsdoc-example.ts
@@ -1,0 +1,24 @@
+/**
+ * Example function with custom elements in JSDoc.
+ * @example
+ * ```html
+ * <form-element>
+ *   <input-field label="Name"></input-field>
+ *   <text-area label="Bio"></text-area>
+ * </form-element>
+ * ```
+ */
+export function exampleBlockComment() {}
+
+/** @example ```html
+ * <card-element>
+ *   <button-element>Click</button-element>
+ * </card-element>
+ * ```
+ */
+export function exampleInlineJsDocComment() {}
+
+// This is an inline comment with example: <inline-element></inline-element>
+
+// This actual usage should still be validated
+const template = html`<my-foo></my-foo>`;


### PR DESCRIPTION
before, this would throw multiple errors

```ts
/**
 * Example function with custom elements in JSDoc.
 * @example
 * ```html
 * <form-element>
 *   <input-field label="Name"></input-field>
 *   <text-area label="Bio"></text-area>
 * </form-element>
 * ```
 */
export function exampleBlockComment() {}

/** @example ```html
 * <card-element>
 *   <button-element>Click</button-element>
 * </card-element>
 * ```
 */
export function exampleInlineJsDocComment() {}

// This is an inline comment with example: <inline-element></inline-element>

// This actual usage should still be validated
const template = html`<my-foo></my-foo>`;
```

Now it just throws one for my-foo