### PR TITLE
fix(generate): token summaries and entries

### DIFF
--- a/generate/jsdoc/apply.go
+++ b/generate/jsdoc/apply.go
@@ -6,6 +6,17 @@ import (
 	M "bennypowers.dev/cem/manifest"
 )
 
+// appendWithSeparator appends new content to existing content with a separator if both are non-empty
+func appendWithSeparator(existing, new, separator string) string {
+	if new == "" {
+		return existing
+	}
+	if existing == "" {
+		return new
+	}
+	return existing + separator + new
+}
+
 func applyToClassDeclaration(info *classInfo, declaration *M.ClassDeclaration) {
 	declaration.Deprecated = info.Deprecated
 	declaration.Description = info.Description
@@ -78,8 +89,8 @@ func applyToCustomElementDeclaration(info *classInfo, declaration *M.CustomEleme
 }
 
 func applyToCSSProperty(info *cssPropertyInfo, declaration *M.CssCustomProperty) {
-	declaration.Description += info.Description
-	declaration.Summary += info.Summary
+	declaration.Description = appendWithSeparator(declaration.Description, info.Description, "\n\n")
+	declaration.Summary = appendWithSeparator(declaration.Summary, info.Summary, "\n\n")
 	declaration.Deprecated = info.Deprecated
 	if info.Syntax != "" {
 		declaration.Syntax = info.Syntax
@@ -87,8 +98,8 @@ func applyToCSSProperty(info *cssPropertyInfo, declaration *M.CssCustomProperty)
 }
 
 func applyToPropertyLike(info *propertyInfo, declaration *M.PropertyLike) {
-	declaration.Description += info.Description
-	declaration.Summary += info.Summary
+	declaration.Description = appendWithSeparator(declaration.Description, info.Description, "\n\n")
+	declaration.Summary = appendWithSeparator(declaration.Summary, info.Summary, "\n\n")
 	declaration.Deprecated = info.Deprecated
 	if info.Type != "" {
 		declaration.Type = &M.Type{

--- a/generate/test/fixtures/project-css-design-token-comments/golden/user-comment-with-token.json
+++ b/generate/test/fixtures/project-css-design-token-comments/golden/user-comment-with-token.json
@@ -27,6 +27,12 @@
               "name": "--cem-color-secondary",
               "description": "USER description for secondary color\nThis is a multiline comment that explains\nthe usage of the secondary color token\n\nDESIGN TOKEN description for secondary color",
               "syntax": "\u003ccolor\u003e"
+            },
+            {
+              "name": "--cem-spacing-base",
+              "summary": "Nested comment on spacing token inside private var fallback\n\nDirect summary comment on design token",
+              "description": "DESIGN TOKEN description for base spacing",
+              "syntax": "\u003clength\u003e"
             }
           ],
           "customElement": true

--- a/generate/test/fixtures/project-css-design-token-comments/src/user-comment-with-token.ts
+++ b/generate/test/fixtures/project-css-design-token-comments/src/user-comment-with-token.ts
@@ -12,6 +12,8 @@ export class UserCommentWithToken extends LitElement {
       color: var(--_my-var,
         /** USER description for the primary color, specified on the token fallback for a _private var */
         var(--cem-color-primary));
+      /** @summary comment on a private var */
+      border-color: var(--_private);
 
       /**
        * USER description for secondary color
@@ -19,6 +21,16 @@ export class UserCommentWithToken extends LitElement {
        * the usage of the secondary color token
        */
       background-color: var(--cem-color-secondary);
+
+      /** @summary Outer comment on private var value assignment */
+      --_private-with-outer-comment: var(--_another-private);
+
+      font-weight: var(--_private-weight,
+        /** @summary Nested comment on spacing token inside private var fallback */
+        var(--cem-spacing-base));
+
+      /** @summary Direct summary comment on design token */
+      padding: var(--cem-spacing-base);
     }
   `;
 }


### PR DESCRIPTION
1. ✓ Private vars correctly excluded: No --_* vars appear in either manifest (correct
  behavior)
  2. ✗ Design token missing from rh-progress-stepper manifest:
    - `--rh-font-weight-body-text-medium` at rh-progress-stepper.css:66-70 with `@summary`
  comment inside nested var() is completely missing from the manifest
    - Should appear with summary field: "Font weight for current step text"
  3. ✗ Design tokens missing from rh-progress-step manifest:
    - `--rh-color-text-secondary` at rh-progress-step.css:45-46 with `@summary` comment is
  missing
    - `--rh-font-weight-body-text-regular` at rh-progress-step.css:91-92 is in manifest but
  missing the `@summary` field "Font weight for labels of steps"
  4. ✗ Summary merging issue: When multiple `@summary` comments exist for the same token,
  they concatenate without newline separator
    - Expected: "summary": "First\n\nSecond"
    - Actual: "summary": "FirstSecond"

  Test Fixtures Created

  Added to
generate/test/fixtures/project-css-design-token-comments/src/user-comment-with-t
  oken.ts:15-33:

  1. Private var with JSDoc (should NOT appear)
  2. Private var assignment with outer comment (should NOT appear)
  3. Design token in nested var() with `@summary` (should appear with separate summary field)
  4. Same token with second `@summary` (summaries should merge with \n\n)

  Red Phase Test Failure ✓

  The test at generate/test/fixtures/project-css-design-token-comments
now fails, showing:

  Expected: "summary": "Nested...fallback\n\nDirect...token"
  Got:      "summary": "Nested...fallbackDirect...token"