### PR TITLE
fix(lsp): load the most-local package.json

### DIFF
--- a/lsp/methods/textDocument/hover/testdata/attribute-hover-html/package.json
+++ b/lsp/methods/textDocument/hover/testdata/attribute-hover-html/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "attribute-hover-html",
+  "version": "1.0.0",
+  "customElements": "manifest.json"
+}


### PR DESCRIPTION
Previously, we did not load package.json unless it was also in the git root. Now we load it nearest to the file, but continue up to determine if we're in a monorepo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace-root detection to prefer the nearest package manifest with customElements when appropriate, correctly handling VCS boundaries and filesystem-root fallbacks.

* **Tests**
  * Added coverage verifying the resolver selects the nearest package manifest over the repository root in nested Git repo layouts.

* **Chores**
  * Added test fixture manifest metadata for attribute-hover HTML test data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->