### PR TITLE
fix(generate): serialize member defaults with correct JSON types

### DIFF
--- a/generate/classDeclarations.go
+++ b/generate/classDeclarations.go
@@ -29,6 +29,26 @@ import (
 	ts "github.com/tree-sitter/go-tree-sitter"
 )
 
+// defaultToString converts a default value (which may be any type for members)
+// to a string representation for HTML attributes (which are always strings).
+func defaultToString(defaultVal any) string {
+	if defaultVal == nil {
+		return ""
+	}
+	switch v := defaultVal.(type) {
+	case string:
+		return v
+	case bool:
+		return fmt.Sprintf("%t", v)
+	case int:
+		return fmt.Sprintf("%d", v)
+	case float64:
+		return fmt.Sprintf("%g", v)
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
 // --- Main entry: Generate a class declaration as ParsedClass ---
 func (mp *ModuleProcessor) generateClassDeclarationParsed(
 	captures Q.CaptureMap,
@@ -279,7 +299,7 @@ func (mp *ModuleProcessor) generateLitElementClassDeclaration(
 		if ok && field.Attribute != "" {
 			return []M.Attribute{{
 				Deprecated: field.Deprecated,
-				Default:    field.Default,
+				Default:    defaultToString(field.Default),
 				Type:       field.Type,
 				FieldName:  field.Name,
 				StartByte:  field.StartByte,

--- a/generate/testdata/fixtures/project-classes/golden/class-fields-multiple.json
+++ b/generate/testdata/fixtures/project-classes/golden/class-fields-multiple.json
@@ -37,7 +37,7 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "true",
+              "default": true,
               "kind": "field",
               "static": true
             },
@@ -47,7 +47,7 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
+              "default": false,
               "kind": "field",
               "attribute": "dupe",
               "reflects": true

--- a/generate/testdata/fixtures/project-classes/golden/class-fields-static.json
+++ b/generate/testdata/fixtures/project-classes/golden/class-fields-static.json
@@ -17,7 +17,7 @@
               "type": {
                 "text": "number"
               },
-              "default": "0",
+              "default": 0,
               "readonly": true,
               "kind": "field",
               "static": true
@@ -27,7 +27,7 @@
               "type": {
                 "text": "number"
               },
-              "default": "0",
+              "default": 0,
               "readonly": true,
               "kind": "field",
               "static": true
@@ -37,7 +37,7 @@
               "type": {
                 "text": "Float"
               },
-              "default": "0.1",
+              "default": 0.1,
               "readonly": true,
               "kind": "field",
               "static": true,
@@ -48,7 +48,7 @@
               "type": {
                 "text": "number"
               },
-              "default": "0",
+              "default": 0,
               "readonly": true,
               "kind": "field",
               "static": true,
@@ -59,7 +59,7 @@
               "type": {
                 "text": "number"
               },
-              "default": "0",
+              "default": 0,
               "kind": "field",
               "static": true,
               "privacy": "private"
@@ -69,7 +69,7 @@
               "type": {
                 "text": "number"
               },
-              "default": "0",
+              "default": 0,
               "kind": "field",
               "static": true,
               "privacy": "protected"
@@ -79,7 +79,7 @@
               "type": {
                 "text": "number"
               },
-              "default": "0",
+              "default": 0,
               "kind": "field",
               "static": true
             },
@@ -88,7 +88,7 @@
               "type": {
                 "text": "number"
               },
-              "default": "0",
+              "default": 0,
               "kind": "field"
             }
           ],

--- a/generate/testdata/fixtures/project-classes/golden/class-fields.json
+++ b/generate/testdata/fixtures/project-classes/golden/class-fields.json
@@ -44,7 +44,7 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
+              "default": false,
               "kind": "field"
             },
             {
@@ -52,7 +52,7 @@
               "type": {
                 "text": "number"
               },
-              "default": "0",
+              "default": 0,
               "kind": "field"
             },
             {
@@ -61,7 +61,7 @@
               "type": {
                 "text": "number"
               },
-              "default": "0",
+              "default": 0,
               "kind": "field"
             },
             {

--- a/generate/testdata/fixtures/project-classes/golden/class-members.json
+++ b/generate/testdata/fixtures/project-classes/golden/class-members.json
@@ -36,7 +36,7 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
+              "default": false,
               "kind": "field",
               "attribute": "attr-reflect-bool",
               "reflects": true
@@ -46,7 +46,7 @@
               "type": {
                 "text": "number"
               },
-              "default": "0",
+              "default": 0,
               "kind": "field"
             },
             {

--- a/generate/testdata/fixtures/project-classes/golden/class-property-decorator-with-type-option.json
+++ b/generate/testdata/fixtures/project-classes/golden/class-property-decorator-with-type-option.json
@@ -28,7 +28,7 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
+              "default": false,
               "kind": "field",
               "attribute": "enabled"
             },

--- a/generate/testdata/fixtures/project-classes/golden/class-reactive-properties-jsdoc.json
+++ b/generate/testdata/fixtures/project-classes/golden/class-reactive-properties-jsdoc.json
@@ -64,7 +64,7 @@
               "type": {
                 "text": "number"
               },
-              "default": "0",
+              "default": 0,
               "kind": "field",
               "attribute": "multi-decorator",
               "reflects": true

--- a/generate/testdata/fixtures/project-classes/golden/class-reactive-properties.json
+++ b/generate/testdata/fixtures/project-classes/golden/class-reactive-properties.json
@@ -76,7 +76,7 @@
               "type": {
                 "text": "number"
               },
-              "default": "0",
+              "default": 0,
               "kind": "field",
               "attribute": "multi-decorator",
               "reflects": true

--- a/generate/testdata/fixtures/project-classes/golden/class-reflecting-attribute.json
+++ b/generate/testdata/fixtures/project-classes/golden/class-reflecting-attribute.json
@@ -17,7 +17,7 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
+              "default": false,
               "kind": "field",
               "attribute": "reflecting-attribute",
               "reflects": true

--- a/generate/testdata/fixtures/project-classes/golden/wa-button.json
+++ b/generate/testdata/fixtures/project-classes/golden/wa-button.json
@@ -90,7 +90,7 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
+              "default": false,
               "kind": "field"
             },
             {
@@ -99,7 +99,7 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
+              "default": false,
               "kind": "field"
             },
             {
@@ -108,7 +108,7 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
+              "default": false,
               "kind": "field"
             },
             {
@@ -117,7 +117,7 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
+              "default": false,
               "kind": "field"
             },
             {

--- a/generate/testdata/fixtures/type-alias-unwrapping/golden/all.json
+++ b/generate/testdata/fixtures/type-alias-unwrapping/golden/all.json
@@ -267,7 +267,7 @@
               "type": {
                 "text": "number"
               },
-              "default": "0",
+              "default": 0,
               "kind": "field"
             },
             {

--- a/manifest/propertylike.go
+++ b/manifest/propertylike.go
@@ -24,7 +24,7 @@ type PropertyLike struct {
 	FullyQualified
 	StartByte  uint       `json:"-"`
 	Type       *Type      `json:"type,omitempty"`
-	Default    string     `json:"default,omitempty"`
+	Default    any        `json:"default,omitempty"`
 	Deprecated Deprecated `json:"deprecated,omitempty"`
 	Readonly   bool       `json:"readonly,omitempty"`
 }

--- a/serve/middleware/routes/knobs.go
+++ b/serve/middleware/routes/knobs.go
@@ -54,6 +54,25 @@ var (
 	stringLiteralRe = regexp.MustCompile(`'([^']+)'`)
 )
 
+// defaultToString converts a default value (which may be any type) to a string.
+func defaultToString(defaultVal any) string {
+	if defaultVal == nil {
+		return ""
+	}
+	switch v := defaultVal.(type) {
+	case string:
+		return v
+	case bool:
+		return fmt.Sprintf("%t", v)
+	case int:
+		return fmt.Sprintf("%d", v)
+	case float64:
+		return fmt.Sprintf("%g", v)
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
 // KnobsData represents all knobs for an element
 type KnobsData struct {
 	TagName          string
@@ -182,7 +201,7 @@ func propertyToKnob(field *M.ClassField, currentValues map[string]string) KnobDa
 		Category:     KnobCategoryProperty,
 		Summary:      template.HTML(field.Summary),
 		Description:  template.HTML(field.Description),
-		Default:      field.Default,
+		Default:      defaultToString(field.Default),
 		CurrentValue: currentValues["prop:"+field.Name],
 	}
 


### PR DESCRIPTION
Fixes #197

## Summary
- Member default values now serialize to match their type (boolean → JSON boolean, number → JSON number)
- Attribute defaults remain strings (HTML serialization requirement)
- Added type parsing and conversion functions

## Changes
- Changed `PropertyLike.Default` from `string` to `any` in `manifest/propertylike.go`
- Added `parseDefaultValue()` in `generate/classMemberDeclarations.go` to convert strings to appropriate types
- Added `defaultToString()` helpers in `generate/classDeclarations.go` and `serve/middleware/routes/knobs.go`
- Updated golden test files to reflect correct JSON types

## Test plan
- [x] All unit tests pass
- [x] Golden files updated with correct JSON types
- [x] Example manifests regenerated and verified

Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected how default values are handled in class field declarations—boolean and numeric defaults now properly use their correct primitive types (true/false, numbers) instead of string representations.

* **Tests**
  * Updated test fixtures across multiple classes to reflect accurate default value type conversions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->