### PR TITLE
fix(serve): check origin before allowing clients to connect

### DIFF
--- a/serve/websocket_origin_test.go
+++ b/serve/websocket_origin_test.go
@@ -73,6 +73,8 @@ func TestIsLocalOrigin_SameOriginAllowed(t *testing.T) {
 		{"custom domain", "https://my-project.dev", "my-project.dev"},
 		{"ngrok tunnel", "https://abc123.ngrok.io", "abc123.ngrok.io"},
 		{"host with port", "http://example.com:8080", "example.com:8080"},
+		{"IPv6 same-origin with port", "http://[2001:db8::1]:8000", "[2001:db8::1]:8000"},
+		{"IPv6 same-origin no port", "http://[2001:db8::1]", "[2001:db8::1]"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced WebSocket connection security with read size limits to prevent denial-of-service attacks.
  * Improved origin validation with stricter local-origin checks and better reverse proxy support.

* **Tests**
  * Added comprehensive test coverage for WebSocket origin validation and read size constraints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->