### PR TITLE
fix(generate): require event `type` field

### DIFF
--- a/generate/jsdoc/parse.go
+++ b/generate/jsdoc/parse.go
@@ -422,9 +422,23 @@ func (info tagInfo) toEvent() M.Event {
 			Description: normalizeJsdocLines(matches["description"]),
 		},
 	}
-	if matches["type"] != "" {
-		event.Type = &M.Type{
-			Text: matches["type"],
+	// Default to "Event" if type is not specified, as required by the CEM schema
+	eventType := matches["type"]
+	if eventType == "" {
+		eventType = "Event"
+	}
+	event.Type = &M.Type{
+		Text: eventType,
+	}
+	// Add global package reference for Event, CustomEvent, and ErrorEvent types
+	if eventType == "Event" || eventType == "CustomEvent" || eventType == "ErrorEvent" {
+		event.Type.References = []M.TypeReference{
+			{
+				Reference: M.Reference{
+					Name:    eventType,
+					Package: "global:",
+				},
+			},
 		}
 	}
 	return event

--- a/generate/testdata/fixtures/project-classes/golden/wa-button.json
+++ b/generate/testdata/fixtures/project-classes/golden/wa-button.json
@@ -310,15 +310,42 @@
           "events": [
             {
               "name": "blur",
-              "description": "Emitted when the button loses focus."
+              "description": "Emitted when the button loses focus.",
+              "type": {
+                "text": "Event",
+                "references": [
+                  {
+                    "name": "Event",
+                    "package": "global:"
+                  }
+                ]
+              }
             },
             {
               "name": "focus",
-              "description": "Emitted when the button gains focus."
+              "description": "Emitted when the button gains focus.",
+              "type": {
+                "text": "Event",
+                "references": [
+                  {
+                    "name": "Event",
+                    "package": "global:"
+                  }
+                ]
+              }
             },
             {
               "name": "wa-invalid",
-              "description": "Emitted when the form control has been checked for validity and its constraints aren't satisfied."
+              "description": "Emitted when the form control has been checked for validity and its constraints aren't satisfied.",
+              "type": {
+                "text": "Event",
+                "references": [
+                  {
+                    "name": "Event",
+                    "package": "global:"
+                  }
+                ]
+              }
             }
           ],
           "slots": [

--- a/generate/testdata/fixtures/project-jsdoc/golden/jsdoc-event.json
+++ b/generate/testdata/fixtures/project-jsdoc/golden/jsdoc-event.json
@@ -18,65 +18,155 @@
           "tagName": "jsdoc-events",
           "events": [
             {
-              "name": "event"
+              "name": "event",
+              "type": {
+                "text": "Event",
+                "references": [
+                  {
+                    "name": "Event",
+                    "package": "global:"
+                  }
+                ]
+              }
             },
             {
               "name": "event-description",
-              "description": "event description"
+              "description": "event description",
+              "type": {
+                "text": "Event",
+                "references": [
+                  {
+                    "name": "Event",
+                    "package": "global:"
+                  }
+                ]
+              }
             },
             {
               "name": "event-description-multiline",
-              "description": "multiline\nevent description"
+              "description": "multiline\nevent description",
+              "type": {
+                "text": "Event",
+                "references": [
+                  {
+                    "name": "Event",
+                    "package": "global:"
+                  }
+                ]
+              }
             },
             {
               "name": "event-typed",
               "type": {
-                "text": "Event"
+                "text": "Event",
+                "references": [
+                  {
+                    "name": "Event",
+                    "package": "global:"
+                  }
+                ]
               }
             },
             {
               "name": "event-typed-description",
               "description": "event typed description",
               "type": {
-                "text": "Event"
+                "text": "Event",
+                "references": [
+                  {
+                    "name": "Event",
+                    "package": "global:"
+                  }
+                ]
               }
             },
             {
               "name": "event-typed-description-multiline",
               "description": "multiline\nevent typed description",
               "type": {
-                "text": "Event"
+                "text": "Event",
+                "references": [
+                  {
+                    "name": "Event",
+                    "package": "global:"
+                  }
+                ]
               }
             },
             {
-              "name": "fires"
+              "name": "fires",
+              "type": {
+                "text": "Event",
+                "references": [
+                  {
+                    "name": "Event",
+                    "package": "global:"
+                  }
+                ]
+              }
             },
             {
               "name": "fires-description",
-              "description": "fires description"
+              "description": "fires description",
+              "type": {
+                "text": "Event",
+                "references": [
+                  {
+                    "name": "Event",
+                    "package": "global:"
+                  }
+                ]
+              }
             },
             {
               "name": "fires-description-multiline",
-              "description": "multiline\nfires description"
+              "description": "multiline\nfires description",
+              "type": {
+                "text": "Event",
+                "references": [
+                  {
+                    "name": "Event",
+                    "package": "global:"
+                  }
+                ]
+              }
             },
             {
               "name": "fires-typed",
               "type": {
-                "text": "Event"
+                "text": "Event",
+                "references": [
+                  {
+                    "name": "Event",
+                    "package": "global:"
+                  }
+                ]
               }
             },
             {
               "name": "fires-typed-description",
               "description": "fires typed description",
               "type": {
-                "text": "Event"
+                "text": "Event",
+                "references": [
+                  {
+                    "name": "Event",
+                    "package": "global:"
+                  }
+                ]
               }
             },
             {
               "name": "fires-typed-description-multiline",
               "description": "multiline\nfires typed description",
               "type": {
-                "text": "Event"
+                "text": "Event",
+                "references": [
+                  {
+                    "name": "Event",
+                    "package": "global:"
+                  }
+                ]
               }
             }
           ],

--- a/mcp/fixtures/template-rendering/schema_resilient_template.golden.md
+++ b/mcp/fixtures/template-rendering/schema_resilient_template.golden.md
@@ -1,0 +1,51 @@
+# Design System Guidelines
+
+## Summary
+<no value> guidelines extracted from manifest documentation
+
+## Element Guidelines
+
+
+
+## Attribute Guidelines
+
+
+
+## Guidelines Application
+
+These guidelines are extracted from element and attribute descriptions in your manifests. Use them to:
+
+### Development Standards
+- **Consistent usage** - Follow documented patterns for element implementation
+- **Attribute validation** - Ensure attributes are used according to their intended purpose
+- **Content guidelines** - Understand proper element content and structure
+- **Integration patterns** - Learn how elements should work together
+
+### Design System Compliance
+- **Component behavior** - Understand expected element behavior and interactions
+- **Content strategy** - Follow documented content guidelines and constraints
+- **Accessibility requirements** - Implement proper accessibility based on element guidance
+- **Performance considerations** - Follow optimization guidelines from element documentation
+
+### Code Review Standards
+- **Manifest compliance** - Verify implementations follow documented guidelines
+- **Consistency checking** - Ensure similar elements are used similarly across projects
+- **Best practice validation** - Apply documented best practices consistently
+- **Documentation completeness** - Ensure new elements include proper guidelines
+
+## Guideline Categories
+
+Guidelines are categorized by their source and scope:
+
+- **Element guidelines** - Overall element usage, behavior, and integration patterns
+- **Attribute guidelines** - Specific attribute usage, validation, and value constraints
+- **Content guidelines** - Slot content requirements and content structure patterns
+- **Styling guidelines** - CSS integration patterns and theming requirements
+
+---
+
+For implementation guidance, use:
+- **`cem://elements`** - Browse elements with guideline context
+- **`cem://element/{tagName}`** - Detailed element information including guidelines
+- **`cem://accessibility`** - Accessibility-specific patterns and requirements
+- **`cem://packages`** - Package-level organization and consistency patterns

--- a/mcp/testdata/fixtures/resource-integration/schema_resource.golden.json
+++ b/mcp/testdata/fixtures/resource-integration/schema_resource.golden.json
@@ -866,7 +866,8 @@
         }
       },
       "required": [
-        "name"
+        "name",
+        "type"
       ],
       "type": "object"
     },

--- a/validate/schemas/2.1.1-speculative.json
+++ b/validate/schemas/2.1.1-speculative.json
@@ -868,7 +868,8 @@
         }
       },
       "required": [
-        "name"
+        "name",
+        "type"
       ],
       "type": "object"
     },

--- a/validate/testdata/goldens/event_without_type.json
+++ b/validate/testdata/goldens/event_without_type.json
@@ -1,6 +1,24 @@
 {
-  "valid": true,
+  "valid": false,
   "schemaVersion": "2.1.0",
-  "errors": [],
+  "errors": [
+    {
+      "id": "schema-invalid-type",
+      "module": "event-without-type.js",
+      "declaration": "class EventWithoutType",
+      "property": "event input",
+      "message": "missing properties: 'type'",
+      "location": "/modules/0/declarations/0/events/0"
+    },
+    {
+      "id": "schema-invalid-type",
+      "module": "event-without-type.js",
+      "declaration": "class EventWithoutType",
+      "property": "event change",
+      "message": "missing properties: 'type'",
+      "location": "/modules/0/declarations/0/events/1",
+      "index": 1
+    }
+  ],
   "warnings": []
 }

--- a/validate/testdata/goldens/invalid_event.json
+++ b/validate/testdata/goldens/invalid_event.json
@@ -3,11 +3,11 @@
   "schemaVersion": "2.1.1",
   "errors": [
     {
-      "id": "schema-validation-error",
+      "id": "schema-invalid-type",
       "module": "invalid-event.js",
       "declaration": "class InvalidEvent",
       "property": "event[0]",
-      "message": "missing properties: 'name'",
+      "message": "missing properties: 'name', 'type'",
       "location": "/modules/0/declarations/0/events/0"
     }
   ],


### PR DESCRIPTION
Fixes #207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Events now include explicit type information in generated documentation, defaulting to "Event" type when not specified.

* **Tests**
  * Added test coverage for event type validation scenarios, including cases where type information is missing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->