### PR TITLE
fix(serve): complete config hot reload by watching cem.yaml

### DIFF
--- a/serve/server.go
+++ b/serve/server.go
@@ -277,6 +277,15 @@ func (s *Server) Start() error {
 			return fmt.Errorf("failed to watch directory: %w", err)
 		}
 
+		// Explicitly watch config files (cem.yaml, tsconfig.json) that affect path resolution
+		// These bypass ignore patterns to ensure config hot-reload always works
+		if len(s.pathResolverSourceFiles) > 0 {
+			if err := fw.WatchPaths(s.pathResolverSourceFiles); err != nil {
+				s.logger.Warning("Failed to watch some config files: %v", err)
+				// Continue anyway - main watch is set up
+			}
+		}
+
 		s.watcher = fw
 
 		// Start file change handler

--- a/serve/types.go
+++ b/serve/types.go
@@ -106,6 +106,7 @@ type WebSocketManager interface {
 // FileWatcher watches files for changes
 type FileWatcher interface {
 	Watch(path string) error
+	WatchPaths(paths []string) error // Watch specific file paths (for config files)
 	Events() <-chan FileEvent
 	Close() error
 	SetIgnorePatterns(watchDir string, patterns []string)


### PR DESCRIPTION
## Summary

Fixes #222

- Add `WatchPaths` method to `FileWatcher` interface for explicit config file watching
- Implement explicit path watching that bypasses ignore patterns
- Call `WatchPaths` with `pathResolverSourceFiles` after file watcher initialization
- Add e2e test verifying automatic config hot-reload works

## Test plan

- [x] Unit tests pass (`make test-unit`)
- [x] E2E tests pass (`make test-e2e` + serve e2e tests)
- [x] New test `TestFileWatcher_ConfigFileHotReload` verifies:
  - Config file changes trigger automatic path resolver rebuild
  - Reload message with `url-rewrites-changed` reason is broadcast
  - URL rewrites are actually updated

Assisted-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration files now support automatic hot reload. When configuration changes are detected during development, the system automatically rebuilds and triggers reload notifications, providing seamless real-time updates without requiring manual server restarts.

* **Tests**
  * Added comprehensive end-to-end test verifying configuration file hot reload behavior, including automatic rebuilds and proper WebSocket reload event notifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->