### PR TITLE
fix: resolve SA5011 staticcheck warnings in tests

### DIFF
--- a/generate/session_test.go
+++ b/generate/session_test.go
@@ -319,16 +319,14 @@ func TestInMemoryManifest_Performance(t *testing.T) {
 	copy := gs.InMemoryManifest()
 	if copy == nil {
 		t.Fatal("InMemoryManifest should return a copy of the manifest")
-	}
-
-	// Verify it's a different instance (thread-safe at the package level)
-	if copy == original {
-		t.Error("InMemoryManifest should return a different instance")
-	}
-
-	// Verify content is preserved
-	if copy.SchemaVersion != original.SchemaVersion {
-		t.Errorf("Content mismatch after copy: got %s, want %s", copy.SchemaVersion, original.SchemaVersion)
+	} else {
+		if copy == original {
+			t.Error("InMemoryManifest should return a different instance")
+		}
+		// Verify content is preserved
+		if copy.SchemaVersion != original.SchemaVersion {
+			t.Errorf("Content mismatch after copy: got %s, want %s", copy.SchemaVersion, original.SchemaVersion)
+		}
 	}
 }
 
@@ -360,23 +358,20 @@ func TestInMemoryManifestDeep_ThreadSafety(t *testing.T) {
 	copy := gs.InMemoryManifestDeep()
 	if copy == nil {
 		t.Fatal("InMemoryManifestDeep should return a copy of the manifest")
-	}
-
-	// Verify it's a different instance (thread-safe)
-	if copy == original {
-		t.Error("InMemoryManifestDeep should return a different instance for thread safety")
-	}
-
-	// Verify content is preserved
-	if copy.SchemaVersion != original.SchemaVersion {
-		t.Errorf("Content mismatch after deep copy: got %s, want %s", copy.SchemaVersion, original.SchemaVersion)
-	}
-
-	// Test that modifying the deep copy doesn't affect the original
-	if len(copy.Modules) > 0 {
-		copy.Modules[0].Summary = "Modified summary"
-		if original.Modules[0].Summary == "Modified summary" {
-			t.Error("Modifying deep copy should not affect original (not properly deep copied)")
+	} else {
+		if copy == original {
+			t.Error("InMemoryManifestDeep should return a different instance for thread safety")
+		}
+		// Verify content is preserved
+		if copy.SchemaVersion != original.SchemaVersion {
+			t.Errorf("Content mismatch after deep copy: got %s, want %s", copy.SchemaVersion, original.SchemaVersion)
+		}
+		// Test that modifying the deep copy doesn't affect the original
+		if len(copy.Modules) > 0 {
+			copy.Modules[0].Summary = "Modified summary"
+			if original.Modules[0].Summary == "Modified summary" {
+				t.Error("Modifying deep copy should not affect original (not properly deep copied)")
+			}
 		}
 	}
 }
@@ -404,9 +399,7 @@ func TestModuleIndex_Performance(t *testing.T) {
 	module := gs.ModuleByPath("test/module2.js")
 	if module == nil {
 		t.Fatal("ModuleByPath should find existing module")
-	}
-
-	if module.Path != "test/module2.js" {
+	} else if module.Path != "test/module2.js" {
 		t.Errorf("Wrong module returned: got %s, want test/module2.js", module.Path)
 	}
 

--- a/lsp/ephemeral/registry_test.go
+++ b/lsp/ephemeral/registry_test.go
@@ -64,8 +64,7 @@ func TestUpdate(t *testing.T) {
 	decl := r.FindCustomElementDeclaration("test-el")
 	if decl == nil {
 		t.Fatal("expected to find test-el declaration after Update")
-	}
-	if decl.TagName != "test-el" {
+	} else if decl.TagName != "test-el" {
 		t.Errorf("expected tag name 'test-el', got %q", decl.TagName)
 	}
 	if decl.Summary != "A test element" {

--- a/lsp/ephemeral_integration_test.go
+++ b/lsp/ephemeral_integration_test.go
@@ -115,8 +115,7 @@ func testSynthesis(t *testing.T, fixture *testutil.LSPFixture) {
 	decl := server.FindCustomElementDeclaration("test-greeting")
 	if decl == nil {
 		t.Fatal("Expected FindCustomElementDeclaration to return non-nil")
-	}
-	if decl.Summary == "" && decl.Description == "" {
+	} else if decl.Summary == "" && decl.Description == "" {
 		t.Error("Expected declaration to have summary or description from JSDoc")
 	}
 
@@ -180,8 +179,7 @@ func testSkipWhenInMain(t *testing.T, fixture *testutil.LSPFixture) {
 	decl := server.FindCustomElementDeclaration("test-button")
 	if decl == nil {
 		t.Fatal("Expected to find declaration")
-	}
-	if decl.Summary != "From main registry" {
+	} else if decl.Summary != "From main registry" {
 		t.Errorf("Expected main registry data ('From main registry'), got %q — ephemeral data overwrote main registry", decl.Summary)
 	}
 }

--- a/lsp/incremental_test.go
+++ b/lsp/incremental_test.go
@@ -129,8 +129,7 @@ func TestIncrementalParser_ParseStrategies(t *testing.T) {
 			parser := NewIncrementalParser(tt.strategy)
 			if parser == nil {
 				t.Fatal("Failed to create incremental parser")
-			}
-			if parser.strategy != tt.strategy {
+			} else if parser.strategy != tt.strategy {
 				t.Errorf("Expected strategy %v, got %v", tt.strategy, parser.strategy)
 			}
 		})

--- a/lsp/methods/textDocument/codeAction/missingImportCodeActions_test.go
+++ b/lsp/methods/textDocument/codeAction/missingImportCodeActions_test.go
@@ -121,14 +121,10 @@ func TestCreateMissingImportAction(t *testing.T) {
 				return
 			}
 
-			// Verify action was created
+			// Verify action was created and properties
 			if action == nil {
 				t.Fatal("Expected action to be created, but got nil")
-			}
-
-			// Verify action properties
-			expectedTitle := "Add import for '" + config.TagName + "'"
-			if action.Title != expectedTitle {
+			} else if expectedTitle := "Add import for '" + config.TagName + "'"; action.Title != expectedTitle {
 				t.Errorf("Expected title '%s', got '%s'", expectedTitle, action.Title)
 			}
 

--- a/lsp/methods/textDocument/hover/hover_multiline_all_attrs_test.go
+++ b/lsp/methods/textDocument/hover/hover_multiline_all_attrs_test.go
@@ -96,10 +96,6 @@ func TestHover_MultilineAllAttributes(t *testing.T) {
 					t.Fatalf("Hover failed: %v", err)
 				}
 
-				if result == nil {
-					t.Fatal("Expected hover result, got nil")
-				}
-
 				// Structured comparison
 				actualContents, ok := result.Contents.(protocol.MarkupContent)
 				if !ok {

--- a/lsp/methods/textDocument/hover/hover_nested_test.go
+++ b/lsp/methods/textDocument/hover/hover_nested_test.go
@@ -89,10 +89,6 @@ func TestHover_NestedElements(t *testing.T) {
 					t.Fatalf("Hover failed: %v", err)
 				}
 
-				if result == nil {
-					t.Fatal("Expected hover result, got nil")
-				}
-
 				actualContents, ok := result.Contents.(protocol.MarkupContent)
 				if !ok {
 					t.Fatalf("Expected Contents to be MarkupContent, got %T", result.Contents)

--- a/manifest/inheritance_integration_test.go
+++ b/manifest/inheritance_integration_test.go
@@ -51,8 +51,7 @@ func TestInheritance_SimpleMixin(t *testing.T) {
 
 	if disabledAttr == nil {
 		t.Fatal("disabled attribute not found in flattened attributes")
-	}
-	if disabledAttr.InheritedFrom == nil {
+	} else if disabledAttr.InheritedFrom == nil {
 		t.Error("disabled attribute should have InheritedFrom set")
 	} else if disabledAttr.InheritedFrom.Name != "DisabledMixin" {
 		t.Errorf("disabled.InheritedFrom.Name = %s, want DisabledMixin", disabledAttr.InheritedFrom.Name)
@@ -60,8 +59,7 @@ func TestInheritance_SimpleMixin(t *testing.T) {
 
 	if labelAttr == nil {
 		t.Fatal("label attribute not found in flattened attributes")
-	}
-	if labelAttr.InheritedFrom != nil {
+	} else if labelAttr.InheritedFrom != nil {
 		t.Error("label attribute should not have InheritedFrom set (class's own attribute)")
 	}
 }
@@ -94,8 +92,7 @@ func TestInheritance_Superclass(t *testing.T) {
 
 	if baseAttr == nil {
 		t.Fatal("base-prop attribute not found in flattened attributes")
-	}
-	if baseAttr.InheritedFrom == nil {
+	} else if baseAttr.InheritedFrom == nil {
 		t.Error("base-prop attribute should have InheritedFrom set")
 	} else if baseAttr.InheritedFrom.Name != "BaseElement" {
 		t.Errorf("base-prop.InheritedFrom.Name = %s, want BaseElement", baseAttr.InheritedFrom.Name)
@@ -103,8 +100,7 @@ func TestInheritance_Superclass(t *testing.T) {
 
 	if childAttr == nil {
 		t.Fatal("child-prop attribute not found in flattened attributes")
-	}
-	if childAttr.InheritedFrom != nil {
+	} else if childAttr.InheritedFrom != nil {
 		t.Error("child-prop attribute should not have InheritedFrom set (class's own attribute)")
 	}
 }

--- a/manifest/package_test.go
+++ b/manifest/package_test.go
@@ -422,11 +422,6 @@ func TestCloneBackreferences(t *testing.T) {
 	// Clone the package
 	cloned := pkg.Clone()
 
-	// Verify the cloned package is not nil
-	if cloned == nil {
-		t.Fatal("Cloned package should not be nil")
-	}
-
 	// Verify we have modules
 	if len(cloned.Modules) != 1 {
 		t.Fatalf("Expected 1 module, got %d", len(cloned.Modules))

--- a/mcp/context_race_test.go
+++ b/mcp/context_race_test.go
@@ -189,16 +189,10 @@ func TestMCPContext_SnapshotConsistency(t *testing.T) {
 			t.Fatalf("Failed to take snapshot: %v", err)
 		}
 
-		if snapshot == nil {
-			t.Fatal("Snapshot is nil")
-		}
-
+		// Verify snapshot contains expected elements
 		if snapshot.elements == nil {
 			t.Fatal("Snapshot elements map is nil")
-		}
-
-		// Verify snapshot contains expected elements
-		if len(snapshot.elements) == 0 {
+		} else if len(snapshot.elements) == 0 {
 			t.Error("Snapshot contains no elements")
 		}
 

--- a/serve/middleware/importmap/importmap_exports_test.go
+++ b/serve/middleware/importmap/importmap_exports_test.go
@@ -47,10 +47,6 @@ func TestImportMap_SinglePackageWithExportsMap(t *testing.T) {
 		t.Fatalf("GenerateImportMap failed: %v", err)
 	}
 
-	if importMap == nil {
-		t.Fatal("Expected import map, got nil")
-	}
-
 	// Should have main export
 	if mainPath, ok := importMap.Imports["my-components"]; !ok {
 		t.Error("Expected 'my-components' in import map")
@@ -121,10 +117,6 @@ func TestImportMap_WorkspacePackageWithExportsMap(t *testing.T) {
 	importMap, err := Generate(tmpDir, nil)
 	if err != nil {
 		t.Fatalf("GenerateImportMap failed: %v", err)
-	}
-
-	if importMap == nil {
-		t.Fatal("Expected import map, got nil")
 	}
 
 	// Should have main export
@@ -206,10 +198,6 @@ func TestImportMap_NodeModuleDependencyWithExportsMap(t *testing.T) {
 		t.Fatalf("GenerateImportMap failed: %v", err)
 	}
 
-	if importMap == nil {
-		t.Fatal("Expected import map, got nil")
-	}
-
 	// Should have main export
 	if mainPath, ok := importMap.Imports["some-lib"]; !ok {
 		t.Error("Expected 'some-lib' in import map")
@@ -288,10 +276,6 @@ func TestImportMap_ConditionalExportsWithImportCondition(t *testing.T) {
 		t.Fatalf("GenerateImportMap failed: %v", err)
 	}
 
-	if importMap == nil {
-		t.Fatal("Expected import map, got nil")
-	}
-
 	// Should use "import" condition, not "require"
 	if mainPath, ok := importMap.Imports["dual-package"]; !ok {
 		t.Error("Expected 'dual-package' in import map")
@@ -345,10 +329,6 @@ func TestImportMap_WildcardExports(t *testing.T) {
 		t.Fatalf("GenerateImportMap failed: %v", err)
 	}
 
-	if importMap == nil {
-		t.Fatal("Expected import map, got nil")
-	}
-
 	// Should have main export
 	if mainPath, ok := importMap.Imports["wildcard-lib"]; !ok {
 		t.Error("Expected 'wildcard-lib' in import map")
@@ -386,10 +366,6 @@ func TestImportMap_WildcardWithPrefix(t *testing.T) {
 	importMap, err := Generate(tmpDir, nil)
 	if err != nil {
 		t.Fatalf("GenerateImportMap failed: %v", err)
-	}
-
-	if importMap == nil {
-		t.Fatal("Expected import map, got nil")
 	}
 
 	// Main export
@@ -447,10 +423,6 @@ func TestImportMap_ConditionOnlyExports(t *testing.T) {
 		t.Fatalf("GenerateImportMap failed: %v", err)
 	}
 
-	if importMap == nil {
-		t.Fatal("Expected import map, got nil")
-	}
-
 	// Should map the package name to the import condition, NOT "condition-only/import"
 	if mainPath, ok := importMap.Imports["condition-only"]; !ok {
 		t.Error("Expected 'condition-only' in import map")
@@ -501,10 +473,6 @@ func TestImportMap_SubpathWildcardPatterns(t *testing.T) {
 	importMap, err := Generate(tmpDir, nil)
 	if err != nil {
 		t.Fatalf("GenerateImportMap failed: %v", err)
-	}
-
-	if importMap == nil {
-		t.Fatal("Expected import map, got nil")
 	}
 
 	// Should have main export
@@ -584,10 +552,6 @@ func TestImportMap_MultipleWorkspacesWithExports(t *testing.T) {
 	importMap, err := Generate(tmpDir, nil)
 	if err != nil {
 		t.Fatalf("GenerateImportMap failed: %v", err)
-	}
-
-	if importMap == nil {
-		t.Fatal("Expected import map, got nil")
 	}
 
 	// Check first workspace package

--- a/serve/middleware/routes/templates_test.go
+++ b/serve/middleware/routes/templates_test.go
@@ -57,8 +57,7 @@ func TestDeclarationAsKind(t *testing.T) {
 		result := declarationAsKind[*M.CustomElementDeclaration](ce)
 		if result == nil {
 			t.Fatal("Expected non-nil result for matching type")
-		}
-		if result.TagName != "my-element" {
+		} else if result.TagName != "my-element" {
 			t.Errorf("Expected TagName='my-element', got %q", result.TagName)
 		}
 	})
@@ -71,8 +70,7 @@ func TestDeclarationAsKind(t *testing.T) {
 		result := declarationAsKind[*M.FunctionDeclaration](fn)
 		if result == nil {
 			t.Fatal("Expected non-nil result for matching type")
-		}
-		if result.Name() != "myFunction" {
+		} else if result.Name() != "myFunction" {
 			t.Errorf("Expected Name='myFunction', got %q", result.Name())
 		}
 	})
@@ -87,8 +85,7 @@ func TestDeclarationAsKind(t *testing.T) {
 		result := declarationAsKind[*M.VariableDeclaration](v)
 		if result == nil {
 			t.Fatal("Expected non-nil result for matching type")
-		}
-		if result.Name() != "myVar" {
+		} else if result.Name() != "myVar" {
 			t.Errorf("Expected Name='myVar', got %q", result.Name())
 		}
 	})
@@ -101,8 +98,7 @@ func TestDeclarationAsKind(t *testing.T) {
 		result := declarationAsKind[*M.MixinDeclaration](mixin)
 		if result == nil {
 			t.Fatal("Expected non-nil result for matching type")
-		}
-		if result.Name() != "MyMixin" {
+		} else if result.Name() != "MyMixin" {
 			t.Errorf("Expected Name='MyMixin', got %q", result.Name())
 		}
 	})


### PR DESCRIPTION
Restructure nil-guard-then-dereference patterns that staticcheck flags as possible nil pointer dereferences. Uses else-if chains or removes redundant nil checks where the error path already guards.

Assisted-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>