### PR TITLE
feat(lsp): validate conditional requirements from RFC 2119 descriptions

### DIFF
--- a/internal/requirements/evaluate.go
+++ b/internal/requirements/evaluate.go
@@ -1,0 +1,111 @@
+/*
+Copyright © 2025 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package requirements
+
+import "fmt"
+
+// Evaluate checks a set of rules against the element facts and returns violations.
+func Evaluate(rules []Rule, facts ElementFacts) []Violation {
+	var violations []Violation
+
+	for _, rule := range rules {
+		// For unconditional rules from an attribute's description,
+		// implicitly require the source attribute to be present.
+		if rule.Condition.Type == ConditionAlways && rule.SourceAttr != "" {
+			if !facts.HasAttr[rule.SourceAttr] {
+				continue
+			}
+		}
+		if !conditionMet(rule.Condition, facts) {
+			continue
+		}
+		if !requirementSatisfied(rule.Requirement, facts) {
+			violations = append(violations, Violation{
+				Rule:    rule,
+				Message: violationMessage(rule),
+			})
+		}
+	}
+
+	return violations
+}
+
+func conditionMet(cond Condition, facts ElementFacts) bool {
+	switch cond.Type {
+	case ConditionAlways:
+		return true
+	case ConditionAttrPresent:
+		return facts.HasAttr[cond.AttrName]
+	case ConditionAttrValue:
+		if !facts.HasAttr[cond.AttrName] {
+			return false
+		}
+		return facts.Attributes[cond.AttrName] == cond.AttrValue
+	case ConditionAttrNotValue:
+		if !facts.HasAttr[cond.AttrName] {
+			return false
+		}
+		return facts.Attributes[cond.AttrName] != cond.AttrValue
+	default:
+		return false
+	}
+}
+
+func requirementSatisfied(req Requirement, facts ElementFacts) bool {
+	switch req.Type {
+	case RequireAttrPresent:
+		return facts.HasAttr[req.AttrName]
+	case RequireAttrAbsent:
+		return !facts.HasAttr[req.AttrName]
+	default:
+		return true
+	}
+}
+
+func violationMessage(rule Rule) string {
+	switch rule.Requirement.Type {
+	case RequireAttrPresent:
+		switch rule.Condition.Type {
+		case ConditionAlways:
+			return fmt.Sprintf("Missing required attribute '%s'. %s", rule.Requirement.AttrName, rule.Source)
+		case ConditionAttrPresent:
+			return fmt.Sprintf("Attribute '%s' requires '%s' to also be set. %s",
+				rule.Condition.AttrName, rule.Requirement.AttrName, rule.Source)
+		case ConditionAttrValue:
+			return fmt.Sprintf("When '%s' is '%s', attribute '%s' is required. %s",
+				rule.Condition.AttrName, rule.Condition.AttrValue, rule.Requirement.AttrName, rule.Source)
+		case ConditionAttrNotValue:
+			return fmt.Sprintf("When '%s' is not '%s', attribute '%s' is required. %s",
+				rule.Condition.AttrName, rule.Condition.AttrValue, rule.Requirement.AttrName, rule.Source)
+		}
+	case RequireAttrAbsent:
+		switch rule.Condition.Type {
+		case ConditionAlways:
+			return fmt.Sprintf("Attribute '%s' must not be used. %s", rule.Requirement.AttrName, rule.Source)
+		case ConditionAttrPresent:
+			return fmt.Sprintf("Attribute '%s' must not be used when '%s' is set. %s",
+				rule.Requirement.AttrName, rule.Condition.AttrName, rule.Source)
+		case ConditionAttrValue:
+			return fmt.Sprintf("Attribute '%s' must not be used when '%s' is '%s'. %s",
+				rule.Requirement.AttrName, rule.Condition.AttrName, rule.Condition.AttrValue, rule.Source)
+		case ConditionAttrNotValue:
+			return fmt.Sprintf("Attribute '%s' must not be used when '%s' is not '%s'. %s",
+				rule.Requirement.AttrName, rule.Condition.AttrName, rule.Condition.AttrValue, rule.Source)
+		}
+	}
+	return rule.Source
+}

--- a/internal/requirements/evaluate_test.go
+++ b/internal/requirements/evaluate_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright © 2025 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package requirements
+
+import (
+	"testing"
+)
+
+func TestEvaluate_ConditionAttrValue(t *testing.T) {
+	rules := []Rule{{
+		Condition:   Condition{Type: ConditionAttrValue, AttrName: "variant", AttrValue: "icon"},
+		Requirement: Requirement{Type: RequireAttrPresent, AttrName: "accessible-label"},
+		Source:      "If you set `variant` to 'icon', you MUST also set `accessible-label`.",
+		SourceAttr:  "variant",
+	}}
+
+	t.Run("violation when condition met and requirement missing", func(t *testing.T) {
+		facts := ElementFacts{
+			Attributes: map[string]string{"variant": "icon"},
+			HasAttr:    map[string]bool{"variant": true},
+		}
+		violations := Evaluate(rules, facts)
+		if len(violations) != 1 {
+			t.Fatalf("expected 1 violation, got %d", len(violations))
+		}
+		if violations[0].Message == "" {
+			t.Error("violation message should not be empty")
+		}
+	})
+
+	t.Run("no violation when condition met and requirement satisfied", func(t *testing.T) {
+		facts := ElementFacts{
+			Attributes: map[string]string{"variant": "icon", "accessible-label": "Dog icon"},
+			HasAttr:    map[string]bool{"variant": true, "accessible-label": true},
+		}
+		violations := Evaluate(rules, facts)
+		if len(violations) != 0 {
+			t.Fatalf("expected 0 violations, got %d: %+v", len(violations), violations)
+		}
+	})
+
+	t.Run("no violation when condition not met", func(t *testing.T) {
+		facts := ElementFacts{
+			Attributes: map[string]string{"variant": "primary"},
+			HasAttr:    map[string]bool{"variant": true},
+		}
+		violations := Evaluate(rules, facts)
+		if len(violations) != 0 {
+			t.Fatalf("expected 0 violations, got %d", len(violations))
+		}
+	})
+
+	t.Run("no violation when condition attr absent", func(t *testing.T) {
+		facts := ElementFacts{
+			Attributes: map[string]string{},
+			HasAttr:    map[string]bool{},
+		}
+		violations := Evaluate(rules, facts)
+		if len(violations) != 0 {
+			t.Fatalf("expected 0 violations, got %d", len(violations))
+		}
+	})
+}
+
+func TestEvaluate_ConditionAttrPresent(t *testing.T) {
+	rules := []Rule{{
+		Condition:   Condition{Type: ConditionAttrPresent, AttrName: "loading"},
+		Requirement: Requirement{Type: RequireAttrPresent, AttrName: "accessible-label"},
+		Source:      "When `loading` is set, you MUST provide `accessible-label`.",
+		SourceAttr:  "loading",
+	}}
+
+	t.Run("violation when attr present but requirement missing", func(t *testing.T) {
+		facts := ElementFacts{
+			Attributes: map[string]string{"loading": ""},
+			HasAttr:    map[string]bool{"loading": true},
+		}
+		violations := Evaluate(rules, facts)
+		if len(violations) != 1 {
+			t.Fatalf("expected 1 violation, got %d", len(violations))
+		}
+	})
+
+	t.Run("no violation when attr absent", func(t *testing.T) {
+		facts := ElementFacts{
+			Attributes: map[string]string{},
+			HasAttr:    map[string]bool{},
+		}
+		violations := Evaluate(rules, facts)
+		if len(violations) != 0 {
+			t.Fatalf("expected 0 violations, got %d", len(violations))
+		}
+	})
+}
+
+func TestEvaluate_RequireAttrAbsent(t *testing.T) {
+	rules := []Rule{{
+		Condition:   Condition{Type: ConditionAttrValue, AttrName: "variant", AttrValue: "compact"},
+		Requirement: Requirement{Type: RequireAttrAbsent, AttrName: "icon"},
+		Source:      "If `variant` is 'compact', you MUST NOT use `icon`.",
+		SourceAttr:  "variant",
+	}}
+
+	t.Run("violation when forbidden attr present", func(t *testing.T) {
+		facts := ElementFacts{
+			Attributes: map[string]string{"variant": "compact", "icon": "star"},
+			HasAttr:    map[string]bool{"variant": true, "icon": true},
+		}
+		violations := Evaluate(rules, facts)
+		if len(violations) != 1 {
+			t.Fatalf("expected 1 violation, got %d", len(violations))
+		}
+	})
+
+	t.Run("no violation when forbidden attr absent", func(t *testing.T) {
+		facts := ElementFacts{
+			Attributes: map[string]string{"variant": "compact"},
+			HasAttr:    map[string]bool{"variant": true},
+		}
+		violations := Evaluate(rules, facts)
+		if len(violations) != 0 {
+			t.Fatalf("expected 0 violations, got %d", len(violations))
+		}
+	})
+}
+
+func TestEvaluate_UnconditionalRequirement(t *testing.T) {
+	rules := []Rule{{
+		Condition:   Condition{Type: ConditionAlways},
+		Requirement: Requirement{Type: RequireAttrPresent, AttrName: "href"},
+		Source:      "MUST be used in conjunction with `href`.",
+		SourceAttr:  "download",
+	}}
+
+	t.Run("violation when requirement missing", func(t *testing.T) {
+		facts := ElementFacts{
+			Attributes: map[string]string{"download": ""},
+			HasAttr:    map[string]bool{"download": true},
+		}
+		violations := Evaluate(rules, facts)
+		if len(violations) != 1 {
+			t.Fatalf("expected 1 violation, got %d", len(violations))
+		}
+	})
+
+	t.Run("no violation when requirement satisfied", func(t *testing.T) {
+		facts := ElementFacts{
+			Attributes: map[string]string{"download": "", "href": "/file.pdf"},
+			HasAttr:    map[string]bool{"download": true, "href": true},
+		}
+		violations := Evaluate(rules, facts)
+		if len(violations) != 0 {
+			t.Fatalf("expected 0 violations, got %d", len(violations))
+		}
+	})
+
+	t.Run("no violation when source attr not present", func(t *testing.T) {
+		facts := ElementFacts{
+			Attributes: map[string]string{},
+			HasAttr:    map[string]bool{},
+		}
+		violations := Evaluate(rules, facts)
+		if len(violations) != 0 {
+			t.Fatalf("expected 0 violations, got %d", len(violations))
+		}
+	})
+}

--- a/internal/requirements/extract.go
+++ b/internal/requirements/extract.go
@@ -1,0 +1,433 @@
+/*
+Copyright © 2025 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package requirements
+
+import (
+	"regexp"
+	"strings"
+
+	M "bennypowers.dev/cem/manifest"
+)
+
+// Signal types extracted from a sentence
+
+type attrRef struct {
+	name  string
+	start int // byte position in sentence
+	end   int
+}
+
+type quotedValue struct {
+	value string
+	start int
+	end   int
+}
+
+type mustKeywordSignal struct {
+	negated bool // MUST NOT / SHALL NOT
+	start   int
+	end     int
+}
+
+type conditionalSignal struct {
+	start int
+	end   int
+}
+
+type negationSignal struct {
+	start int
+	end   int
+}
+
+type signals struct {
+	attrRefs     []attrRef
+	quotedValues []quotedValue
+	mustKeyword  *mustKeywordSignal
+	conditionals []conditionalSignal
+	negations    []negationSignal
+}
+
+// Compiled regexes for signal extraction
+
+var (
+	// Backtick-quoted names: `variant`, `accessible-label`
+	attrRefRegex = regexp.MustCompile("`([a-zA-Z][a-zA-Z0-9-]*)`")
+
+	// Single or double quoted values: 'icon', "icon"
+	quotedValueRegex = regexp.MustCompile(`'([^']+)'|"([^"]+)"`)
+
+	// MUST-level RFC 2119 keywords (case-insensitive)
+	mustKeywordRegex = regexp.MustCompile(`(?i)\b(MUST\s+NOT|SHALL\s+NOT|MUST|SHALL|REQUIRED)\b`)
+
+	// Conditional markers
+	conditionalRegex = regexp.MustCompile(`(?i)\b(if|when|whenever|where)\b`)
+
+	// Negation words (excluding "NOT" after MUST/SHALL, which is handled separately)
+	negationRegex = regexp.MustCompile(`(?i)\b(not|never|without)\b`)
+
+	// Sentence-ending punctuation
+	sentenceEndRegex = regexp.MustCompile(`[.!?](?:\s+|$)`)
+)
+
+// extractSignals finds all meaningful signals in a sentence.
+func extractSignals(sentence string) signals {
+	var s signals
+
+	// Extract attr refs
+	for _, match := range attrRefRegex.FindAllStringSubmatchIndex(sentence, -1) {
+		s.attrRefs = append(s.attrRefs, attrRef{
+			name:  sentence[match[2]:match[3]],
+			start: match[0],
+			end:   match[1],
+		})
+	}
+
+	// Extract quoted values
+	for _, match := range quotedValueRegex.FindAllStringSubmatchIndex(sentence, -1) {
+		value := ""
+		if match[2] >= 0 {
+			value = sentence[match[2]:match[3]] // single-quoted
+		} else if match[4] >= 0 {
+			value = sentence[match[4]:match[5]] // double-quoted
+		}
+		// Skip values that look like they're inside backticks (attr refs)
+		if isInsideBackticks(sentence, match[0]) {
+			continue
+		}
+		s.quotedValues = append(s.quotedValues, quotedValue{
+			value: value,
+			start: match[0],
+			end:   match[1],
+		})
+	}
+
+	// Extract MUST keyword
+	if match := mustKeywordRegex.FindStringSubmatchIndex(sentence); match != nil {
+		keyword := strings.ToUpper(strings.TrimSpace(sentence[match[2]:match[3]]))
+		negated := strings.Contains(keyword, "NOT")
+		s.mustKeyword = &mustKeywordSignal{
+			negated: negated,
+			start:   match[0],
+			end:     match[1],
+		}
+	}
+
+	// Extract conditionals
+	for _, match := range conditionalRegex.FindAllStringSubmatchIndex(sentence, -1) {
+		s.conditionals = append(s.conditionals, conditionalSignal{
+			start: match[0],
+			end:   match[1],
+		})
+	}
+
+	// Extract negations (but not ones that are part of MUST NOT / SHALL NOT)
+	for _, match := range negationRegex.FindAllStringSubmatchIndex(sentence, -1) {
+		// Skip if this "not" is part of the MUST NOT keyword
+		if s.mustKeyword != nil && match[0] >= s.mustKeyword.start && match[1] <= s.mustKeyword.end {
+			continue
+		}
+		s.negations = append(s.negations, negationSignal{
+			start: match[0],
+			end:   match[1],
+		})
+	}
+
+	return s
+}
+
+func isInsideBackticks(s string, pos int) bool {
+	// Check if position is between a pair of backticks
+	backticksBefore := strings.Count(s[:pos], "`")
+	return backticksBefore%2 == 1
+}
+
+// splitSentences splits text into sentences, preserving the ending punctuation.
+func splitSentences(text string) []string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+
+	var sentences []string
+	indices := sentenceEndRegex.FindAllStringIndex(text, -1)
+
+	if len(indices) == 0 {
+		return []string{text}
+	}
+
+	start := 0
+	for _, idx := range indices {
+		end := idx[1]
+		sentence := strings.TrimSpace(text[start:end])
+		if sentence != "" {
+			sentences = append(sentences, sentence)
+		}
+		start = end
+	}
+
+	if start < len(text) {
+		remaining := strings.TrimSpace(text[start:])
+		if remaining != "" {
+			sentences = append(sentences, remaining)
+		}
+	}
+
+	return sentences
+}
+
+// ExtractRules extracts conditional requirement rules from a description string.
+func ExtractRules(description, sourceAttr string) []Rule {
+	var rules []Rule
+
+	sentences := splitSentences(description)
+	for _, sentence := range sentences {
+		rules = append(rules, inferRules(sentence, sourceAttr)...)
+	}
+
+	return rules
+}
+
+// inferRules uses signal extraction + positional inference to find rules.
+func inferRules(sentence, sourceAttr string) []Rule {
+	s := extractSignals(sentence)
+
+	// Must have a MUST-level keyword
+	if s.mustKeyword == nil {
+		return nil
+	}
+
+	// Must have at least one backtick-quoted attr ref
+	if len(s.attrRefs) == 0 {
+		return nil
+	}
+
+	// Determine if there's a conditional clause
+	hasConditional := len(s.conditionals) > 0
+
+	// Find condition and requirement via positional inference
+	condAttr, condValues, condNegated := findCondition(s, hasConditional)
+	reqAttr := findRequirement(s, condAttr)
+
+	// If we couldn't determine a requirement attr, nothing to do
+	if reqAttr == "" {
+		return nil
+	}
+
+	// Don't create rules where the requirement is the same as the source
+	if reqAttr == sourceAttr {
+		return nil
+	}
+
+	// Determine requirement type
+	reqType := RequireAttrPresent
+	if s.mustKeyword.negated {
+		reqType = RequireAttrAbsent
+	}
+
+	// Build condition
+	if condAttr == "" {
+		// Unconditional: "You MUST set `attr`"
+		return []Rule{{
+			Condition:   Condition{Type: ConditionAlways},
+			Requirement: Requirement{Type: reqType, AttrName: reqAttr},
+			Source:      sentence,
+			SourceAttr:  sourceAttr,
+		}}
+	}
+
+	// Multiple values: "if `attr` is 'a' or 'b'" -> one rule per value
+	if len(condValues) > 1 {
+		var rules []Rule
+		for _, v := range condValues {
+			condType := ConditionAttrValue
+			if condNegated {
+				condType = ConditionAttrNotValue
+			}
+			rules = append(rules, Rule{
+				Condition:   Condition{Type: condType, AttrName: condAttr, AttrValue: v},
+				Requirement: Requirement{Type: reqType, AttrName: reqAttr},
+				Source:      sentence,
+				SourceAttr:  sourceAttr,
+			})
+		}
+		return rules
+	}
+
+	// Single value condition
+	if len(condValues) == 1 {
+		condType := ConditionAttrValue
+		if condNegated {
+			condType = ConditionAttrNotValue
+		}
+		return []Rule{{
+			Condition:   Condition{Type: condType, AttrName: condAttr, AttrValue: condValues[0]},
+			Requirement: Requirement{Type: reqType, AttrName: reqAttr},
+			Source:      sentence,
+			SourceAttr:  sourceAttr,
+		}}
+	}
+
+	// Presence condition (no value)
+	return []Rule{{
+		Condition:   Condition{Type: ConditionAttrPresent, AttrName: condAttr},
+		Requirement: Requirement{Type: reqType, AttrName: reqAttr},
+		Source:      sentence,
+		SourceAttr:  sourceAttr,
+	}}
+}
+
+// findCondition determines the condition attribute, its values, and whether it's negated.
+func findCondition(s signals, hasConditional bool) (string, []string, bool) {
+	if !hasConditional {
+		return "", nil, false
+	}
+
+	condPos := s.conditionals[0].start
+
+	// The condition attr is the one closest to the conditional marker
+	condRef := nearestAttrRef(s.attrRefs, condPos)
+	if condRef == nil {
+		return "", nil, false
+	}
+
+	// Find quoted values near the condition attr
+	var values []string
+	for _, qv := range s.quotedValues {
+		if isNear(qv.start, condRef.start, condRef.end, 80) {
+			values = append(values, qv.value)
+		}
+	}
+
+	// Check for negation near the condition
+	negated := false
+	for _, neg := range s.negations {
+		// Negation between the condition attr and the closest quoted value,
+		// or between the conditional and the value
+		if neg.start > condRef.start-20 && neg.start < condRef.end+40 {
+			negated = true
+			break
+		}
+		if len(values) > 0 {
+			// Also check if negation is between condRef and the first value
+			for _, qv := range s.quotedValues {
+				if neg.start > condRef.end && neg.start < qv.start {
+					negated = true
+					break
+				}
+			}
+		}
+	}
+
+	// If no quoted values, check if there are presence words near the attr
+	// to distinguish "when `attr` is set" (presence) from just "when `attr`" (also presence)
+	// Both mean the same thing: attr presence condition
+
+	return condRef.name, values, negated
+}
+
+// findRequirement determines the requirement attribute.
+func findRequirement(s signals, condAttr string) string {
+	// The requirement attr is the one on the MUST side that isn't the condition
+	// Typical patterns:
+	//   "If `condAttr` is X, MUST set `reqAttr`"  -> reqAttr is after MUST
+	//   "`reqAttr` MUST be set when `condAttr`"    -> reqAttr is before MUST
+
+	candidates := make([]attrRef, 0, len(s.attrRefs))
+	for _, ref := range s.attrRefs {
+		if ref.name != condAttr {
+			candidates = append(candidates, ref)
+		}
+	}
+
+	if len(candidates) == 0 {
+		return ""
+	}
+
+	if len(candidates) == 1 {
+		return candidates[0].name
+	}
+
+	// Multiple candidates: pick the one nearest to the MUST keyword
+	best := nearestAttrRef(candidates, s.mustKeyword.start)
+	if best != nil {
+		return best.name
+	}
+
+	return candidates[0].name
+}
+
+// nearestAttrRef finds the attr ref nearest to a given position.
+func nearestAttrRef(refs []attrRef, pos int) *attrRef {
+	if len(refs) == 0 {
+		return nil
+	}
+	best := &refs[0]
+	bestDist := abs(refs[0].start - pos)
+	for i := 1; i < len(refs); i++ {
+		d := abs(refs[i].start - pos)
+		if d < bestDist {
+			bestDist = d
+			best = &refs[i]
+		}
+	}
+	return best
+}
+
+func isNear(pos, refStart, refEnd, threshold int) bool {
+	if pos >= refStart && pos <= refEnd {
+		return true
+	}
+	return abs(pos-refStart) < threshold || abs(pos-refEnd) < threshold
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+// ExtractElementRules extracts all rules from all descriptions on an element declaration.
+func ExtractElementRules(decl *M.CustomElementDeclaration) []Rule {
+	if decl == nil {
+		return nil
+	}
+
+	var rules []Rule
+
+	for _, attr := range decl.Attributes() {
+		desc := attr.Description
+		if desc == "" {
+			desc = attr.Summary
+		}
+		if desc != "" {
+			rules = append(rules, ExtractRules(desc, attr.Name)...)
+		}
+	}
+
+	for _, slot := range decl.Slots() {
+		desc := slot.Description
+		if desc == "" {
+			desc = slot.Summary
+		}
+		if desc != "" {
+			rules = append(rules, ExtractRules(desc, slot.Name)...)
+		}
+	}
+
+	return rules
+}

--- a/internal/requirements/extract_test.go
+++ b/internal/requirements/extract_test.go
@@ -1,0 +1,526 @@
+/*
+Copyright © 2025 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package requirements
+
+import (
+	"testing"
+)
+
+func TestExtractRules_ConditionThenRequirement(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		sourceAttr  string
+		wantRules   []Rule
+	}{
+		{
+			name:        "if attr is value, MUST set attr",
+			description: "The button's theme variant. If you set `variant` to 'icon', you MUST also set `accessible-label`.",
+			sourceAttr:  "variant",
+			wantRules: []Rule{{
+				Condition:   Condition{Type: ConditionAttrValue, AttrName: "variant", AttrValue: "icon"},
+				Requirement: Requirement{Type: RequireAttrPresent, AttrName: "accessible-label"},
+				SourceAttr:  "variant",
+			}},
+		},
+		{
+			name:        "when attr is set, MUST provide attr",
+			description: "Shows a loading spinner. When `loading` is set, you MUST provide `accessible-label`.",
+			sourceAttr:  "loading",
+			wantRules: []Rule{{
+				Condition:   Condition{Type: ConditionAttrPresent, AttrName: "loading"},
+				Requirement: Requirement{Type: RequireAttrPresent, AttrName: "accessible-label"},
+				SourceAttr:  "loading",
+			}},
+		},
+		{
+			name:        "if using attr, MUST set attr",
+			description: "When using `icon`, you MUST set `accessible-label`.",
+			sourceAttr:  "icon",
+			wantRules: []Rule{{
+				Condition:   Condition{Type: ConditionAttrPresent, AttrName: "icon"},
+				Requirement: Requirement{Type: RequireAttrPresent, AttrName: "accessible-label"},
+				SourceAttr:  "icon",
+			}},
+		},
+		{
+			name:        "if attr equals value, MUST NOT use attr",
+			description: "If `variant` is 'compact', you MUST NOT use `icon`.",
+			sourceAttr:  "variant",
+			wantRules: []Rule{{
+				Condition:   Condition{Type: ConditionAttrValue, AttrName: "variant", AttrValue: "compact"},
+				Requirement: Requirement{Type: RequireAttrAbsent, AttrName: "icon"},
+				SourceAttr:  "variant",
+			}},
+		},
+		{
+			name:        "double-quoted value",
+			description: `If you set ` + "`variant`" + ` to "icon", you MUST also set ` + "`accessible-label`" + `.`,
+			sourceAttr:  "variant",
+			wantRules: []Rule{{
+				Condition:   Condition{Type: ConditionAttrValue, AttrName: "variant", AttrValue: "icon"},
+				Requirement: Requirement{Type: RequireAttrPresent, AttrName: "accessible-label"},
+				SourceAttr:  "variant",
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rules := ExtractRules(tt.description, tt.sourceAttr)
+			assertRulesMatch(t, tt.wantRules, rules)
+		})
+	}
+}
+
+func TestExtractRules_RequirementThenCondition(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		sourceAttr  string
+		wantRules   []Rule
+	}{
+		{
+			name:        "MUST set attr when attr is set",
+			description: "You MUST set `accessible-label` when `loading` is set.",
+			sourceAttr:  "loading",
+			wantRules: []Rule{{
+				Condition:   Condition{Type: ConditionAttrPresent, AttrName: "loading"},
+				Requirement: Requirement{Type: RequireAttrPresent, AttrName: "accessible-label"},
+				SourceAttr:  "loading",
+			}},
+		},
+		{
+			name:        "MUST provide attr when attr is value",
+			description: "You MUST provide `accessible-label` when `variant` is 'icon'.",
+			sourceAttr:  "variant",
+			wantRules: []Rule{{
+				Condition:   Condition{Type: ConditionAttrValue, AttrName: "variant", AttrValue: "icon"},
+				Requirement: Requirement{Type: RequireAttrPresent, AttrName: "accessible-label"},
+				SourceAttr:  "variant",
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rules := ExtractRules(tt.description, tt.sourceAttr)
+			assertRulesMatch(t, tt.wantRules, rules)
+		})
+	}
+}
+
+func TestExtractRules_UnconditionalRequirement(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		sourceAttr  string
+		wantRules   []Rule
+	}{
+		{
+			name:        "MUST also set attr",
+			description: "The icon name. You MUST also set `accessible-label`.",
+			sourceAttr:  "icon",
+			wantRules: []Rule{{
+				Condition:   Condition{Type: ConditionAlways},
+				Requirement: Requirement{Type: RequireAttrPresent, AttrName: "accessible-label"},
+				SourceAttr:  "icon",
+			}},
+		},
+		{
+			name:        "MUST be used in conjunction with attr",
+			description: "MUST be used in conjunction with `href`.",
+			sourceAttr:  "download",
+			wantRules: []Rule{{
+				Condition:   Condition{Type: ConditionAlways},
+				Requirement: Requirement{Type: RequireAttrPresent, AttrName: "href"},
+				SourceAttr:  "download",
+			}},
+		},
+		{
+			name:        "MUST be used together with attr",
+			description: "MUST be used together with `href`.",
+			sourceAttr:  "download",
+			wantRules: []Rule{{
+				Condition:   Condition{Type: ConditionAlways},
+				Requirement: Requirement{Type: RequireAttrPresent, AttrName: "href"},
+				SourceAttr:  "download",
+			}},
+		},
+		{
+			name:        "REQUIRED keyword",
+			description: "`accessible-label` is REQUIRED.",
+			sourceAttr:  "accessible-label",
+			wantRules:   nil, // no rule: it's about itself, not requiring another attr
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rules := ExtractRules(tt.description, tt.sourceAttr)
+			assertRulesMatch(t, tt.wantRules, rules)
+		})
+	}
+}
+
+func TestExtractRules_NoMatch(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+	}{
+		{
+			name:        "no RFC 2119 keywords",
+			description: "The button's theme variant.",
+		},
+		{
+			name:        "SHOULD keyword ignored",
+			description: "If `variant` is 'icon', you SHOULD set `accessible-label`.",
+		},
+		{
+			name:        "MAY keyword ignored",
+			description: "You MAY set `accessible-label` when `loading` is set.",
+		},
+		{
+			name:        "no backtick-quoted attrs",
+			description: "If you set variant to icon, you MUST also set accessible-label.",
+		},
+		{
+			name:        "value constraint not conditional requirement",
+			description: "This attribute MUST be a valid URL.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rules := ExtractRules(tt.description, "test")
+			if len(rules) != 0 {
+				t.Errorf("expected no rules, got %d: %+v", len(rules), rules)
+			}
+		})
+	}
+}
+
+// Tests for the signal-based approach: phrasing variations the old regex couldn't handle
+
+func TestExtractRules_PassiveVoice(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		sourceAttr  string
+		wantRules   []Rule
+	}{
+		{
+			name:        "attr MUST be provided when condition",
+			description: "`accessible-label` MUST be provided when `variant` is 'icon'.",
+			sourceAttr:  "variant",
+			wantRules: []Rule{{
+				Condition:   Condition{Type: ConditionAttrValue, AttrName: "variant", AttrValue: "icon"},
+				Requirement: Requirement{Type: RequireAttrPresent, AttrName: "accessible-label"},
+				SourceAttr:  "variant",
+			}},
+		},
+		{
+			name:        "attr MUST be set when condition present",
+			description: "`accessible-label` MUST be set when `loading` is present.",
+			sourceAttr:  "loading",
+			wantRules: []Rule{{
+				Condition:   Condition{Type: ConditionAttrPresent, AttrName: "loading"},
+				Requirement: Requirement{Type: RequireAttrPresent, AttrName: "accessible-label"},
+				SourceAttr:  "loading",
+			}},
+		},
+		{
+			name:        "attr is REQUIRED when condition",
+			description: "`accessible-label` is REQUIRED when `icon` is set.",
+			sourceAttr:  "icon",
+			wantRules: []Rule{{
+				Condition:   Condition{Type: ConditionAttrPresent, AttrName: "icon"},
+				Requirement: Requirement{Type: RequireAttrPresent, AttrName: "accessible-label"},
+				SourceAttr:  "icon",
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rules := ExtractRules(tt.description, tt.sourceAttr)
+			assertRulesMatch(t, tt.wantRules, rules)
+		})
+	}
+}
+
+func TestExtractRules_ArbitraryVerbs(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		sourceAttr  string
+		wantRules   []Rule
+	}{
+		{
+			name:        "MUST configure attr",
+			description: "You MUST configure `accessible-label` when `icon` is set.",
+			sourceAttr:  "icon",
+			wantRules: []Rule{{
+				Condition:   Condition{Type: ConditionAttrPresent, AttrName: "icon"},
+				Requirement: Requirement{Type: RequireAttrPresent, AttrName: "accessible-label"},
+				SourceAttr:  "icon",
+			}},
+		},
+		{
+			name:        "MUST define attr",
+			description: "If `variant` is 'icon', you MUST define `accessible-label`.",
+			sourceAttr:  "variant",
+			wantRules: []Rule{{
+				Condition:   Condition{Type: ConditionAttrValue, AttrName: "variant", AttrValue: "icon"},
+				Requirement: Requirement{Type: RequireAttrPresent, AttrName: "accessible-label"},
+				SourceAttr:  "variant",
+			}},
+		},
+		{
+			name:        "MUST specify attr",
+			description: "When using `icon`, you MUST specify `accessible-label`.",
+			sourceAttr:  "icon",
+			wantRules: []Rule{{
+				Condition:   Condition{Type: ConditionAttrPresent, AttrName: "icon"},
+				Requirement: Requirement{Type: RequireAttrPresent, AttrName: "accessible-label"},
+				SourceAttr:  "icon",
+			}},
+		},
+		{
+			name:        "MUST ensure attr is present",
+			description: "When `loading` is set, you MUST ensure `accessible-label` is present.",
+			sourceAttr:  "loading",
+			wantRules: []Rule{{
+				Condition:   Condition{Type: ConditionAttrPresent, AttrName: "loading"},
+				Requirement: Requirement{Type: RequireAttrPresent, AttrName: "accessible-label"},
+				SourceAttr:  "loading",
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rules := ExtractRules(tt.description, tt.sourceAttr)
+			assertRulesMatch(t, tt.wantRules, rules)
+		})
+	}
+}
+
+func TestExtractRules_NegatedConditions(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		sourceAttr  string
+		wantRules   []Rule
+	}{
+		{
+			name:        "when attr is not value, MUST set attr",
+			description: "When `variant` is not 'default', you MUST set `accessible-label`.",
+			sourceAttr:  "variant",
+			wantRules: []Rule{{
+				Condition:   Condition{Type: ConditionAttrNotValue, AttrName: "variant", AttrValue: "default"},
+				Requirement: Requirement{Type: RequireAttrPresent, AttrName: "accessible-label"},
+				SourceAttr:  "variant",
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rules := ExtractRules(tt.description, tt.sourceAttr)
+			assertRulesMatch(t, tt.wantRules, rules)
+		})
+	}
+}
+
+func TestExtractRules_MultipleValues(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		sourceAttr  string
+		wantRules   []Rule
+	}{
+		{
+			name:        "if attr is value or value, MUST set attr",
+			description: "If `variant` is 'icon' or 'loading', you MUST set `accessible-label`.",
+			sourceAttr:  "variant",
+			wantRules: []Rule{
+				{
+					Condition:   Condition{Type: ConditionAttrValue, AttrName: "variant", AttrValue: "icon"},
+					Requirement: Requirement{Type: RequireAttrPresent, AttrName: "accessible-label"},
+					SourceAttr:  "variant",
+				},
+				{
+					Condition:   Condition{Type: ConditionAttrValue, AttrName: "variant", AttrValue: "loading"},
+					Requirement: Requirement{Type: RequireAttrPresent, AttrName: "accessible-label"},
+					SourceAttr:  "variant",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rules := ExtractRules(tt.description, tt.sourceAttr)
+			assertRulesMatch(t, tt.wantRules, rules)
+		})
+	}
+}
+
+func TestExtractRules_PresenceVariations(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		sourceAttr  string
+		wantRules   []Rule
+	}{
+		{
+			name:        "attr is defined",
+			description: "When `icon` is defined, you MUST set `accessible-label`.",
+			sourceAttr:  "icon",
+			wantRules: []Rule{{
+				Condition:   Condition{Type: ConditionAttrPresent, AttrName: "icon"},
+				Requirement: Requirement{Type: RequireAttrPresent, AttrName: "accessible-label"},
+				SourceAttr:  "icon",
+			}},
+		},
+		{
+			name:        "attr is specified",
+			description: "When `icon` is specified, `accessible-label` is REQUIRED.",
+			sourceAttr:  "icon",
+			wantRules: []Rule{{
+				Condition:   Condition{Type: ConditionAttrPresent, AttrName: "icon"},
+				Requirement: Requirement{Type: RequireAttrPresent, AttrName: "accessible-label"},
+				SourceAttr:  "icon",
+			}},
+		},
+		{
+			name:        "attr is provided",
+			description: "If `icon` is provided, you MUST also set `accessible-label`.",
+			sourceAttr:  "icon",
+			wantRules: []Rule{{
+				Condition:   Condition{Type: ConditionAttrPresent, AttrName: "icon"},
+				Requirement: Requirement{Type: RequireAttrPresent, AttrName: "accessible-label"},
+				SourceAttr:  "icon",
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rules := ExtractRules(tt.description, tt.sourceAttr)
+			assertRulesMatch(t, tt.wantRules, rules)
+		})
+	}
+}
+
+func TestExtractSignals(t *testing.T) {
+	t.Run("extracts attr refs", func(t *testing.T) {
+		signals := extractSignals("If `variant` is 'icon', you MUST set `accessible-label`.")
+		if len(signals.attrRefs) != 2 {
+			t.Fatalf("expected 2 attr refs, got %d: %+v", len(signals.attrRefs), signals.attrRefs)
+		}
+		if signals.attrRefs[0].name != "variant" {
+			t.Errorf("expected first attr ref 'variant', got %q", signals.attrRefs[0].name)
+		}
+		if signals.attrRefs[1].name != "accessible-label" {
+			t.Errorf("expected second attr ref 'accessible-label', got %q", signals.attrRefs[1].name)
+		}
+	})
+
+	t.Run("extracts quoted values", func(t *testing.T) {
+		signals := extractSignals("If `variant` is 'icon', you MUST set `label`.")
+		if len(signals.quotedValues) != 1 {
+			t.Fatalf("expected 1 quoted value, got %d", len(signals.quotedValues))
+		}
+		if signals.quotedValues[0].value != "icon" {
+			t.Errorf("expected value 'icon', got %q", signals.quotedValues[0].value)
+		}
+	})
+
+	t.Run("extracts MUST keyword", func(t *testing.T) {
+		signals := extractSignals("You MUST set `label`.")
+		if signals.mustKeyword == nil {
+			t.Fatal("expected MUST keyword")
+		}
+		if signals.mustKeyword.negated {
+			t.Error("expected non-negated keyword")
+		}
+	})
+
+	t.Run("extracts MUST NOT keyword", func(t *testing.T) {
+		signals := extractSignals("You MUST NOT set `label`.")
+		if signals.mustKeyword == nil {
+			t.Fatal("expected MUST NOT keyword")
+		}
+		if !signals.mustKeyword.negated {
+			t.Error("expected negated keyword")
+		}
+	})
+
+	t.Run("extracts conditional marker", func(t *testing.T) {
+		signals := extractSignals("If `variant` is 'icon', you MUST set `label`.")
+		if len(signals.conditionals) == 0 {
+			t.Fatal("expected conditional marker")
+		}
+	})
+
+	t.Run("extracts negation near condition", func(t *testing.T) {
+		signals := extractSignals("When `variant` is not 'default', you MUST set `label`.")
+		if len(signals.negations) == 0 {
+			t.Fatal("expected negation")
+		}
+	})
+
+	t.Run("extracts multiple quoted values with or", func(t *testing.T) {
+		signals := extractSignals("If `variant` is 'icon' or 'loading', you MUST set `label`.")
+		if len(signals.quotedValues) != 2 {
+			t.Fatalf("expected 2 quoted values, got %d: %+v", len(signals.quotedValues), signals.quotedValues)
+		}
+	})
+}
+
+func assertRulesMatch(t *testing.T, want, got []Rule) {
+	t.Helper()
+	if len(want) != len(got) {
+		t.Fatalf("expected %d rules, got %d\nwant: %+v\ngot:  %+v", len(want), len(got), want, got)
+	}
+	for i := range want {
+		w, g := want[i], got[i]
+		if w.Condition.Type != g.Condition.Type {
+			t.Errorf("rule[%d] condition type: want %v, got %v", i, w.Condition.Type, g.Condition.Type)
+		}
+		if w.Condition.AttrName != g.Condition.AttrName {
+			t.Errorf("rule[%d] condition attr: want %q, got %q", i, w.Condition.AttrName, g.Condition.AttrName)
+		}
+		if w.Condition.AttrValue != g.Condition.AttrValue {
+			t.Errorf("rule[%d] condition value: want %q, got %q", i, w.Condition.AttrValue, g.Condition.AttrValue)
+		}
+		if w.Requirement.Type != g.Requirement.Type {
+			t.Errorf("rule[%d] requirement type: want %v, got %v", i, w.Requirement.Type, g.Requirement.Type)
+		}
+		if w.Requirement.AttrName != g.Requirement.AttrName {
+			t.Errorf("rule[%d] requirement attr: want %q, got %q", i, w.Requirement.AttrName, g.Requirement.AttrName)
+		}
+		if w.SourceAttr != g.SourceAttr {
+			t.Errorf("rule[%d] source attr: want %q, got %q", i, w.SourceAttr, g.SourceAttr)
+		}
+		if g.Source == "" {
+			t.Errorf("rule[%d] source sentence should not be empty", i)
+		}
+	}
+}

--- a/internal/requirements/requirements.go
+++ b/internal/requirements/requirements.go
@@ -1,0 +1,71 @@
+/*
+Copyright © 2025 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Package requirements extracts and evaluates conditional requirements
+// from custom element manifest descriptions using RFC 2119 keywords.
+package requirements
+
+// ConditionType describes what triggers a rule.
+type ConditionType int
+
+const (
+	ConditionAlways       ConditionType = iota // unconditional requirement
+	ConditionAttrPresent                       // "when `loading` is set"
+	ConditionAttrValue                         // "if `variant` is 'icon'"
+	ConditionAttrNotValue                      // "when `variant` is not 'default'"
+)
+
+// RequirementType describes what the rule demands.
+type RequirementType int
+
+const (
+	RequireAttrPresent RequirementType = iota // "MUST set `accessible-label`"
+	RequireAttrAbsent                         // "MUST NOT use `icon`"
+)
+
+// Condition describes when a rule applies.
+type Condition struct {
+	Type      ConditionType
+	AttrName  string // attribute referenced in condition
+	AttrValue string // specific value (only for ConditionAttrValue)
+}
+
+// Requirement describes what the rule demands.
+type Requirement struct {
+	Type     RequirementType
+	AttrName string // attribute to require or forbid
+}
+
+// Rule is a single conditional requirement extracted from a description.
+type Rule struct {
+	Condition   Condition
+	Requirement Requirement
+	Source      string // original sentence for diagnostic messages
+	SourceAttr  string // which attribute's description this came from
+}
+
+// Violation represents a rule that was not satisfied.
+type Violation struct {
+	Rule    Rule
+	Message string
+}
+
+// ElementFacts describes the current state of an element instance in HTML.
+type ElementFacts struct {
+	Attributes map[string]string // attr name -> value ("" = present with no value)
+	HasAttr    map[string]bool   // tracks attribute presence
+}

--- a/lsp/methods/textDocument/publishDiagnostics/publishDiagnostics.go
+++ b/lsp/methods/textDocument/publishDiagnostics/publishDiagnostics.go
@@ -51,6 +51,10 @@ func PublishDiagnostics(ctx types.ServerContext, glspContext *glsp.Context, uri 
 	attributeValueDiagnostics := analyzeAttributeValueDiagnostics(ctx, doc)
 	diagnostics = append(diagnostics, attributeValueDiagnostics...)
 
+	// Analyze conditional requirement diagnostics from descriptions
+	requirementDiags := analyzeRequirementDiagnostics(ctx, doc)
+	diagnostics = append(diagnostics, requirementDiags...)
+
 	helpers.SafeDebugLog("[DIAGNOSTICS] Found %d diagnostics for %s", len(diagnostics), uri)
 
 	// Publish diagnostics to the client

--- a/lsp/methods/textDocument/publishDiagnostics/requirementDiagnostics.go
+++ b/lsp/methods/textDocument/publishDiagnostics/requirementDiagnostics.go
@@ -1,0 +1,99 @@
+/*
+Copyright © 2025 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package publishDiagnostics
+
+import (
+	"fmt"
+
+	"bennypowers.dev/cem/internal/requirements"
+	"bennypowers.dev/cem/lsp/helpers"
+	"bennypowers.dev/cem/lsp/types"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// analyzeRequirementDiagnostics validates conditional requirements extracted from manifest descriptions.
+func analyzeRequirementDiagnostics(ctx types.ServerContext, doc types.Document) []protocol.Diagnostic {
+	return AnalyzeRequirementDiagnosticsForTest(ctx, doc)
+}
+
+// AnalyzeRequirementDiagnosticsForTest is the exported version for testing.
+func AnalyzeRequirementDiagnosticsForTest(ctx types.ServerContext, doc types.Document) []protocol.Diagnostic {
+	var diagnostics []protocol.Diagnostic
+
+	dm, err := ctx.DocumentManager()
+	if err != nil {
+		helpers.SafeDebugLog("[REQ_DIAGNOSTICS] Failed to get DocumentManager: %v", err)
+		return diagnostics
+	}
+
+	elements, err := doc.FindCustomElements(dm)
+	if err != nil {
+		helpers.SafeDebugLog("[REQ_DIAGNOSTICS] Error finding custom elements: %v", err)
+		return diagnostics
+	}
+
+	for _, element := range elements {
+		decl := ctx.FindCustomElementDeclaration(element.TagName)
+		if decl == nil {
+			continue
+		}
+
+		rules := requirements.ExtractElementRules(decl)
+		if len(rules) == 0 {
+			continue
+		}
+
+		facts := requirements.ElementFacts{
+			Attributes: make(map[string]string),
+			HasAttr:    make(map[string]bool),
+		}
+		for attrName, attr := range element.Attributes {
+			facts.Attributes[attrName] = attr.Value
+			facts.HasAttr[attrName] = true
+		}
+
+		violations := requirements.Evaluate(rules, facts)
+		for _, v := range violations {
+			diagnostics = append(diagnostics, createRequirementDiagnostic(v, element.Range))
+		}
+	}
+
+	helpers.SafeDebugLog("[REQ_DIAGNOSTICS] Generated %d requirement diagnostics", len(diagnostics))
+	return diagnostics
+}
+
+func createRequirementDiagnostic(v requirements.Violation, elemRange protocol.Range) protocol.Diagnostic {
+	diagnostic := protocol.Diagnostic{
+		Range:    elemRange,
+		Message:  v.Message,
+		Severity: &[]protocol.DiagnosticSeverity{protocol.DiagnosticSeverityError}[0],
+		Source:   &[]string{"cem-lsp"}[0],
+	}
+
+	// Add autofix data for RequireAttrPresent violations (suggest adding the attribute)
+	if v.Rule.Requirement.Type == requirements.RequireAttrPresent {
+		autofixData := &types.AutofixData{
+			Type:       types.DiagnosticTypeRequirementViolation,
+			Original:   "",
+			Suggestion: fmt.Sprintf(`%s=""`, v.Rule.Requirement.AttrName),
+			Range:      elemRange,
+		}
+		diagnostic.Data = autofixData.ToMap()
+	}
+
+	return diagnostic
+}

--- a/lsp/methods/textDocument/publishDiagnostics/requirementDiagnostics_test.go
+++ b/lsp/methods/textDocument/publishDiagnostics/requirementDiagnostics_test.go
@@ -1,0 +1,225 @@
+/*
+Copyright © 2025 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package publishDiagnostics_test
+
+import (
+	"testing"
+
+	"bennypowers.dev/cem/lsp/document"
+	"bennypowers.dev/cem/lsp/methods/textDocument/publishDiagnostics"
+	"bennypowers.dev/cem/lsp/testhelpers"
+	M "bennypowers.dev/cem/manifest"
+)
+
+func makeTestManifest() *M.Package {
+	return &M.Package{
+		SchemaVersion: "2.1.0",
+		Modules: []M.Module{{
+			Kind: "javascript-module",
+			Path: "elements/my-button/my-button.js",
+			Declarations: []M.Declaration{
+				&M.CustomElementDeclaration{
+					ClassDeclaration: M.ClassDeclaration{
+						ClassLike: M.ClassLike{
+							FullyQualified: M.FullyQualified{Name: "MyButton"},
+						},
+					},
+					CustomElement: M.CustomElement{
+						TagName:       "my-button",
+						CustomElement: true,
+						Attributes: []M.Attribute{
+							{
+								FullyQualified: M.FullyQualified{
+									Name:        "variant",
+									Description: "The button's theme variant. If you set `variant` to 'icon', you MUST also set `accessible-label`.",
+								},
+								Type: &M.Type{Text: "'primary' | 'secondary' | 'icon'"},
+							},
+							{
+								FullyQualified: M.FullyQualified{
+									Name:        "accessible-label",
+									Description: "Accessible label for the button.",
+								},
+								Type: &M.Type{Text: "string"},
+							},
+							{
+								FullyQualified: M.FullyQualified{
+									Name:        "icon",
+									Description: "The icon name. You MUST also set `accessible-label`.",
+								},
+								Type: &M.Type{Text: "string"},
+							},
+							{
+								FullyQualified: M.FullyQualified{
+									Name:        "loading",
+									Description: "Shows a loading spinner. When `loading` is set, you MUST provide `accessible-label`.",
+								},
+								Type: &M.Type{Text: "boolean"},
+							},
+							{
+								FullyQualified: M.FullyQualified{
+									Name:        "compact",
+									Description: "Compact mode.",
+								},
+								Type: &M.Type{Text: "boolean"},
+							},
+						},
+					},
+				},
+			},
+		}},
+	}
+}
+
+func TestRequirementDiagnostics_ViolationWhenAttrValueMissing(t *testing.T) {
+	ctx := testhelpers.NewMockServerContext()
+
+	dm, err := document.NewDocumentManager()
+	if err != nil {
+		t.Fatalf("Failed to create DocumentManager: %v", err)
+	}
+	defer dm.Close()
+	ctx.SetDocumentManager(dm)
+
+	ctx.AddManifest(makeTestManifest())
+
+	// variant="icon" without accessible-label -> should produce diagnostic
+	html := `<my-button variant="icon" icon="doggy"></my-button>`
+	doc := dm.OpenDocument("test.html", html, 1)
+	ctx.AddDocument("test.html", doc)
+
+	diagnostics := publishDiagnostics.AnalyzeRequirementDiagnosticsForTest(ctx, doc)
+
+	// We expect violations:
+	// 1. variant="icon" requires accessible-label (from variant's description)
+	// 2. icon is set, requires accessible-label (from icon's description, unconditional)
+	if len(diagnostics) < 1 {
+		t.Fatalf("expected at least 1 diagnostic, got %d", len(diagnostics))
+	}
+
+	foundVariantViolation := false
+	for _, d := range diagnostics {
+		t.Logf("diagnostic: %s", d.Message)
+		if d.Severity != nil && *d.Severity == 1 { // Error
+			foundVariantViolation = true
+		}
+	}
+
+	if !foundVariantViolation {
+		t.Error("expected an error-severity diagnostic for missing accessible-label")
+	}
+}
+
+func TestRequirementDiagnostics_NoViolationWhenSatisfied(t *testing.T) {
+	ctx := testhelpers.NewMockServerContext()
+
+	dm, err := document.NewDocumentManager()
+	if err != nil {
+		t.Fatalf("Failed to create DocumentManager: %v", err)
+	}
+	defer dm.Close()
+	ctx.SetDocumentManager(dm)
+
+	ctx.AddManifest(makeTestManifest())
+
+	// variant="icon" with accessible-label -> no diagnostic
+	html := `<my-button variant="icon" icon="doggy" accessible-label="Dog icon"></my-button>`
+	doc := dm.OpenDocument("test.html", html, 1)
+	ctx.AddDocument("test.html", doc)
+
+	diagnostics := publishDiagnostics.AnalyzeRequirementDiagnosticsForTest(ctx, doc)
+
+	if len(diagnostics) != 0 {
+		for _, d := range diagnostics {
+			t.Errorf("unexpected diagnostic: %s", d.Message)
+		}
+	}
+}
+
+func TestRequirementDiagnostics_NoViolationWhenConditionNotMet(t *testing.T) {
+	ctx := testhelpers.NewMockServerContext()
+
+	dm, err := document.NewDocumentManager()
+	if err != nil {
+		t.Fatalf("Failed to create DocumentManager: %v", err)
+	}
+	defer dm.Close()
+	ctx.SetDocumentManager(dm)
+
+	ctx.AddManifest(makeTestManifest())
+
+	// variant="primary" (not "icon") -> no requirement for accessible-label
+	html := `<my-button variant="primary"></my-button>`
+	doc := dm.OpenDocument("test.html", html, 1)
+	ctx.AddDocument("test.html", doc)
+
+	diagnostics := publishDiagnostics.AnalyzeRequirementDiagnosticsForTest(ctx, doc)
+
+	if len(diagnostics) != 0 {
+		for _, d := range diagnostics {
+			t.Errorf("unexpected diagnostic: %s", d.Message)
+		}
+	}
+}
+
+func TestRequirementDiagnostics_UnconditionalRequirement(t *testing.T) {
+	ctx := testhelpers.NewMockServerContext()
+
+	dm, err := document.NewDocumentManager()
+	if err != nil {
+		t.Fatalf("Failed to create DocumentManager: %v", err)
+	}
+	defer dm.Close()
+	ctx.SetDocumentManager(dm)
+
+	ctx.AddManifest(makeTestManifest())
+
+	// icon is set without accessible-label -> violation (unconditional MUST from icon's description)
+	html := `<my-button icon="star"></my-button>`
+	doc := dm.OpenDocument("test.html", html, 1)
+	ctx.AddDocument("test.html", doc)
+
+	diagnostics := publishDiagnostics.AnalyzeRequirementDiagnosticsForTest(ctx, doc)
+
+	if len(diagnostics) == 0 {
+		t.Fatal("expected at least 1 diagnostic for unconditional requirement violation")
+	}
+}
+
+func TestRequirementDiagnostics_LoadingRequiresLabel(t *testing.T) {
+	ctx := testhelpers.NewMockServerContext()
+
+	dm, err := document.NewDocumentManager()
+	if err != nil {
+		t.Fatalf("Failed to create DocumentManager: %v", err)
+	}
+	defer dm.Close()
+	ctx.SetDocumentManager(dm)
+
+	ctx.AddManifest(makeTestManifest())
+
+	// loading is set without accessible-label -> violation
+	html := `<my-button loading></my-button>`
+	doc := dm.OpenDocument("test.html", html, 1)
+	ctx.AddDocument("test.html", doc)
+
+	diagnostics := publishDiagnostics.AnalyzeRequirementDiagnosticsForTest(ctx, doc)
+
+	if len(diagnostics) == 0 {
+		t.Fatal("expected diagnostic for loading without accessible-label")
+	}
+}

--- a/lsp/types/diagnostics.go
+++ b/lsp/types/diagnostics.go
@@ -27,6 +27,7 @@ const (
 	DiagnosticTypeMissingImport            DiagnosticType = "missing-import"
 	DiagnosticTypeAttributeSuggestion      DiagnosticType = "attribute-suggestion"
 	DiagnosticTypeAttributeValueSuggestion DiagnosticType = "attribute-value-suggestion"
+	DiagnosticTypeRequirementViolation     DiagnosticType = "requirement-violation"
 )
 
 // AutofixData contains the data needed for creating autofix code actions


### PR DESCRIPTION
> **Experimental** — this branch explores extracting and enforcing conditional requirements from natural language descriptions in custom elements manifests.

## Summary

- Extracts RFC 2119 conditional requirements from attribute/slot descriptions (e.g. "If you set `variant` to 'icon', you MUST also set `accessible-label`")
- Produces LSP error diagnostics when HTML violates those requirements
- Only MUST/REQUIRED/SHALL keywords trigger diagnostics (SHOULD/MAY ignored to reduce noise)

## Approach: Signal-based extraction

Rather than matching whole-sentence regex templates (fragile, limited to exact phrasings), this uses a **signal-based pipeline**:

1. **Extract signals** from each sentence: backtick-quoted attribute names, RFC 2119 keywords, conditional markers (if/when), quoted values, negation words
2. **Infer relationships** from relative positions of those signals — the attr nearest the conditional marker is the condition; the attr nearest the MUST keyword is the requirement
3. **Evaluate rules** against the actual HTML element's attributes

This handles arbitrary verbs, passive voice, negated conditions, OR values, and any word order — because it never looks at verbs or sentence structure.

## Alternatives considered

| Approach | Description | Trade-off |
|----------|-------------|-----------|
| **Regex templates** | Match exact sentence patterns like `if/when ATTR is VALUE, MUST VERB ATTR` | Brittle — fails on passive voice, unusual verbs, different word order |
| **Clause parser** | Split sentences into clauses, classify each as conditional/declarative | More structured but higher complexity for similar coverage |
| **POS tagging (prose)** | Use part-of-speech tags to match grammatical patterns like `MODAL+VERB+NOUN` | Adds dependency, POS errors on domain-specific terms |
| **Structured manifest field** | Add a `constraints` field to the CEM schema | Reliable but requires schema changes and author buy-in |
| **Build-time LLM extraction** | Run LLM at `cem generate` to extract rules, store as structured data | Powerful but adds LLM dependency to build step |

## Test plan

- [x] 41 unit tests for signal extraction and rule evaluation
- [x] 5 LSP integration tests for end-to-end diagnostic generation
- [x] Full test suite passes (2214 tests)
- [ ] Manual testing with real-world manifests (RHDS, PFE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)