### PR TITLE
fix(generate): process @element and @tagName JSDoc tags without decorator

### DIFF
--- a/generate/classDeclarations.go
+++ b/generate/classDeclarations.go
@@ -58,7 +58,7 @@ func (mp *ModuleProcessor) generateClassDeclarationParsed(
 	if jsdocNodes, ok := captures["class.jsdoc"]; ok && len(jsdocNodes) > 0 {
 		has, err := jsdoc.HasElementTag(jsdocNodes[0].Text, mp.queryManager)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to check JSDoc element tag for class %s: %w", className, err)
 		}
 		hasJSDocElementTag = has
 	}

--- a/generate/classDeclarations.go
+++ b/generate/classDeclarations.go
@@ -53,7 +53,15 @@ func (mp *ModuleProcessor) generateClassDeclarationParsed(
 		}
 	}
 
-	isCustomElement := hasCustomElementDecorator || isHTMLElement
+	// Check if JSDoc contains @element, @tagName, or @customElement tags
+	hasJSDocElementTag := false
+	if jsdocNodes, ok := captures["class.jsdoc"]; ok && len(jsdocNodes) > 0 {
+		if has, err := jsdoc.HasElementTag(jsdocNodes[0].Text, mp.queryManager); err == nil && has {
+			hasJSDocElementTag = true
+		}
+	}
+
+	isCustomElement := hasCustomElementDecorator || isHTMLElement || hasJSDocElementTag
 	classDeclarationCaptures, hasClassDeclaration := captures["class.declaration"]
 	if !hasClassDeclaration || len(classDeclarationCaptures) <= 0 {
 		return nil, NewError("could not find class declaration")
@@ -308,8 +316,6 @@ func (mp *ModuleProcessor) generateLitElementClassDeclaration(
 		if tagName != "" {
 			declaration.TagName = tagName
 		}
-	} else {
-		errs = errors.Join(errs, &Q.NoCaptureError{Capture: "tag-name", Query: "classes"})
 	}
 
 	declaration.CustomElement.Attributes = A.Chain(func(member M.ClassMember) []M.Attribute {

--- a/generate/classDeclarations.go
+++ b/generate/classDeclarations.go
@@ -56,9 +56,11 @@ func (mp *ModuleProcessor) generateClassDeclarationParsed(
 	// Check if JSDoc contains @element, @tagName, or @customElement tags
 	hasJSDocElementTag := false
 	if jsdocNodes, ok := captures["class.jsdoc"]; ok && len(jsdocNodes) > 0 {
-		if has, err := jsdoc.HasElementTag(jsdocNodes[0].Text, mp.queryManager); err == nil && has {
-			hasJSDocElementTag = true
+		has, err := jsdoc.HasElementTag(jsdocNodes[0].Text, mp.queryManager)
+		if err != nil {
+			return nil, err
 		}
+		hasJSDocElementTag = has
 	}
 
 	isCustomElement := hasCustomElementDecorator || isHTMLElement || hasJSDocElementTag

--- a/generate/jsdoc/jsdoc.go
+++ b/generate/jsdoc/jsdoc.go
@@ -126,6 +126,9 @@ func ExtractAliasFromJSDoc(jsdocText string, queryManager *Q.QueryManager) (stri
 
 // HasElementTag checks whether JSDoc contains an @element, @tagName, or @customElement tag.
 func HasElementTag(jsdocText string, queryManager *Q.QueryManager) (bool, error) {
+	if strings.TrimSpace(jsdocText) == "" {
+		return false, nil
+	}
 	info, err := parseForClass(jsdocText, queryManager)
 	if err != nil {
 		return false, err

--- a/generate/jsdoc/jsdoc.go
+++ b/generate/jsdoc/jsdoc.go
@@ -123,3 +123,12 @@ func ExtractAliasFromJSDoc(jsdocText string, queryManager *Q.QueryManager) (stri
 	}
 	return info.Alias, nil
 }
+
+// HasElementTag checks whether JSDoc contains an @element, @tagName, or @customElement tag.
+func HasElementTag(jsdocText string, queryManager *Q.QueryManager) (bool, error) {
+	info, err := parseForClass(jsdocText, queryManager)
+	if err != nil {
+		return false, err
+	}
+	return info.TagName != "", nil
+}

--- a/generate/testdata/fixtures/project-classes/golden/class-jsdoc-element-no-known-superclass.json
+++ b/generate/testdata/fixtures/project-classes/golden/class-jsdoc-element-no-known-superclass.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/class-jsdoc-element-no-known-superclass.js",
+      "declarations": [
+        {
+          "name": "SomeBase",
+          "source": {
+            "href": "https://github.com/bennypowers/cem/tree/main/generate/test/fixtures/project-classes/src/class-jsdoc-element-no-known-superclass.ts#L1"
+          },
+          "kind": "class"
+        },
+        {
+          "name": "MyWidget",
+          "description": "A custom element extending an unknown base class",
+          "superclass": {
+            "name": "SomeBase"
+          },
+          "source": {
+            "href": "https://github.com/bennypowers/cem/tree/main/generate/test/fixtures/project-classes/src/class-jsdoc-element-no-known-superclass.ts#L7"
+          },
+          "kind": "class",
+          "tagName": "my-widget",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "my-widget",
+          "declaration": {
+            "name": "MyWidget",
+            "module": "src/class-jsdoc-element-no-known-superclass.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "MyWidget",
+          "declaration": {
+            "name": "MyWidget",
+            "module": "src/class-jsdoc-element-no-known-superclass.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/generate/testdata/fixtures/project-classes/golden/class-jsdoc-element-tag.json
+++ b/generate/testdata/fixtures/project-classes/golden/class-jsdoc-element-tag.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/class-jsdoc-element-tag.js",
+      "declarations": [
+        {
+          "name": "Foo",
+          "description": "Foo element",
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "source": {
+            "href": "https://github.com/bennypowers/cem/tree/main/generate/test/fixtures/project-classes/src/class-jsdoc-element-tag.ts#L7"
+          },
+          "kind": "class",
+          "tagName": "my-foo",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "my-foo",
+          "declaration": {
+            "name": "Foo",
+            "module": "src/class-jsdoc-element-tag.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "Foo",
+          "declaration": {
+            "name": "Foo",
+            "module": "src/class-jsdoc-element-tag.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/generate/testdata/fixtures/project-classes/golden/class-jsdoc-tagname-tag.json
+++ b/generate/testdata/fixtures/project-classes/golden/class-jsdoc-tagname-tag.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/class-jsdoc-tagname-tag.js",
+      "declarations": [
+        {
+          "name": "Bar",
+          "description": "Bar element",
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "source": {
+            "href": "https://github.com/bennypowers/cem/tree/main/generate/test/fixtures/project-classes/src/class-jsdoc-tagname-tag.ts#L7"
+          },
+          "kind": "class",
+          "tagName": "my-bar",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "my-bar",
+          "declaration": {
+            "name": "Bar",
+            "module": "src/class-jsdoc-tagname-tag.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "Bar",
+          "declaration": {
+            "name": "Bar",
+            "module": "src/class-jsdoc-tagname-tag.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/generate/testdata/fixtures/project-classes/src/class-jsdoc-element-no-known-superclass.ts
+++ b/generate/testdata/fixtures/project-classes/src/class-jsdoc-element-no-known-superclass.ts
@@ -1,0 +1,7 @@
+class SomeBase {}
+
+/**
+ * A custom element extending an unknown base class
+ * @element my-widget
+ */
+export class MyWidget extends SomeBase {}

--- a/generate/testdata/fixtures/project-classes/src/class-jsdoc-element-tag.ts
+++ b/generate/testdata/fixtures/project-classes/src/class-jsdoc-element-tag.ts
@@ -1,0 +1,11 @@
+import { html, LitElement, type TemplateResult } from 'lit';
+
+/**
+ * Foo element
+ * @element my-foo
+ */
+export class Foo extends LitElement {
+  render(): TemplateResult {
+    return html`<p>Foo</p>`;
+  }
+}

--- a/generate/testdata/fixtures/project-classes/src/class-jsdoc-tagname-tag.ts
+++ b/generate/testdata/fixtures/project-classes/src/class-jsdoc-tagname-tag.ts
@@ -1,0 +1,7 @@
+import { LitElement } from 'lit';
+
+/**
+ * Bar element
+ * @tagName my-bar
+ */
+export class Bar extends LitElement {}


### PR DESCRIPTION
## Summary
- Classes using `@element` or `@tagName` JSDoc tags (without a `@customElement` decorator) were not recognized as custom elements, producing a plain `ClassDeclaration` with no `tagName` or `customElement` flag
- Pre-check JSDoc for element tags before routing the class declaration, and stop treating a missing decorator `tag-name` capture as a fatal error so JSDoc enrichment can provide the tag name instead

Closes #281

## Test plan
- [x] Added fixture for `@element` tag on a LitElement subclass
- [x] Added fixture for `@tagName` tag on a LitElement subclass
- [x] Added fixture for `@element` tag on a class with unknown superclass
- [x] All existing tests pass unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved custom element detection: classes with JSDoc element tags (e.g., @element, @tagName, @customElement) are now recognized as custom elements even without specific decorators or known superclasses.

* **Bug Fixes**
  * Suppressed a spurious error when a custom element tag name is absent so missing tag metadata no longer produces an error.

* **Tests**
  * Added fixtures covering various JSDoc-based custom element declaration patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->