### PR TITLE
feat(generate): support scalar shorthand for slot/part YAML comments

### DIFF
--- a/docs/content/docs/usage/documenting-components.md
+++ b/docs/content/docs/usage/documenting-components.md
@@ -130,7 +130,11 @@ something as `deprecated`, use multi-key YAML syntax inside the comment:
 ### Combined Slot and Part
 
 When the same element has both a `slot` and `part` attribute and you want
-separate documentation for each, use nested `slot:` and `part:` keys:
+separate documentation for each, use nested `slot:` and `part:` keys.
+
+A scalar string is shorthand for `description`, so you can mix scalar and
+object forms when one side only needs a description and the other needs
+full metadata:
 
 ```html
 <!-- slot:
@@ -138,6 +142,18 @@ separate documentation for each, use nested `slot:` and `part:` keys:
      part:
        summary: The `info-part` part -->
 <slot name="info" part="info-part"></slot>
+
+<!-- slot: The info slot
+     part:
+       summary: Short label
+       description: Longer description of the part -->
+<slot name="info" part="info-part"></slot>
+
+<!-- part: The overlay container
+     slot:
+       summary: Overlay
+       description: Content shown in the overlay -->
+<slot name="overlay" part="overlay"></slot>
 ```
 
 {{<tip "warning">}}

--- a/extensions/claude-code/skills/_shared/html-comment-syntax.md
+++ b/extensions/claude-code/skills/_shared/html-comment-syntax.md
@@ -1,0 +1,103 @@
+# Inline HTML Comment Syntax for Slots and Parts
+
+`cem` extracts documentation from HTML comments immediately before `<slot>`
+elements and elements with `part` attributes. Prefer inline comments over
+JSDoc `@slot`/`@csspart` tags -- they stay co-located with the markup.
+
+## Plain string comment
+
+A plain (non-YAML) comment becomes the `description`:
+
+```html
+<!-- Button label content. SHOULD contain text. -->
+<slot></slot>
+
+<!-- The native button element -->
+<button part="button">
+```
+
+## Single-key YAML
+
+Use `summary:` for a short label shown in tooling previews:
+
+```html
+<!-- summary: Button label content -->
+<slot></slot>
+```
+
+## Multi-key YAML
+
+Combine `summary`, `description`, and `deprecated`:
+
+```html
+<!--
+  summary: The main slot for content
+  description: |
+    This slot displays user-provided content.
+    Supports multiline **markdown**.
+  deprecated: true
+-->
+<slot></slot>
+```
+
+## Combined slot and part
+
+When an element has both a `slot` name and a `part` attribute, use nested
+`slot:` and `part:` keys. Each accepts either a scalar string (shorthand
+for `description`) or the full object form. Mix them freely:
+
+```html
+<!-- slot: Sub navigation links
+     part:
+       summary: Nav container
+       description: The scrollable link list container -->
+<slot name="nav" part="nav-container"></slot>
+
+<!-- part: The overlay container
+     slot:
+       summary: Overlay
+       description: Content shown in the overlay -->
+<slot name="overlay" part="overlay"></slot>
+
+<!-- slot: Info content
+     part: Info container -->
+<slot name="info" part="info"></slot>
+```
+
+## Backtick escaping
+
+Inside lit-html `html` tagged template literals, escape backticks in
+comments with `\``:
+
+```html
+<!-- summary: Uses \`currentColor\` by default -->
+<slot></slot>
+```
+
+## CSS custom properties
+
+Document CSS variables using JSDoc-style comments in CSS source files
+(preferred over `@cssprop` tags on the class):
+
+```css
+:host {
+  /**
+   * A property defined on the host
+   * @summary The host's custom property
+   */
+  --host-property: red;
+
+  color:
+    /**
+     * Custom color for use in this element
+     * @summary color
+     * @deprecated Use the `color` property instead
+     */
+    var(--custom-color);
+
+  border:
+    1px solid
+    /** Border color of the element */
+    var(--border-color);
+}
+```

--- a/extensions/claude-code/skills/design-api/SKILL.md
+++ b/extensions/claude-code/skills/design-api/SKILL.md
@@ -123,7 +123,14 @@ Work through each API surface systematically:
 - Map to existing CSS pseudo-classes where appropriate
 - Document state transitions
 
-### Phase 4: Consistency Check
+### Phase 4: Source Documentation
+
+When presenting the designed API, show how each part should be documented
+in source code.
+
+!`cat ${CLAUDE_SKILL_DIR}/html-comment-syntax.md`
+
+### Phase 5: Consistency Check
 
 Compare the proposed API against existing elements:
 - Are similar concepts named the same way?
@@ -131,7 +138,7 @@ Compare the proposed API against existing elements:
 - Are event patterns consistent?
 - Do CSS property names follow the same scheme?
 
-### Phase 5: Output
+### Phase 6: Output
 
 Present the designed API as a structured summary:
 

--- a/extensions/claude-code/skills/design-api/html-comment-syntax.md
+++ b/extensions/claude-code/skills/design-api/html-comment-syntax.md
@@ -1,0 +1,1 @@
+../_shared/html-comment-syntax.md

--- a/extensions/claude-code/skills/docs-health/SKILL.md
+++ b/extensions/claude-code/skills/docs-health/SKILL.md
@@ -149,6 +149,12 @@ cem://element/{tagName}/slots
 
 This provides the full manifest data so you can show exactly what's missing and suggest what to document.
 
+### Phase 5: Suggesting Fixes
+
+When reporting gaps, show the user how to fix them.
+
+!`cat ${CLAUDE_SKILL_DIR}/html-comment-syntax.md`
+
 ## Guidelines
 
 - **Use `cem health` as the source of truth**: Don't reinvent the scoring — it already checks descriptions, types, defaults, etc.

--- a/extensions/claude-code/skills/docs-health/html-comment-syntax.md
+++ b/extensions/claude-code/skills/docs-health/html-comment-syntax.md
@@ -1,0 +1,1 @@
+../_shared/html-comment-syntax.md

--- a/extensions/claude-code/skills/write-docs/SKILL.md
+++ b/extensions/claude-code/skills/write-docs/SKILL.md
@@ -40,25 +40,9 @@ Also read project-level guidelines for tone and conventions:
 cem://guidelines
 ```
 
-### Phase 1b: Consult CEM Documentation Guides
+### Phase 1b: Source Comment Syntax
 
-Fetch and follow CEM's own guidance on writing effective documentation:
-
-- **Documenting Components**: https://bennypowers.dev/cem/docs/usage/documenting-components/
-  Covers JSDoc tags (`@summary`, `@cssprop`, `@csspart`, `@slot`, `@fires`),
-  CSS file documentation, and how manifest descriptions are generated from source.
-
-- **Writing Demos**: https://bennypowers.dev/cem/docs/usage/demos/
-  Covers demo file structure, `<meta>` tags for demo metadata, and how
-  `cem serve` discovers and renders demos from the manifest's `demos` array.
-
-- **Effective MCP Descriptions**: https://bennypowers.dev/cem/docs/usage/effective-mcp-descriptions/
-  Covers writing element and attribute descriptions that work well with
-  AI tools — concise, specific, and machine-readable.
-
-These guides define how documentation *feeds into* the manifest and tooling.
-When writing docs, ensure the source-level JSDoc will produce a good manifest,
-not just a good standalone doc page.
+!`cat ${CLAUDE_SKILL_DIR}/html-comment-syntax.md`
 
 ### Phase 2: Detect Documentation Conventions
 

--- a/extensions/claude-code/skills/write-docs/html-comment-syntax.md
+++ b/extensions/claude-code/skills/write-docs/html-comment-syntax.md
@@ -1,0 +1,1 @@
+../_shared/html-comment-syntax.md

--- a/generate/html.go
+++ b/generate/html.go
@@ -35,6 +35,17 @@ type HtmlDocYaml struct {
 	Deprecated  any    `yaml:"deprecated"`
 }
 
+func (h *HtmlDocYaml) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		h.Description = value.Value
+		return nil
+	}
+
+	// For mapping nodes, decode normally
+	type plain HtmlDocYaml
+	return value.Decode((*plain)(h))
+}
+
 type NestedHtmlDocYaml struct {
 	Slot        *HtmlDocYaml `yaml:"slot"`
 	Part        *HtmlDocYaml `yaml:"part"`

--- a/generate/testdata/fixtures/project-html/golden/class-render-scalar-shorthand.json
+++ b/generate/testdata/fixtures/project-html/golden/class-render-scalar-shorthand.json
@@ -1,0 +1,64 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/class-render-scalar-shorthand.js",
+      "declarations": [
+        {
+          "name": "ClassRenderScalarShorthand",
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "source": {
+            "href": "https://github.com/bennypowers/cem/tree/main/generate/test/fixtures/project-html/src/class-render-scalar-shorthand.ts#L1"
+          },
+          "kind": "class",
+          "tagName": "class-render-scalar-shorthand",
+          "slots": [
+            {
+              "name": "nav",
+              "description": "Sub navigation links"
+            },
+            {
+              "name": "overlay",
+              "summary": "Overlay",
+              "description": "Content shown in the overlay"
+            },
+            {
+              "name": "info",
+              "description": "Info content"
+            }
+          ],
+          "cssParts": [
+            {
+              "name": "nav-container",
+              "summary": "Nav container",
+              "description": "The scrollable link list container"
+            },
+            {
+              "name": "overlay",
+              "description": "The overlay container"
+            },
+            {
+              "name": "info",
+              "description": "Info container"
+            }
+          ],
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "class-render-scalar-shorthand",
+          "declaration": {
+            "name": "ClassRenderScalarShorthand",
+            "module": "src/class-render-scalar-shorthand.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/generate/testdata/fixtures/project-html/src/class-render-scalar-shorthand.ts
+++ b/generate/testdata/fixtures/project-html/src/class-render-scalar-shorthand.ts
@@ -1,0 +1,24 @@
+@customElement('class-render-scalar-shorthand')
+class ClassRenderScalarShorthand extends LitElement {
+  render() {
+    return html`
+      <!--
+        slot: Sub navigation links
+        part:
+          summary: Nav container
+          description: The scrollable link list container
+      -->
+      <slot name="nav" part="nav-container"></slot>
+      <!--
+        part: The overlay container
+        slot:
+          summary: Overlay
+          description: Content shown in the overlay
+      -->
+      <slot name="overlay" part="overlay"></slot>
+      <!-- slot: Info content
+           part: Info container -->
+      <slot name="info" part="info"></slot>
+    `;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `UnmarshalYAML` on `HtmlDocYaml` so scalar strings in nested `slot:`/`part:` YAML keys are treated as the `description` field
- Lets users mix scalar and object forms when documenting elements with both a slot and a part
- Updates docs with new syntax examples
- Adds shared Claude Code skill supporting file for HTML comment syntax, symlinked into `write-docs`, `design-api`, and `docs-health` skills

## Test plan
- [x] New golden test `class-render-scalar-shorthand` covers scalar `slot:` + object `part:`, object `slot:` + scalar `part:`, and both scalar
- [x] All existing `project-html` tests pass (no regressions)
- [x] `go vet` clean

Closes #278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded component documentation with improved examples showing combined slot and part documentation patterns
  * Added comprehensive HTML comment syntax reference for documenting component slots, CSS parts, and CSS custom properties

* **New Features**
  * Support for scalar shorthand syntax when documenting component slots and CSS parts, allowing simplified metadata notation alongside full object forms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->