### PR TITLE
fix(generate): parse JSDoc comments before calc/min/max wrapping var()

### DIFF
--- a/generate/testdata/fixtures/project-css-design-token-comments/golden/calc-outer-comment.json
+++ b/generate/testdata/fixtures/project-css-design-token-comments/golden/calc-outer-comment.json
@@ -1,0 +1,73 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/calc-outer-comment.js",
+      "declarations": [
+        {
+          "name": "CalcOuterComment",
+          "description": "Element that demonstrates comments before declarations with calc/min/max wrapping var()",
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "source": {
+            "href": "https://github.com/bennypowers/cem/tree/main/generate/test/fixtures/project-css-design-token-comments/src/calc-outer-comment.ts#L9"
+          },
+          "kind": "class",
+          "tagName": "calc-outer-comment",
+          "cssProperties": [
+            {
+              "name": "--cem-length-xl",
+              "summary": "Outer comment on calc with fallback",
+              "description": "DESIGN TOKEN description for XL length",
+              "default": "24px",
+              "syntax": "\u003clength\u003e"
+            },
+            {
+              "name": "--cem-color-secondary",
+              "summary": "Non-host calc outer comment",
+              "description": "DESIGN TOKEN description for secondary color",
+              "default": "#6666cc",
+              "syntax": "\u003ccolor\u003e"
+            },
+            {
+              "name": "--cem-color-primary",
+              "summary": "Token inside container query",
+              "description": "DESIGN TOKEN description for primary color",
+              "default": "#0066cc",
+              "syntax": "\u003ccolor\u003e"
+            },
+            {
+              "name": "--cem-spacing-base",
+              "summary": "Outer comment on calc with no fallback\n\nNon-host token inside named container query",
+              "description": "DESIGN TOKEN description for base spacing",
+              "default": "1rem",
+              "syntax": "\u003clength\u003e"
+            }
+          ],
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "calc-outer-comment",
+          "declaration": {
+            "name": "CalcOuterComment",
+            "module": "src/calc-outer-comment.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "CalcOuterComment",
+          "declaration": {
+            "name": "CalcOuterComment",
+            "module": "src/calc-outer-comment.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/generate/testdata/fixtures/project-css-design-token-comments/src/calc-outer-comment.ts
+++ b/generate/testdata/fixtures/project-css-design-token-comments/src/calc-outer-comment.ts
@@ -1,0 +1,38 @@
+import { LitElement, css } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+/**
+ * Element that demonstrates comments before declarations with calc/min/max wrapping var()
+ * @customElement calc-outer-comment
+ */
+@customElement('calc-outer-comment')
+export class CalcOuterComment extends LitElement {
+  static styles = css`
+    :host {
+      /** @summary Outer comment on calc with no fallback */
+      padding: calc(var(--cem-spacing-base) / 2);
+
+      /** @summary Outer comment on calc with fallback */
+      width: calc(var(--cem-length-xl, 24px) + 4px);
+    }
+
+    .inner {
+      /** @summary Non-host calc outer comment */
+      margin: calc(var(--cem-color-secondary) + 0);
+    }
+
+    @container style(--cem-color-primary) {
+      :host {
+        /** @summary Token inside container query */
+        color: var(--cem-color-primary);
+      }
+    }
+
+    @container sidebar style(--cem-length-xl) {
+      .content {
+        /** @summary Non-host token inside named container query */
+        padding: calc(var(--cem-spacing-base) * 3);
+      }
+    }
+  `;
+}

--- a/queries/css/cssCustomProperties.scm
+++ b/queries/css/cssCustomProperties.scm
@@ -93,3 +93,53 @@
           .
           ")"))))) @cssProperty
 
+( ; /** comment before calc/min/max wrapping var */
+  ; padding: calc(var(--blue, 24px));
+  ; min-width: min(var(--blue, 24px), 100%);
+  ; Matches comment before declaration where var() is a direct argument
+  ; of a wrapping function (calc, min, max, clamp, etc.)
+  (rule_set
+    (block (
+      (comment)? @comment (#match? @comment "^/\\*\\*")
+      .
+      (declaration
+        (property_name) @prop.name (#not-match? @prop.name "^--[^_]")
+        ":"
+        (call_expression
+          (function_name) @fn.outer (#not-eq? @fn.outer "var")
+          (arguments
+            (call_expression
+              (function_name) @fn (#eq? @fn "var")
+              (arguments
+                "("
+                .
+                (plain_value) @property (#match? @property "^--[^_]")
+                ("," [_(_)]* @default)?
+                .
+                ")")))))) @cssProperty)))
+
+( ; /** comment before calc wrapping var in binary expression */
+  ; width: calc(var(--blue, 24px) + 4px);
+  ; Matches comment before declaration where var() is inside a binary
+  ; expression within a wrapping function's arguments
+  (rule_set
+    (block (
+      (comment)? @comment (#match? @comment "^/\\*\\*")
+      .
+      (declaration
+        (property_name) @prop.name (#not-match? @prop.name "^--[^_]")
+        ":"
+        (call_expression
+          (function_name) @fn.outer (#not-eq? @fn.outer "var")
+          (arguments
+            (_
+              (call_expression
+                (function_name) @fn (#eq? @fn "var")
+                (arguments
+                  "("
+                  .
+                  (plain_value) @property (#match? @property "^--[^_]")
+                  ("," [_(_)]* @default)?
+                  .
+                  ")"))))))) @cssProperty)))
+


### PR DESCRIPTION
## Summary

- Add two tree-sitter query patterns to handle JSDoc comments before declarations where `var()` is nested inside `calc()`, `min()`, `max()`, `clamp()`, etc.
- Patterns are selector-agnostic, covering both `:host` and non-`:host` contexts
- Token detection inside `@container` query bodies works; extracting tokens from `@container style(--token)` conditions is blocked on tree-sitter/tree-sitter-css#95

Closes #286

## Test plan

- [x] New fixture `calc-outer-comment.ts` covering:
  - `calc(var(--token) / 2)` in `:host` (binary expression, no fallback)
  - `calc(var(--token, 24px) + 4px)` in `:host` (binary expression, with fallback)
  - `calc(var(--token) + 0)` in non-`:host` selector
  - `var(--token)` inside `@container style(...)` query body
  - `calc(var(--token) * 3)` inside named `@container` query body
- [x] All 2312 existing tests pass with no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test fixtures for CSS custom property handling with `calc()` functions and comments

* **Chores**
  * Enhanced CSS query patterns to better detect custom property usage within wrapper functions and nested expressions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->