### PR TITLE
fix(serve): separate rendering from serve and build commands

### DIFF
--- a/manifest/context.go
+++ b/manifest/context.go
@@ -133,6 +133,10 @@ func (x *Package) RenderableCustomElementDeclarations() (tags []*RenderableCusto
 		for _, e := range m.Exports {
 			if cee, ok := e.(*CustomElementExport); ok {
 				r := mrs[cee.Name]
+				if r == nil {
+					// Export has no matching declaration in this module (e.g., re-export)
+					continue
+				}
 				r.CustomElementExport = cee
 				mrs[cee.Name] = r
 			}

--- a/manifest/context_test.go
+++ b/manifest/context_test.go
@@ -233,6 +233,62 @@ func TestTagRenderableClassMethods(t *testing.T) {
 	}
 }
 
+// TestRenderableCustomElementDeclarations_ExportWithoutDeclaration verifies that
+// a CustomElementExport with no matching CustomElementDeclaration in the same
+// module does not panic (regression test for #288).
+func TestRenderableCustomElementDeclarations_ExportWithoutDeclaration(t *testing.T) {
+	pkg := &Package{
+		Modules: []Module{
+			{
+				Kind: "javascript-module",
+				Path: "src/wrapper.js",
+				Declarations: []Declaration{
+					// No CustomElementDeclaration here
+				},
+				Exports: []Export{
+					// Re-export of an element defined elsewhere
+					&CustomElementExport{
+						Name:      "other-element",
+						StartByte: 1,
+					},
+				},
+			},
+			{
+				Kind: "javascript-module",
+				Path: "src/my-element.js",
+				Declarations: []Declaration{
+					&CustomElementDeclaration{
+						ClassDeclaration: ClassDeclaration{
+							ClassLike: ClassLike{
+								FullyQualified: FullyQualified{Name: "MyElement"},
+							},
+							Kind: "class",
+						},
+						CustomElement: CustomElement{
+							TagName:       "my-element",
+							CustomElement: true,
+						},
+					},
+				},
+				Exports: []Export{
+					&CustomElementExport{Name: "my-element", StartByte: 1},
+				},
+			},
+		},
+	}
+
+	// Must not panic
+	tags := pkg.RenderableCustomElementDeclarations()
+
+	// Should contain only the module with a matching declaration+export
+	if len(tags) != 1 {
+		t.Fatalf("expected 1 tag, got %d", len(tags))
+	}
+	if tags[0].Name() != "my-element" {
+		t.Errorf("expected tag 'my-element', got %q", tags[0].Name())
+	}
+}
+
 func TestGetTagAttrsWithContext_TagNotFound(t *testing.T) {
 	pkg := makeTestPackage()
 	_, err := pkg.TagRenderableAttributes("does-not-exist")

--- a/serve/build.go
+++ b/serve/build.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"html"
-	"io"
 	"io/fs"
 	"net/http"
 	"net/http/httptest"
@@ -21,7 +20,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"time"
 
 	"bennypowers.dev/cem/serve/middleware"
 	"bennypowers.dev/cem/serve/middleware/importmap"
@@ -48,8 +46,8 @@ func (c BuildConfig) siteRoot() string {
 }
 
 // Build generates a static site from the dev server's demo pages.
-// It spins up the full middleware chain, renders each page via internal
-// HTTP requests, and writes the results to disk.
+// It renders each page in-process through the middleware chain
+// and writes the results to disk.
 func (s *Server) Build(config BuildConfig) error {
 	if config.OutputDir == "" {
 		config.OutputDir = "dist"
@@ -73,19 +71,21 @@ func (s *Server) Build(config BuildConfig) error {
 		return fmt.Errorf("no demo routes found")
 	}
 
-	// Create a test server backed by the real handler
-	ts := httptest.NewServer(s.Handler())
-	defer ts.Close()
+	// Render pages in-process through the middleware chain.
+	// No HTTP server is started -- requests are handled directly via
+	// handler.ServeHTTP, avoiding TCP connections and the EOF errors
+	// that httptest.Server causes on resource-constrained CI runners.
+	handler := s.Handler()
 
 	// Write the index listing page
-	if err := s.buildPage(ts, "/", config); err != nil {
+	if err := s.buildPage(handler, "/", config); err != nil {
 		return fmt.Errorf("build index: %w", err)
 	}
 
 	// Write each demo page
 	var pageErrors error
 	for route := range demoRoutes {
-		if err := s.buildPage(ts, route, config); err != nil {
+		if err := s.buildPage(handler, route, config); err != nil {
 			s.logger.Error("Failed to build %s: %v", route, err)
 			pageErrors = errors.Join(pageErrors, fmt.Errorf("%s: %w", route, err))
 			continue
@@ -111,7 +111,7 @@ func (s *Server) Build(config BuildConfig) error {
 	}
 
 	// Transform and copy user source files (TS→JS, CSS modules, etc.)
-	if err := s.buildUserSources(ts, config, demoRoutes); err != nil {
+	if err := s.buildUserSources(handler, config, demoRoutes); err != nil {
 		return fmt.Errorf("build user sources: %w", err)
 	}
 
@@ -124,7 +124,7 @@ func (s *Server) Build(config BuildConfig) error {
 		}
 	default:
 		// Vendor mode (default): copy node_modules to output
-		if err := s.buildDependencies(ts, config); err != nil {
+		if err := s.buildDependencies(handler, config); err != nil {
 			return fmt.Errorf("build dependencies: %w", err)
 		}
 	}
@@ -138,7 +138,7 @@ func (s *Server) Build(config BuildConfig) error {
 	}
 
 	// Pre-render health API as static JSON
-	if err := s.buildHealthJSON(ts, config); err != nil {
+	if err := s.buildHealthJSON(handler, config); err != nil {
 		s.logger.Warning("Failed to build health JSON: %v", err)
 	}
 
@@ -156,10 +156,10 @@ func (s *Server) Build(config BuildConfig) error {
 	return nil
 }
 
-// buildPage fetches a page from the internal server and writes it to disk.
+// buildPage renders a page through the handler and writes it to disk.
 // The template's {{if .StaticBuild}} block handles chrome-bundle.js injection.
-func (s *Server) buildPage(ts *httptest.Server, route string, config BuildConfig) error {
-	body, err := s.retryFetch(ts, route)
+func (s *Server) buildPage(handler http.Handler, route string, config BuildConfig) error {
+	body, err := renderURL(handler, route)
 	if err != nil {
 		return err
 	}
@@ -305,9 +305,9 @@ func (s *Server) buildLightdomCSS(config BuildConfig) error {
 	return os.WriteFile(outPath, []byte(combined.String()), 0o644)
 }
 
-// buildHealthJSON fetches health data from the internal server and writes it as static JSON.
-func (s *Server) buildHealthJSON(ts *httptest.Server, config BuildConfig) error {
-	body, err := s.retryFetch(ts, "/__cem/api/health")
+// buildHealthJSON renders the health API endpoint and writes it as static JSON.
+func (s *Server) buildHealthJSON(handler http.Handler, config BuildConfig) error {
+	body, err := renderURL(handler, "/__cem/api/health")
 	if err != nil {
 		return err
 	}
@@ -337,9 +337,9 @@ export class CEMReloadClient {
 	return os.WriteFile(outPath, []byte(stub), 0o644)
 }
 
-// buildUserSources walks the user's source directory and fetches each file
-// through the test server, which applies TS→JS and CSS transforms.
-func (s *Server) buildUserSources(ts *httptest.Server, config BuildConfig, demoRoutes map[string]*middleware.DemoRouteEntry) error {
+// buildUserSources walks the user's source directory and renders each file
+// through the handler, which applies TS→JS and CSS transforms.
+func (s *Server) buildUserSources(handler http.Handler, config BuildConfig, demoRoutes map[string]*middleware.DemoRouteEntry) error {
 	watchDir := s.WatchDir()
 	if watchDir == "" {
 		return nil
@@ -406,7 +406,7 @@ func (s *Server) buildUserSources(ts *httptest.Server, config BuildConfig, demoR
 				urlPath = strings.TrimSuffix(urlPath, ".ts") + ".js"
 			}
 
-			body, fetchErr := s.retryFetch(ts, urlPath)
+			body, fetchErr := renderURL(handler, urlPath)
 			if fetchErr != nil {
 				// Non-fatal: file may not be directly servable
 				return nil
@@ -436,7 +436,7 @@ func (s *Server) buildUserSources(ts *httptest.Server, config BuildConfig, demoR
 			// For CSS files, also create a .css.js wrapper (CSS module for JS import)
 			if ext == ".css" {
 				cssModuleURL := urlPath + "?__cem-import-attrs[type]=css"
-				jsBody, jsErr := s.retryFetch(ts, cssModuleURL)
+				jsBody, jsErr := renderURL(handler, cssModuleURL)
 				if jsErr == nil {
 					jsPath := outPath + ".js"
 					if writeErr := os.WriteFile(jsPath, jsBody, 0o644); writeErr != nil {
@@ -461,8 +461,8 @@ func (s *Server) buildUserSources(ts *httptest.Server, config BuildConfig, demoR
 }
 
 // buildDependencies copies node_modules files referenced by the import map.
-// Fetches through the test server so transforms are applied.
-func (s *Server) buildDependencies(ts *httptest.Server, config BuildConfig) error {
+// Renders through the handler so transforms are applied.
+func (s *Server) buildDependencies(handler http.Handler, config BuildConfig) error {
 	im := s.ImportMap()
 	if im == nil {
 		return nil
@@ -501,7 +501,7 @@ func (s *Server) buildDependencies(ts *httptest.Server, config BuildConfig) erro
 
 	count := 0
 	for _, urlPath := range paths {
-		body, err := s.retryFetch(ts, urlPath)
+		body, err := renderURL(handler, urlPath)
 		if err != nil {
 			s.logger.Debug("Skip dependency %s: %v", urlPath, err)
 			continue
@@ -519,7 +519,7 @@ func (s *Server) buildDependencies(ts *httptest.Server, config BuildConfig) erro
 		// Also copy source map if it exists
 		if strings.HasSuffix(urlPath, ".js") {
 			mapURL := urlPath + ".map"
-			mapBody, mapErr := s.retryFetch(ts, mapURL)
+			mapBody, mapErr := renderURL(handler, mapURL)
 			if mapErr == nil {
 				mapPath := outPath + ".map"
 				_ = os.WriteFile(mapPath, mapBody, 0o644)
@@ -692,57 +692,21 @@ func cdnURL(mode, pkg, subpath string) string {
 	}
 }
 
-// retryFetch wraps fetchURL with exponential backoff for transient errors.
-// It retries up to 3 times with delays of 100ms, 200ms, and 400ms.
-func (s *Server) retryFetch(ts *httptest.Server, urlPath string) ([]byte, error) {
-	const maxRetries = 3
-	delay := 100 * time.Millisecond
-	var lastErr error
-	for attempt := range maxRetries + 1 {
-		body, err := fetchURL(ts, urlPath)
-		if err == nil {
-			return body, nil
-		}
-		lastErr = err
-		if attempt < maxRetries && isTransientError(err) {
-			s.logger.Debug("Retry %d/%d for %s: %v", attempt+1, maxRetries, urlPath, err)
-			time.Sleep(delay)
-			delay *= 2
-			continue
-		}
-		break
-	}
-	return nil, lastErr
-}
-
-// isTransientError reports whether err looks like a temporary network
-// problem that may resolve on retry (EOF, connection reset/refused).
-func isTransientError(err error) bool {
-	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
-		return true
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "connection reset") ||
-		strings.Contains(msg, "connection refused")
-}
-
-// fetchURL fetches a URL path from the test server, returning the body bytes.
-func fetchURL(ts *httptest.Server, urlPath string) (retBody []byte, retErr error) {
-	resp, err := ts.Client().Get(ts.URL + urlPath)
+// renderURL renders a URL path through the handler in-process, returning the body bytes.
+// No HTTP server or TCP connection is involved.
+func renderURL(handler http.Handler, urlPath string) ([]byte, error) {
+	req, err := http.NewRequest("GET", urlPath, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating request for %s: %w", urlPath, err)
 	}
-	defer func() {
-		if closeErr := resp.Body.Close(); closeErr != nil && retErr == nil {
-			retErr = closeErr
-		}
-	}()
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	if w.Code != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d", w.Code)
 	}
 
-	return io.ReadAll(resp.Body)
+	return w.Body.Bytes(), nil
 }
 
 // rewriteAssetPaths rewrites absolute paths in JS and CSS assets for base path deployment.

--- a/serve/build.go
+++ b/serve/build.go
@@ -15,15 +15,16 @@ import (
 	"html"
 	"io/fs"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 
 	"bennypowers.dev/cem/serve/middleware"
 	"bennypowers.dev/cem/serve/middleware/importmap"
 	"bennypowers.dev/cem/serve/middleware/routes"
+	renderPkg "bennypowers.dev/cem/serve/render"
 )
 
 // BuildConfig holds configuration for static site generation.
@@ -78,17 +79,30 @@ func (s *Server) Build(config BuildConfig) error {
 	handler := s.Handler()
 
 	// Write the index listing page
-	if err := s.buildPage(handler, "/", config); err != nil {
+	indexBody, err := renderPkg.Page(handler, "/")
+	if err != nil {
 		return fmt.Errorf("build index: %w", err)
 	}
+	if err := writePage("/", indexBody, config); err != nil {
+		return fmt.Errorf("write index: %w", err)
+	}
 
-	// Write each demo page
-	var pageErrors error
+	// Render all demo pages concurrently
+	routeList := make([]string, 0, len(demoRoutes))
 	for route := range demoRoutes {
-		if err := s.buildPage(handler, route, config); err != nil {
-			s.logger.Error("Failed to build %s: %v", route, err)
-			pageErrors = errors.Join(pageErrors, fmt.Errorf("%s: %w", route, err))
+		routeList = append(routeList, route)
+	}
+	results := renderPkg.Pages(handler, routeList, runtime.NumCPU())
+
+	var pageErrors error
+	for _, res := range results {
+		if res.Err != nil {
+			s.logger.Error("Failed to build %s: %v", res.Route, res.Err)
+			pageErrors = errors.Join(pageErrors, fmt.Errorf("%s: %w", res.Route, res.Err))
 			continue
+		}
+		if err := writePage(res.Route, res.Body, config); err != nil {
+			return fmt.Errorf("write %s: %w", res.Route, err)
 		}
 	}
 	if pageErrors != nil {
@@ -156,14 +170,8 @@ func (s *Server) Build(config BuildConfig) error {
 	return nil
 }
 
-// buildPage renders a page through the handler and writes it to disk.
-// The template's {{if .StaticBuild}} block handles chrome-bundle.js injection.
-func (s *Server) buildPage(handler http.Handler, route string, config BuildConfig) error {
-	body, err := renderURL(handler, route)
-	if err != nil {
-		return err
-	}
-
+// writePage writes rendered page bytes to disk, applying base path rewrites.
+func writePage(route string, body []byte, config BuildConfig) error {
 	// Rewrite absolute URLs with base path prefix
 	if config.BasePath != "" {
 		body = rewriteBasePath(body, config.BasePath)
@@ -307,7 +315,7 @@ func (s *Server) buildLightdomCSS(config BuildConfig) error {
 
 // buildHealthJSON renders the health API endpoint and writes it as static JSON.
 func (s *Server) buildHealthJSON(handler http.Handler, config BuildConfig) error {
-	body, err := renderURL(handler, "/__cem/api/health")
+	body, err := renderPkg.Page(handler, "/__cem/api/health")
 	if err != nil {
 		return err
 	}
@@ -406,7 +414,7 @@ func (s *Server) buildUserSources(handler http.Handler, config BuildConfig, demo
 				urlPath = strings.TrimSuffix(urlPath, ".ts") + ".js"
 			}
 
-			body, fetchErr := renderURL(handler, urlPath)
+			body, fetchErr := renderPkg.Page(handler, urlPath)
 			if fetchErr != nil {
 				// Non-fatal: file may not be directly servable
 				return nil
@@ -436,7 +444,7 @@ func (s *Server) buildUserSources(handler http.Handler, config BuildConfig, demo
 			// For CSS files, also create a .css.js wrapper (CSS module for JS import)
 			if ext == ".css" {
 				cssModuleURL := urlPath + "?__cem-import-attrs[type]=css"
-				jsBody, jsErr := renderURL(handler, cssModuleURL)
+				jsBody, jsErr := renderPkg.Page(handler, cssModuleURL)
 				if jsErr == nil {
 					jsPath := outPath + ".js"
 					if writeErr := os.WriteFile(jsPath, jsBody, 0o644); writeErr != nil {
@@ -501,7 +509,7 @@ func (s *Server) buildDependencies(handler http.Handler, config BuildConfig) err
 
 	count := 0
 	for _, urlPath := range paths {
-		body, err := renderURL(handler, urlPath)
+		body, err := renderPkg.Page(handler, urlPath)
 		if err != nil {
 			s.logger.Debug("Skip dependency %s: %v", urlPath, err)
 			continue
@@ -519,7 +527,7 @@ func (s *Server) buildDependencies(handler http.Handler, config BuildConfig) err
 		// Also copy source map if it exists
 		if strings.HasSuffix(urlPath, ".js") {
 			mapURL := urlPath + ".map"
-			mapBody, mapErr := renderURL(handler, mapURL)
+			mapBody, mapErr := renderPkg.Page(handler, mapURL)
 			if mapErr == nil {
 				mapPath := outPath + ".map"
 				_ = os.WriteFile(mapPath, mapBody, 0o644)
@@ -690,23 +698,6 @@ func cdnURL(mode, pkg, subpath string) string {
 		// Shouldn't happen, return original
 		return "/node_modules/" + pkg
 	}
-}
-
-// renderURL renders a URL path through the handler in-process, returning the body bytes.
-// No HTTP server or TCP connection is involved.
-func renderURL(handler http.Handler, urlPath string) ([]byte, error) {
-	req, err := http.NewRequest("GET", urlPath, nil)
-	if err != nil {
-		return nil, fmt.Errorf("creating request for %s: %w", urlPath, err)
-	}
-	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		return nil, fmt.Errorf("HTTP %d", w.Code)
-	}
-
-	return w.Body.Bytes(), nil
 }
 
 // rewriteAssetPaths rewrites absolute paths in JS and CSS assets for base path deployment.

--- a/serve/build.go
+++ b/serve/build.go
@@ -416,8 +416,7 @@ func (s *Server) buildUserSources(handler http.Handler, config BuildConfig, demo
 
 			body, fetchErr := renderPkg.Page(handler, urlPath)
 			if fetchErr != nil {
-				// Non-fatal: file may not be directly servable
-				return nil
+				return fmt.Errorf("transform %s: %w", urlPath, fetchErr)
 			}
 
 			// For JS/TS files, rewrite CSS import attribute query params to .js extension
@@ -511,8 +510,7 @@ func (s *Server) buildDependencies(handler http.Handler, config BuildConfig) err
 	for _, urlPath := range paths {
 		body, err := renderPkg.Page(handler, urlPath)
 		if err != nil {
-			s.logger.Debug("Skip dependency %s: %v", urlPath, err)
-			continue
+			return fmt.Errorf("vendor dependency %s: %w", urlPath, err)
 		}
 
 		outPath := filepath.Join(config.siteRoot(), urlPath)

--- a/serve/build.go
+++ b/serve/build.go
@@ -10,6 +10,7 @@ the Free Software Foundation, either version 3 of the License, or
 package serve
 
 import (
+	"errors"
 	"fmt"
 	"html"
 	"io"
@@ -20,6 +21,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"bennypowers.dev/cem/serve/middleware"
 	"bennypowers.dev/cem/serve/middleware/importmap"
@@ -81,11 +83,16 @@ func (s *Server) Build(config BuildConfig) error {
 	}
 
 	// Write each demo page
+	var pageErrors error
 	for route := range demoRoutes {
 		if err := s.buildPage(ts, route, config); err != nil {
-			s.logger.Warning("Failed to build %s: %v", route, err)
+			s.logger.Error("Failed to build %s: %v", route, err)
+			pageErrors = errors.Join(pageErrors, fmt.Errorf("%s: %w", route, err))
 			continue
 		}
+	}
+	if pageErrors != nil {
+		return fmt.Errorf("failed to build pages: %w", pageErrors)
 	}
 
 	// Copy chrome bundle
@@ -151,22 +158,8 @@ func (s *Server) Build(config BuildConfig) error {
 
 // buildPage fetches a page from the internal server and writes it to disk.
 // The template's {{if .StaticBuild}} block handles chrome-bundle.js injection.
-func (s *Server) buildPage(ts *httptest.Server, route string, config BuildConfig) (retErr error) {
-	resp, err := ts.Client().Get(ts.URL + route)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if closeErr := resp.Body.Close(); closeErr != nil && retErr == nil {
-			retErr = closeErr
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("HTTP %d for %s", resp.StatusCode, route)
-	}
-
-	body, err := io.ReadAll(resp.Body)
+func (s *Server) buildPage(ts *httptest.Server, route string, config BuildConfig) error {
+	body, err := s.retryFetch(ts, route)
 	if err != nil {
 		return err
 	}
@@ -313,22 +306,8 @@ func (s *Server) buildLightdomCSS(config BuildConfig) error {
 }
 
 // buildHealthJSON fetches health data from the internal server and writes it as static JSON.
-func (s *Server) buildHealthJSON(ts *httptest.Server, config BuildConfig) (retErr error) {
-	resp, err := ts.Client().Get(ts.URL + "/__cem/api/health")
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if closeErr := resp.Body.Close(); closeErr != nil && retErr == nil {
-			retErr = closeErr
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("health API returned %d", resp.StatusCode)
-	}
-
-	body, err := io.ReadAll(resp.Body)
+func (s *Server) buildHealthJSON(ts *httptest.Server, config BuildConfig) error {
+	body, err := s.retryFetch(ts, "/__cem/api/health")
 	if err != nil {
 		return err
 	}
@@ -427,7 +406,7 @@ func (s *Server) buildUserSources(ts *httptest.Server, config BuildConfig, demoR
 				urlPath = strings.TrimSuffix(urlPath, ".ts") + ".js"
 			}
 
-			body, fetchErr := fetchURL(ts, urlPath)
+			body, fetchErr := s.retryFetch(ts, urlPath)
 			if fetchErr != nil {
 				// Non-fatal: file may not be directly servable
 				return nil
@@ -457,7 +436,7 @@ func (s *Server) buildUserSources(ts *httptest.Server, config BuildConfig, demoR
 			// For CSS files, also create a .css.js wrapper (CSS module for JS import)
 			if ext == ".css" {
 				cssModuleURL := urlPath + "?__cem-import-attrs[type]=css"
-				jsBody, jsErr := fetchURL(ts, cssModuleURL)
+				jsBody, jsErr := s.retryFetch(ts, cssModuleURL)
 				if jsErr == nil {
 					jsPath := outPath + ".js"
 					if writeErr := os.WriteFile(jsPath, jsBody, 0o644); writeErr != nil {
@@ -522,7 +501,7 @@ func (s *Server) buildDependencies(ts *httptest.Server, config BuildConfig) erro
 
 	count := 0
 	for _, urlPath := range paths {
-		body, err := fetchURL(ts, urlPath)
+		body, err := s.retryFetch(ts, urlPath)
 		if err != nil {
 			s.logger.Debug("Skip dependency %s: %v", urlPath, err)
 			continue
@@ -540,7 +519,7 @@ func (s *Server) buildDependencies(ts *httptest.Server, config BuildConfig) erro
 		// Also copy source map if it exists
 		if strings.HasSuffix(urlPath, ".js") {
 			mapURL := urlPath + ".map"
-			mapBody, mapErr := fetchURL(ts, mapURL)
+			mapBody, mapErr := s.retryFetch(ts, mapURL)
 			if mapErr == nil {
 				mapPath := outPath + ".map"
 				_ = os.WriteFile(mapPath, mapBody, 0o644)
@@ -711,6 +690,40 @@ func cdnURL(mode, pkg, subpath string) string {
 		// Shouldn't happen, return original
 		return "/node_modules/" + pkg
 	}
+}
+
+// retryFetch wraps fetchURL with exponential backoff for transient errors.
+// It retries up to 3 times with delays of 100ms, 200ms, and 400ms.
+func (s *Server) retryFetch(ts *httptest.Server, urlPath string) ([]byte, error) {
+	const maxRetries = 3
+	delay := 100 * time.Millisecond
+	var lastErr error
+	for attempt := range maxRetries + 1 {
+		body, err := fetchURL(ts, urlPath)
+		if err == nil {
+			return body, nil
+		}
+		lastErr = err
+		if attempt < maxRetries && isTransientError(err) {
+			s.logger.Debug("Retry %d/%d for %s: %v", attempt+1, maxRetries, urlPath, err)
+			time.Sleep(delay)
+			delay *= 2
+			continue
+		}
+		break
+	}
+	return nil, lastErr
+}
+
+// isTransientError reports whether err looks like a temporary network
+// problem that may resolve on retry (EOF, connection reset/refused).
+func isTransientError(err error) bool {
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "connection refused")
 }
 
 // fetchURL fetches a URL path from the test server, returning the body bytes.

--- a/serve/build.go
+++ b/serve/build.go
@@ -92,6 +92,7 @@ func (s *Server) Build(config BuildConfig) error {
 	for route := range demoRoutes {
 		routeList = append(routeList, route)
 	}
+	sort.Strings(routeList)
 	results := renderPkg.Pages(handler, routeList, runtime.NumCPU())
 
 	var pageErrors error
@@ -444,13 +445,14 @@ func (s *Server) buildUserSources(handler http.Handler, config BuildConfig, demo
 			if ext == ".css" {
 				cssModuleURL := urlPath + "?__cem-import-attrs[type]=css"
 				jsBody, jsErr := renderPkg.Page(handler, cssModuleURL)
-				if jsErr == nil {
-					jsPath := outPath + ".js"
-					if writeErr := os.WriteFile(jsPath, jsBody, 0o644); writeErr != nil {
-						return writeErr
-					}
-					count++
+				if jsErr != nil {
+					return fmt.Errorf("transform CSS module %s: %w", cssModuleURL, jsErr)
 				}
+				jsPath := outPath + ".js"
+				if writeErr := os.WriteFile(jsPath, jsBody, 0o644); writeErr != nil {
+					return writeErr
+				}
+				count++
 			}
 
 			return nil

--- a/serve/build_test.go
+++ b/serve/build_test.go
@@ -11,7 +11,6 @@ package serve
 
 import (
 	"io/fs"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -476,34 +475,6 @@ func TestRewriteJSONScopeKeys(t *testing.T) {
 				t.Errorf("rewriteJSONScopeKeys() = %q, want %q", got, tt.want)
 			}
 		})
-	}
-}
-
-func TestRenderURL_Success(t *testing.T) {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("hello"))
-	})
-
-	body, err := renderURL(handler, "/test")
-	if err != nil {
-		t.Fatalf("renderURL() error: %v", err)
-	}
-	if string(body) != "hello" {
-		t.Errorf("renderURL() = %q, want %q", string(body), "hello")
-	}
-}
-
-func TestRenderURL_NonOKStatus(t *testing.T) {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	})
-
-	_, err := renderURL(handler, "/fail")
-	if err == nil {
-		t.Fatal("expected error for 500 response")
-	}
-	if !strings.Contains(err.Error(), "HTTP 500") {
-		t.Errorf("expected HTTP 500 error, got: %v", err)
 	}
 }
 

--- a/serve/build_test.go
+++ b/serve/build_test.go
@@ -586,8 +586,11 @@ func TestIsTransientError(t *testing.T) {
 	}{
 		{"EOF", io.EOF, true},
 		{"unexpected EOF", io.ErrUnexpectedEOF, true},
+		{"wrapped EOF", fmt.Errorf("Get http://...: %w", io.EOF), true},
 		{"connection reset", &net.OpError{Op: "read", Err: &os.SyscallError{Syscall: "read", Err: fmt.Errorf("connection reset by peer")}}, true},
-		{"not found", fmt.Errorf("HTTP 404"), false},
+		{"connection refused", &net.OpError{Op: "dial", Err: &os.SyscallError{Syscall: "connect", Err: fmt.Errorf("connection refused")}}, true},
+		{"HTTP 404", fmt.Errorf("HTTP 404"), false},
+		{"timeout", &net.OpError{Op: "read", Err: &os.SyscallError{Syscall: "read", Err: fmt.Errorf("i/o timeout")}}, false},
 	}
 
 	for _, tt := range tests {

--- a/serve/build_test.go
+++ b/serve/build_test.go
@@ -10,11 +10,19 @@ the Free Software Foundation, either version 3 of the License, or
 package serve
 
 import (
+	"fmt"
+	"io"
 	"io/fs"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+
+	"bennypowers.dev/cem/serve/logger"
 )
 
 func TestSiteRoot(t *testing.T) {
@@ -471,6 +479,121 @@ func TestRewriteJSONScopeKeys(t *testing.T) {
 			got := rewriteJSONScopeKeys(tt.input, tt.basePath)
 			if got != tt.want {
 				t.Errorf("rewriteJSONScopeKeys() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRetryFetch_SucceedsOnFirstAttempt(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer ts.Close()
+
+	s := &Server{logger: logger.NewDefaultLogger()}
+	body, err := s.retryFetch(ts, "/test")
+	if err != nil {
+		t.Fatalf("retryFetch() error: %v", err)
+	}
+	if string(body) != "ok" {
+		t.Errorf("retryFetch() = %q, want %q", string(body), "ok")
+	}
+}
+
+func TestRetryFetch_RetriesOnEOF(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := attempts.Add(1)
+		if n <= 2 {
+			// Simulate EOF by hijacking the connection and closing it
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatal("server does not support hijacking")
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = conn.Close()
+			return
+		}
+		_, _ = w.Write([]byte("recovered"))
+	}))
+	defer ts.Close()
+
+	s := &Server{logger: logger.NewDefaultLogger()}
+	body, err := s.retryFetch(ts, "/test")
+	if err != nil {
+		t.Fatalf("retryFetch() error after retries: %v", err)
+	}
+	if string(body) != "recovered" {
+		t.Errorf("retryFetch() = %q, want %q", string(body), "recovered")
+	}
+	if got := attempts.Load(); got != 3 {
+		t.Errorf("expected 3 attempts, got %d", got)
+	}
+}
+
+func TestRetryFetch_DoesNotRetryHTTPErrors(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	s := &Server{logger: logger.NewDefaultLogger()}
+	_, err := s.retryFetch(ts, "/missing")
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Errorf("expected 1 attempt for HTTP error, got %d", got)
+	}
+}
+
+func TestRetryFetch_ExhaustsRetries(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatal("server does not support hijacking")
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = conn.Close()
+	}))
+	defer ts.Close()
+
+	s := &Server{logger: logger.NewDefaultLogger()}
+	_, err := s.retryFetch(ts, "/always-fail")
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if got := attempts.Load(); got != 4 {
+		t.Errorf("expected 4 attempts (1 + 3 retries), got %d", got)
+	}
+}
+
+func TestIsTransientError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"EOF", io.EOF, true},
+		{"unexpected EOF", io.ErrUnexpectedEOF, true},
+		{"connection reset", &net.OpError{Op: "read", Err: &os.SyscallError{Syscall: "read", Err: fmt.Errorf("connection reset by peer")}}, true},
+		{"not found", fmt.Errorf("HTTP 404"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTransientError(tt.err); got != tt.want {
+				t.Errorf("isTransientError(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
 	}

--- a/serve/build_test.go
+++ b/serve/build_test.go
@@ -484,6 +484,21 @@ func TestRewriteJSONScopeKeys(t *testing.T) {
 	}
 }
 
+// forceCloseConnection hijacks an HTTP connection and closes it immediately,
+// causing the client to see an EOF error. Panics if hijacking fails (which
+// would indicate a broken test server, not a test failure).
+func forceCloseConnection(w http.ResponseWriter) {
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		panic("test server does not support hijacking")
+	}
+	conn, _, err := hj.Hijack()
+	if err != nil {
+		panic(fmt.Sprintf("hijack failed: %v", err))
+	}
+	_ = conn.Close()
+}
+
 func TestRetryFetch_SucceedsOnFirstAttempt(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("ok"))
@@ -506,15 +521,7 @@ func TestRetryFetch_RetriesOnEOF(t *testing.T) {
 		n := attempts.Add(1)
 		if n <= 2 {
 			// Simulate EOF by hijacking the connection and closing it
-			hj, ok := w.(http.Hijacker)
-			if !ok {
-				t.Fatal("server does not support hijacking")
-			}
-			conn, _, err := hj.Hijack()
-			if err != nil {
-				t.Fatal(err)
-			}
-			_ = conn.Close()
+			forceCloseConnection(w)
 			return
 		}
 		_, _ = w.Write([]byte("recovered"))
@@ -556,15 +563,7 @@ func TestRetryFetch_ExhaustsRetries(t *testing.T) {
 	var attempts atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		attempts.Add(1)
-		hj, ok := w.(http.Hijacker)
-		if !ok {
-			t.Fatal("server does not support hijacking")
-		}
-		conn, _, err := hj.Hijack()
-		if err != nil {
-			t.Fatal(err)
-		}
-		_ = conn.Close()
+		forceCloseConnection(w)
 	}))
 	defer ts.Close()
 

--- a/serve/build_test.go
+++ b/serve/build_test.go
@@ -22,6 +22,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"bennypowers.dev/cem/internal/platform"
 	"bennypowers.dev/cem/serve/logger"
 )
 
@@ -595,6 +596,69 @@ func TestIsTransientError(t *testing.T) {
 				t.Errorf("isTransientError(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestBuild_ReturnsErrorOnPageFailure verifies that Build() returns a non-nil
+// error when a demo page fetch fails, instead of silently succeeding.
+func TestBuild_ReturnsErrorOnPageFailure(t *testing.T) {
+	// Manifest with two elements: one demo file will exist, one won't.
+	manifest := []byte(`{
+  "schemaVersion": "1.0.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/el-ok.ts",
+      "declarations": [{
+        "kind": "class",
+        "customElement": true,
+        "name": "ElOk",
+        "tagName": "el-ok",
+        "demos": [{"description": "OK", "url": "./demo/exists.html"}]
+      }]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/el-bad.ts",
+      "declarations": [{
+        "kind": "class",
+        "customElement": true,
+        "name": "ElBad",
+        "tagName": "el-bad",
+        "demos": [{"description": "Bad", "url": "./demo/missing.html"}]
+      }]
+    }
+  ]
+}`)
+
+	// Create a MapFileSystem with only the "exists" demo file present.
+	mfs := platform.NewMapFileSystem(nil)
+	mfs.AddFile("/test/demo/exists.html", `<el-ok>hello</el-ok>`, 0o644)
+	// Deliberately omit /test/demo/missing.html
+
+	server, err := NewServerWithConfig(Config{
+		Port:   0,
+		Reload: false,
+		FS:     mfs,
+	})
+	if err != nil {
+		t.Fatalf("NewServerWithConfig: %v", err)
+	}
+
+	if err := server.SetWatchDir("/test"); err != nil {
+		t.Fatalf("SetWatchDir: %v", err)
+	}
+	if err := server.SetManifest(manifest); err != nil {
+		t.Fatalf("SetManifest: %v", err)
+	}
+
+	// Build should fail because the missing demo file causes HTTP 500.
+	buildErr := server.Build(BuildConfig{OutputDir: t.TempDir()})
+	if buildErr == nil {
+		t.Fatal("expected Build() to return an error when a page fetch fails, got nil")
+	}
+	if !strings.Contains(buildErr.Error(), "failed to build pages") {
+		t.Errorf("expected error about failed pages, got: %v", buildErr)
 	}
 }
 

--- a/serve/build_test.go
+++ b/serve/build_test.go
@@ -10,20 +10,14 @@ the Free Software Foundation, either version 3 of the License, or
 package serve
 
 import (
-	"fmt"
-	"io"
 	"io/fs"
-	"net"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
-	"sync/atomic"
 	"testing"
 
 	"bennypowers.dev/cem/internal/platform"
-	"bennypowers.dev/cem/serve/logger"
 )
 
 func TestSiteRoot(t *testing.T) {
@@ -485,120 +479,31 @@ func TestRewriteJSONScopeKeys(t *testing.T) {
 	}
 }
 
-// forceCloseConnection hijacks an HTTP connection and closes it immediately,
-// causing the client to see an EOF error. Panics if hijacking fails (which
-// would indicate a broken test server, not a test failure).
-func forceCloseConnection(w http.ResponseWriter) {
-	hj, ok := w.(http.Hijacker)
-	if !ok {
-		panic("test server does not support hijacking")
-	}
-	conn, _, err := hj.Hijack()
-	if err != nil {
-		panic(fmt.Sprintf("hijack failed: %v", err))
-	}
-	_ = conn.Close()
-}
+func TestRenderURL_Success(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("hello"))
+	})
 
-func TestRetryFetch_SucceedsOnFirstAttempt(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("ok"))
-	}))
-	defer ts.Close()
-
-	s := &Server{logger: logger.NewDefaultLogger()}
-	body, err := s.retryFetch(ts, "/test")
+	body, err := renderURL(handler, "/test")
 	if err != nil {
-		t.Fatalf("retryFetch() error: %v", err)
+		t.Fatalf("renderURL() error: %v", err)
 	}
-	if string(body) != "ok" {
-		t.Errorf("retryFetch() = %q, want %q", string(body), "ok")
+	if string(body) != "hello" {
+		t.Errorf("renderURL() = %q, want %q", string(body), "hello")
 	}
 }
 
-func TestRetryFetch_RetriesOnEOF(t *testing.T) {
-	var attempts atomic.Int32
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		n := attempts.Add(1)
-		if n <= 2 {
-			// Simulate EOF by hijacking the connection and closing it
-			forceCloseConnection(w)
-			return
-		}
-		_, _ = w.Write([]byte("recovered"))
-	}))
-	defer ts.Close()
+func TestRenderURL_NonOKStatus(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
 
-	s := &Server{logger: logger.NewDefaultLogger()}
-	body, err := s.retryFetch(ts, "/test")
-	if err != nil {
-		t.Fatalf("retryFetch() error after retries: %v", err)
-	}
-	if string(body) != "recovered" {
-		t.Errorf("retryFetch() = %q, want %q", string(body), "recovered")
-	}
-	if got := attempts.Load(); got != 3 {
-		t.Errorf("expected 3 attempts, got %d", got)
-	}
-}
-
-func TestRetryFetch_DoesNotRetryHTTPErrors(t *testing.T) {
-	var attempts atomic.Int32
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		attempts.Add(1)
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer ts.Close()
-
-	s := &Server{logger: logger.NewDefaultLogger()}
-	_, err := s.retryFetch(ts, "/missing")
+	_, err := renderURL(handler, "/fail")
 	if err == nil {
-		t.Fatal("expected error for 404 response")
+		t.Fatal("expected error for 500 response")
 	}
-	if got := attempts.Load(); got != 1 {
-		t.Errorf("expected 1 attempt for HTTP error, got %d", got)
-	}
-}
-
-func TestRetryFetch_ExhaustsRetries(t *testing.T) {
-	var attempts atomic.Int32
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		attempts.Add(1)
-		forceCloseConnection(w)
-	}))
-	defer ts.Close()
-
-	s := &Server{logger: logger.NewDefaultLogger()}
-	_, err := s.retryFetch(ts, "/always-fail")
-	if err == nil {
-		t.Fatal("expected error after exhausting retries")
-	}
-	if got := attempts.Load(); got != 4 {
-		t.Errorf("expected 4 attempts (1 + 3 retries), got %d", got)
-	}
-}
-
-func TestIsTransientError(t *testing.T) {
-	tests := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{"EOF", io.EOF, true},
-		{"unexpected EOF", io.ErrUnexpectedEOF, true},
-		{"wrapped EOF", fmt.Errorf("Get http://...: %w", io.EOF), true},
-		{"connection reset", &net.OpError{Op: "read", Err: &os.SyscallError{Syscall: "read", Err: fmt.Errorf("connection reset by peer")}}, true},
-		{"connection refused", &net.OpError{Op: "dial", Err: &os.SyscallError{Syscall: "connect", Err: fmt.Errorf("connection refused")}}, true},
-		{"HTTP 404", fmt.Errorf("HTTP 404"), false},
-		{"timeout", &net.OpError{Op: "read", Err: &os.SyscallError{Syscall: "read", Err: fmt.Errorf("i/o timeout")}}, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := isTransientError(tt.err); got != tt.want {
-				t.Errorf("isTransientError(%v) = %v, want %v", tt.err, got, tt.want)
-			}
-		})
+	if !strings.Contains(err.Error(), "HTTP 500") {
+		t.Errorf("expected HTTP 500 error, got: %v", err)
 	}
 }
 

--- a/serve/render/render.go
+++ b/serve/render/render.go
@@ -29,10 +29,7 @@ type PageResult struct {
 // No HTTP server or TCP connection is involved. Panics in the handler
 // are recovered and returned as errors.
 func Page(handler http.Handler, urlPath string) (body []byte, err error) {
-	req, reqErr := http.NewRequest("GET", urlPath, nil)
-	if reqErr != nil {
-		return nil, fmt.Errorf("creating request for %s: %w", urlPath, reqErr)
-	}
+	req := httptest.NewRequest("GET", urlPath, nil)
 	w := httptest.NewRecorder()
 
 	defer func() {

--- a/serve/render/render.go
+++ b/serve/render/render.go
@@ -1,0 +1,77 @@
+/*
+Copyright © 2025 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+// Package render provides in-process page rendering for static site generation.
+// It is shared by both the dev server (serve) and the build command (serve --build).
+package render
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+)
+
+// PageResult holds the outcome of rendering a single page.
+type PageResult struct {
+	Route string
+	Body  []byte
+	Err   error
+}
+
+// Page renders a single URL path through the handler in-process.
+// No HTTP server or TCP connection is involved. Panics in the handler
+// are recovered and returned as errors.
+func Page(handler http.Handler, urlPath string) (body []byte, err error) {
+	req, reqErr := http.NewRequest("GET", urlPath, nil)
+	if reqErr != nil {
+		return nil, fmt.Errorf("creating request for %s: %w", urlPath, reqErr)
+	}
+	w := httptest.NewRecorder()
+
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic rendering %s: %v", urlPath, r)
+		}
+	}()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d for %s", w.Code, urlPath)
+	}
+	return w.Body.Bytes(), nil
+}
+
+// Pages renders multiple URL paths concurrently through the handler.
+// Concurrency is bounded by the concurrency parameter. Each page has
+// independent panic recovery.
+func Pages(handler http.Handler, routes []string, concurrency int) []PageResult {
+	if concurrency < 1 {
+		concurrency = 1
+	}
+
+	results := make([]PageResult, len(routes))
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+
+	for i, route := range routes {
+		wg.Add(1)
+		go func(i int, route string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			body, err := Page(handler, route)
+			results[i] = PageResult{Route: route, Body: body, Err: err}
+		}(i, route)
+	}
+
+	wg.Wait()
+	return results
+}

--- a/serve/render/render_test.go
+++ b/serve/render/render_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright © 2025 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+package render
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestPage_Success(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("hello"))
+	})
+
+	body, err := Page(handler, "/test")
+	if err != nil {
+		t.Fatalf("Page() error: %v", err)
+	}
+	if string(body) != "hello" {
+		t.Errorf("Page() = %q, want %q", string(body), "hello")
+	}
+}
+
+func TestPage_NonOKStatus(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := Page(handler, "/fail")
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+	if !strings.Contains(err.Error(), "HTTP 500") {
+		t.Errorf("expected HTTP 500 error, got: %v", err)
+	}
+}
+
+func TestPage_RecoversPanic(t *testing.T) {
+	handler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		panic("renderer exploded")
+	})
+
+	_, err := Page(handler, "/boom")
+	if err == nil {
+		t.Fatal("expected error from recovered panic")
+	}
+	if !strings.Contains(err.Error(), "panic rendering /boom") {
+		t.Errorf("expected panic error, got: %v", err)
+	}
+}
+
+func TestPages_Concurrent(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("page:" + r.URL.Path))
+	})
+
+	routes := []string{"/a", "/b", "/c", "/d"}
+	results := Pages(handler, routes, 2)
+
+	if len(results) != 4 {
+		t.Fatalf("expected 4 results, got %d", len(results))
+	}
+
+	// Results should be in the same order as input routes
+	for i, res := range results {
+		if res.Route != routes[i] {
+			t.Errorf("result[%d].Route = %q, want %q", i, res.Route, routes[i])
+		}
+		if res.Err != nil {
+			t.Errorf("result[%d] unexpected error: %v", i, res.Err)
+		}
+		want := "page:" + routes[i]
+		if string(res.Body) != want {
+			t.Errorf("result[%d].Body = %q, want %q", i, string(res.Body), want)
+		}
+	}
+}
+
+func TestPages_PanicIsolation(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/bad" {
+			panic("nil pointer")
+		}
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	routes := []string{"/good", "/bad", "/also-good"}
+	results := Pages(handler, routes, 2)
+
+	// /good and /also-good should succeed
+	if results[0].Err != nil {
+		t.Errorf("/good should succeed, got: %v", results[0].Err)
+	}
+	if results[2].Err != nil {
+		t.Errorf("/also-good should succeed, got: %v", results[2].Err)
+	}
+
+	// /bad should have a panic error
+	if results[1].Err == nil {
+		t.Fatal("/bad should have a panic error")
+	}
+	if !strings.Contains(results[1].Err.Error(), "panic") {
+		t.Errorf("expected panic error for /bad, got: %v", results[1].Err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #288

### Root cause

A nil pointer dereference in `RenderableCustomElementDeclarations()` (`manifest/context.go:136`) panicked on every demo page render. When a `CustomElementExport` had no matching `CustomElementDeclaration` in the same module, a map lookup returned nil and the next line dereferenced it.

Go's `net/http` has built-in panic recovery that catches panics and closes the connection. Clients saw EOF. This is why retries didn't help: every request panicked, and panic recovery closed the connection every time.

### Fix

1. **Nil guard** in `RenderableCustomElementDeclarations()` -- skip exports with no matching declaration
2. **In-process rendering** -- replaced `httptest.NewServer` with direct `handler.ServeHTTP()` calls, eliminating TCP connections entirely. This also removed the panic recovery that was masking the bug.
3. **`serve/render` package** -- shared rendering interface used by both serve (indirectly, via handler) and build (directly):
   - `render.Page()` renders a single URL in-process with panic recovery
   - `render.Pages()` renders multiple URLs concurrently with bounded concurrency
4. **Parallel page rendering** -- demo pages are rendered concurrently via `render.Pages()`, bounded by `runtime.NumCPU()`. Rendering and disk I/O are decoupled.
5. **Exit non-zero** when any page fails to build, with errors accumulated via `errors.Join`

### Performance

- **Build**: pages render in parallel (NumCPU goroutines), no HTTP server, no TCP overhead. One panicking page cannot crash the build or affect others.
- **Serve**: the nil dereference fix eliminates the panics that were causing EOF errors. Pages that were failing now render correctly.

## Test plan

- [x] `TestRenderableCustomElementDeclarations_ExportWithoutDeclaration` -- nil deref regression test
- [x] `TestPage_RecoversPanic` -- panic recovery in render package
- [x] `TestPages_PanicIsolation` -- one panicking page doesn't affect others
- [x] `TestPages_Concurrent` -- concurrent rendering preserves result order
- [x] `TestBuild_ReturnsErrorOnPageFailure` -- Build() returns error on page failure
- [x] All 2318 tests pass
- [x] `golangci-lint` clean
- [ ] Validate on CI with chickadee project (29 elements, ~129 pages)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed potential panic when processing custom element re-exports without matching declarations.

* **Performance Improvements**
  * Static page builds now use in-process rendering instead of HTTP requests, enabling concurrent page generation for faster build times.
  * Enhanced build error reporting with aggregated error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->