### PR TITLE
feat(generate): support YAML frontmatter in demo HTML files

### DIFF
--- a/docs/content/docs/reference/configuration.md
+++ b/docs/content/docs/reference/configuration.md
@@ -474,9 +474,31 @@ PathResolver: mapped source found: /dist/button.js -> /src/button.ts (pattern: /
 
 The demo discovery system supports multiple ways to control how demos are associated with elements and how their URLs are generated.
 
+### YAML Frontmatter
+
+Demos can use YAML frontmatter to declare metadata, URLs, and element associations:
+
+```html
+---
+description: Primary variant demonstration
+url: /elements/call-to-action/demo/
+for: rh-button pf-button
+---
+<rh-button>Click me</rh-button>
+```
+
+All frontmatter fields are optional:
+
+| Field | Description |
+|-------|-------------|
+| `description` | A description of the demo (plain text or markdown) |
+| `url` | Explicit URL for this demo, overriding URLPattern generation |
+| `for` | Space-separated list of element tag names this demo is for (by default, all custom elements used in the demo are associated automatically) |
+
 ### HTML5 Microdata
 
-Demos can use HTML5 microdata to explicitly declare their URLs and associations:
+Demos can also use HTML5 microdata to declare their URLs and associations.
+Frontmatter takes precedence when both are present in the same file.
 
 ```html
 <!-- Explicit URL declaration -->
@@ -497,11 +519,12 @@ Showcases primary variant with styling, accessibility, and interaction states.
 
 The system uses the following priority order to associate demos with elements:
 
-1. **Explicit microdata**: `<meta itemprop="demo-for" content="element-name">`
-2. **Path-based** (only when `urlPattern` is configured): Elements whose tag names appear in demo file paths
-3. **Content-based**: Custom elements found in the demo HTML
+1. **Frontmatter**: `for` field in YAML frontmatter
+2. **Explicit microdata**: `<meta itemprop="demo-for" content="element-name">`
+3. **Path-based** (only when `urlPattern` is configured): Elements whose tag names appear in demo file paths
+4. **Content-based**: Custom elements found in the demo HTML
 
-**Note**: Path-based association is disabled when `urlPattern` is not configured. In that case, the system uses only explicit microdata (priority 1) and content-based discovery (priority 3).
+**Note**: Path-based association is disabled when `urlPattern` is not configured. In that case, the system uses frontmatter (priority 1), explicit microdata (priority 2), and content-based discovery (priority 4).
 
 #### Path-Based Association with URLPattern
 
@@ -534,18 +557,20 @@ demoDiscovery:
 
 ### Description Sources
 
-Demo descriptions are extracted exclusively from microdata:
+Demo descriptions are extracted from (in priority order):
 
-- **Meta tags**: `<meta itemprop="description" content="Simple description">`
-- **Script tags**: `<script type="text/markdown" itemprop="description">Rich **markdown** content</script>`
+1. **Frontmatter**: `description` field in YAML frontmatter
+2. **Meta tags**: `<meta itemprop="description" content="Simple description">`
+3. **Script tags**: `<script type="text/markdown" itemprop="description">Rich **markdown** content</script>`
 
 ### URL Generation Priority
 
 URLs are generated using the following priority:
 
-1. **Explicit microdata**: `<meta itemprop="demo-url" content="/path/to/demo/">`
-2. **URLPattern fallback**: Using `urlPattern` and `urlTemplate` configuration
-3. **No URL**: Demo is skipped if no pattern matches
+1. **Frontmatter**: `url` field in YAML frontmatter
+2. **Explicit microdata**: `<meta itemprop="demo-url" content="/path/to/demo/">`
+3. **URLPattern fallback**: Using `urlPattern` and `urlTemplate` configuration
+4. **No URL**: Demo is skipped if no pattern matches
 
 ### URL Template Functions
 
@@ -578,7 +603,7 @@ urlTemplate: "https://example.com/{{alias .component}}/{{slug .demo}}/"
 
 ### Configuration Examples
 
-**Minimal (microdata-driven):**
+**Minimal (frontmatter-driven):**
 ```yaml
 demoDiscovery:
   fileGlob: elements/**/demo/*.html

--- a/docs/content/docs/usage/demos.md
+++ b/docs/content/docs/usage/demos.md
@@ -242,25 +242,18 @@ CEM uses this priority order to associate demos with elements:
 
 1. **Frontmatter** - `for: element-name` in YAML frontmatter
 2. **Explicit microdata** - `<meta itemprop="demo-for" content="element-name">`
-3. **Path-based** - Elements whose aliases appear in demo file paths
+3. **Path-based** - Elements whose tag names appear in demo file paths (requires `urlPattern`)
 4. **Content-based** - Custom elements found in the demo HTML
 
 ### Path-Based Association
 
-When elements use the `@alias` JSDoc tag, or have configured aliases in `cem.yaml`:
-
-```yaml
-aliases:
-  my-button: button
-  my-card: card
-```
-
-These paths match:
+When `urlPattern` is configured, the system extracts parameter values from demo
+file paths and matches them against element tag names directly.
 
 ```text
-✅ elements/button/demo/basic.html → my-button
-✅ elements/card/demo/index.html   → my-card
-❌ elements/btn/demo/index.html    → No match (alias is "button", not "btn")
+✅ elements/my-button/demo/basic.html → my-button (tag name matches)
+✅ elements/my-card/demo/index.html   → my-card
+❌ elements/button/demo/index.html    → No match (no element with tag name "button")
 ```
 
 ## See Also

--- a/docs/content/docs/usage/demos.md
+++ b/docs/content/docs/usage/demos.md
@@ -4,7 +4,10 @@ weight: 40
 ---
 
 {{< tip >}}
-**TL;DR**: Create HTML files showcasing your components. Add `@demo` JSDoc tags for automatic discovery, or configure `demoDiscovery` patterns in `cem.yaml`. Demos are HTML partials—the server adds the wrapper, import maps, and live reload.
+**TL;DR**: Create HTML files showcasing your components.
+Add `@demo` JSDoc tags for automatic discovery, or configure `demoDiscovery`
+patterns in `cem.yaml`. Demos are HTML partials—the server adds the wrapper,
+import maps, and live reload.
 {{< /tip >}}
 
 Demos are HTML files that showcase your custom elements in action. They serve as
@@ -20,7 +23,7 @@ to showcase, and the dev server handles the document wrapper, import maps,
 TypeScript transformation, and error overlay. Demos fit naturally into the
 [development workflow][developmentworkflow]—create them as you build components,
 use them during the [test phase][testphase], and update them when you edit APIs.
-Use [HTML5 microdata][documenting-your-demos] to add descriptions, control URLs,
+Use [YAML frontmatter][documenting-your-demos] to add descriptions, control URLs,
 and explicitly associate demos with elements. For advanced URL generation and
 path-based discovery, configure [URLPattern matching][url-generation-with-urlpattern]
 and [URL templates][url-generation-with-urlpattern] in your `cem.yaml`.
@@ -176,8 +179,43 @@ You can include as many elements as you want in your demos:
 
 ## Documenting Your Demos
 
-Use HTML5 microdata to control demo metadata and association. You can modify the demo's URL, add a description, or explicitly associate that demo with a tag name.
+Add YAML frontmatter to your demo files to control metadata and association.
 
+```html
+---
+description: Basic button demonstration
+url: /elements/my-button/demo/
+---
+<my-button>Click me</my-button>
+```
+
+All frontmatter fields are optional:
+
+| Field | Description |
+|-------|-------------|
+| `description` | A description of the demo (plain text or markdown) |
+| `url` | Explicit URL for this demo, overriding URLPattern generation |
+| `for` | Space-separated list of element tag names this demo is for |
+
+By default, all custom elements used in the demo HTML are automatically
+associated with it. The `for` field is only needed when you want to override
+this, for example to associate the demo with elements it doesn't directly
+contain, or to prevent association with elements that appear only incidentally.
+
+```html
+---
+description: Shared accordion demo
+for: my-accordion my-accordion-header
+---
+<my-accordion>
+  <my-accordion-header>Header</my-accordion-header>
+</my-accordion>
+```
+
+### HTML5 Microdata (Alternative)
+
+You can also use HTML5 microdata attributes instead of frontmatter. Frontmatter
+takes precedence when both are present.
 
 ```html
 <meta itemprop="demo-url" content="/elements/my-button/demo/">
@@ -185,11 +223,10 @@ Use HTML5 microdata to control demo metadata and association. You can modify the
 <meta itemprop="description" content="Basic button demonstration">
 ```
 
-The `demo-for` property is useful when the demo file path doesn't indicate which element it's for, when a demo showcases multiple elements, or when you need to prevent incorrect auto-association.
-
 ### Rich Descriptions
 
-You can also add Markdown scripts to add rich content to your demo's description
+For rich content in your demo's description, use a Markdown script tag:
+
 ```html
 <script type="text/markdown" itemprop="description">
 Showcases all button variants:
@@ -203,9 +240,10 @@ Showcases all button variants:
 
 CEM uses this priority order to associate demos with elements:
 
-1. **Explicit microdata** - `<meta itemprop="demo-for" content="element-name">`
-2. **Path-based** - Elements whose aliases appear in demo file paths
-3. **Content-based** - Custom elements found in the demo HTML
+1. **Frontmatter** - `for: element-name` in YAML frontmatter
+2. **Explicit microdata** - `<meta itemprop="demo-for" content="element-name">`
+3. **Path-based** - Elements whose aliases appear in demo file paths
+4. **Content-based** - Custom elements found in the demo HTML
 
 ### Path-Based Association
 

--- a/generate/demodiscovery/discovery.go
+++ b/generate/demodiscovery/discovery.go
@@ -46,11 +46,12 @@ type DemoMetadata struct {
 	DemoFor     []string // Elements this demo is explicitly for
 }
 
-// demoFrontmatter represents YAML frontmatter in a demo HTML file
+// demoFrontmatter represents YAML frontmatter in a demo HTML file.
+// Pointer fields distinguish "key omitted" (nil) from "key present but empty".
 type demoFrontmatter struct {
-	Description string `yaml:"description"`
-	URL         string `yaml:"url"`
-	DemoFor     string `yaml:"for"`
+	Description *string `yaml:"description"`
+	URL         *string `yaml:"url"`
+	DemoFor     *string `yaml:"for"`
 }
 
 // parseFrontmatter extracts YAML frontmatter from file content.
@@ -163,10 +164,14 @@ func extractDemoMetadata(ctx types.WorkspaceContext, path string) (DemoMetadata,
 	// Parse frontmatter first
 	fm, htmlContent := parseFrontmatter(code)
 	if fm != nil {
-		metadata.URL = fm.URL
-		metadata.Description = fm.Description
-		if fm.DemoFor != "" {
-			metadata.DemoFor = strings.Fields(fm.DemoFor)
+		if fm.URL != nil {
+			metadata.URL = *fm.URL
+		}
+		if fm.Description != nil {
+			metadata.Description = *fm.Description
+		}
+		if fm.DemoFor != nil {
+			metadata.DemoFor = strings.Fields(*fm.DemoFor)
 		}
 	}
 
@@ -177,19 +182,19 @@ func extractDemoMetadata(ctx types.WorkspaceContext, path string) (DemoMetadata,
 	defer tree.Close()
 	root := tree.RootNode()
 
-	if metadata.URL == "" {
+	if fm == nil || fm.URL == nil {
 		if url := extractMicrodata(root, htmlContent, "demo-url"); url != "" {
 			metadata.URL = url
 		}
 	}
 
-	if metadata.Description == "" {
+	if fm == nil || fm.Description == nil {
 		if desc := extractMicrodata(root, htmlContent, "description"); desc != "" {
 			metadata.Description = desc
 		}
 	}
 
-	if len(metadata.DemoFor) == 0 {
+	if fm == nil || fm.DemoFor == nil {
 		if demoFor := extractMicrodata(root, htmlContent, "demo-for"); demoFor != "" {
 			metadata.DemoFor = strings.Fields(demoFor)
 		}

--- a/generate/demodiscovery/discovery.go
+++ b/generate/demodiscovery/discovery.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gosimple/slug"
 	"github.com/pterm/pterm"
 	ts "github.com/tree-sitter/go-tree-sitter"
+	"gopkg.in/yaml.v3"
 )
 
 // DemoMetadata represents metadata extracted from demo files
@@ -43,6 +44,54 @@ type DemoMetadata struct {
 	URL         string
 	Description string
 	DemoFor     []string // Elements this demo is explicitly for
+}
+
+// demoFrontmatter represents YAML frontmatter in a demo HTML file
+type demoFrontmatter struct {
+	Description string `yaml:"description"`
+	URL         string `yaml:"url"`
+	DemoFor     string `yaml:"for"`
+}
+
+// parseFrontmatter extracts YAML frontmatter from file content.
+// Returns the parsed frontmatter and the remaining content after the closing "---".
+// If no frontmatter is present, returns nil and the original content.
+func parseFrontmatter(content []byte) (*demoFrontmatter, []byte) {
+	trimmed := bytes.TrimLeft(content, " \t\r\n")
+
+	// Check for opening "---" followed by a newline
+	var openLen int
+	switch {
+	case bytes.HasPrefix(trimmed, []byte("---\n")):
+		openLen = 4
+	case bytes.HasPrefix(trimmed, []byte("---\r\n")):
+		openLen = 5
+	default:
+		return nil, content
+	}
+
+	// Find the closing ---
+	rest := trimmed[openLen:]
+	idx := bytes.Index(rest, []byte("\n---"))
+	if idx < 0 {
+		return nil, content
+	}
+
+	yamlBlock := rest[:idx]
+	var fm demoFrontmatter
+	if err := yaml.Unmarshal(yamlBlock, &fm); err != nil {
+		return nil, content
+	}
+
+	// Content after the closing "---\n"
+	after := rest[idx+4:] // skip "\n---"
+	if len(after) > 0 && after[0] == '\n' {
+		after = after[1:]
+	} else if len(after) > 1 && after[0] == '\r' && after[1] == '\n' {
+		after = after[2:]
+	}
+
+	return &fm, after
 }
 
 // extractMicrodata extracts a specific microdata property from an HTML document
@@ -92,7 +141,9 @@ func extractMicrodata(root *ts.Node, code []byte, property string) string {
 	return walk(root)
 }
 
-// extractDemoMetadata extracts metadata from a demo file using HTML5 microdata
+// extractDemoMetadata extracts metadata from a demo file.
+// It first checks for YAML frontmatter, then falls back to HTML5 microdata.
+// Frontmatter values take precedence over microdata when both are present.
 func extractDemoMetadata(ctx types.WorkspaceContext, path string) (DemoMetadata, error) {
 	// Resolve path relative to workspace root if it's not absolute
 	var absPath string
@@ -107,27 +158,41 @@ func extractDemoMetadata(ctx types.WorkspaceContext, path string) (DemoMetadata,
 		return DemoMetadata{}, fmt.Errorf("could not read demo file: %w", err)
 	}
 
+	metadata := DemoMetadata{}
+
+	// Parse frontmatter first
+	fm, htmlContent := parseFrontmatter(code)
+	if fm != nil {
+		metadata.URL = fm.URL
+		metadata.Description = fm.Description
+		if fm.DemoFor != "" {
+			metadata.DemoFor = strings.Fields(fm.DemoFor)
+		}
+	}
+
+	// Fall back to microdata for any fields not set by frontmatter
 	parser := Q.GetHTMLParser()
 	defer Q.PutHTMLParser(parser)
-	tree := parser.Parse(code, nil)
+	tree := parser.Parse(htmlContent, nil)
 	defer tree.Close()
 	root := tree.RootNode()
 
-	metadata := DemoMetadata{}
-
-	// Extract demo URL
-	if url := extractMicrodata(root, code, "demo-url"); url != "" {
-		metadata.URL = url
+	if metadata.URL == "" {
+		if url := extractMicrodata(root, htmlContent, "demo-url"); url != "" {
+			metadata.URL = url
+		}
 	}
 
-	// Extract description from microdata
-	if desc := extractMicrodata(root, code, "description"); desc != "" {
-		metadata.Description = desc
+	if metadata.Description == "" {
+		if desc := extractMicrodata(root, htmlContent, "description"); desc != "" {
+			metadata.Description = desc
+		}
 	}
 
-	// Extract demo-for associations
-	if demoFor := extractMicrodata(root, code, "demo-for"); demoFor != "" {
-		metadata.DemoFor = strings.Fields(demoFor)
+	if len(metadata.DemoFor) == 0 {
+		if demoFor := extractMicrodata(root, htmlContent, "demo-for"); demoFor != "" {
+			metadata.DemoFor = strings.Fields(demoFor)
+		}
 	}
 
 	return metadata, nil

--- a/generate/demodiscovery/discovery_test.go
+++ b/generate/demodiscovery/discovery_test.go
@@ -581,6 +581,8 @@ func TestValidateDemoDiscoveryConfig(t *testing.T) {
 	}
 }
 
+func ptr(s string) *string { return &s }
+
 func TestParseFrontmatter(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -597,13 +599,13 @@ func TestParseFrontmatter(t *testing.T) {
 		{
 			name:        "frontmatter with description",
 			input:       "---\ndescription: A demo\n---\n<rh-button>Click</rh-button>\n",
-			wantFM:      &demoFrontmatter{Description: "A demo"},
+			wantFM:      &demoFrontmatter{Description: ptr("A demo")},
 			wantContent: "<rh-button>Click</rh-button>\n",
 		},
 		{
 			name:        "frontmatter with all fields",
 			input:       "---\ndescription: A demo\nurl: /demo/\nfor: rh-button rh-card\n---\n<p>Content</p>\n",
-			wantFM:      &demoFrontmatter{Description: "A demo", URL: "/demo/", DemoFor: "rh-button rh-card"},
+			wantFM:      &demoFrontmatter{Description: ptr("A demo"), URL: ptr("/demo/"), DemoFor: ptr("rh-button rh-card")},
 			wantContent: "<p>Content</p>\n",
 		},
 		{
@@ -621,8 +623,14 @@ func TestParseFrontmatter(t *testing.T) {
 		{
 			name:        "CRLF line endings",
 			input:       "---\r\ndescription: CRLF demo\r\n---\r\n<rh-button>Click</rh-button>\r\n",
-			wantFM:      &demoFrontmatter{Description: "CRLF demo"},
+			wantFM:      &demoFrontmatter{Description: ptr("CRLF demo")},
 			wantContent: "<rh-button>Click</rh-button>\r\n",
+		},
+		{
+			name:        "empty description suppresses microdata fallback",
+			input:       "---\ndescription: \"\"\n---\n<meta itemprop=\"description\" content=\"should not appear\">\n",
+			wantFM:      &demoFrontmatter{Description: ptr("")},
+			wantContent: "<meta itemprop=\"description\" content=\"should not appear\">\n",
 		},
 	}
 
@@ -639,20 +647,28 @@ func TestParseFrontmatter(t *testing.T) {
 				if fm == nil {
 					t.Fatalf("expected frontmatter %+v, got nil", tt.wantFM)
 				}
-				if fm.Description != tt.wantFM.Description {
-					t.Errorf("Description: got %q, want %q", fm.Description, tt.wantFM.Description)
-				}
-				if fm.URL != tt.wantFM.URL {
-					t.Errorf("URL: got %q, want %q", fm.URL, tt.wantFM.URL)
-				}
-				if fm.DemoFor != tt.wantFM.DemoFor {
-					t.Errorf("DemoFor: got %q, want %q", fm.DemoFor, tt.wantFM.DemoFor)
-				}
+				comparePtrField(t, "Description", fm.Description, tt.wantFM.Description)
+				comparePtrField(t, "URL", fm.URL, tt.wantFM.URL)
+				comparePtrField(t, "DemoFor", fm.DemoFor, tt.wantFM.DemoFor)
 			}
 
 			if gotContent != tt.wantContent {
 				t.Errorf("content mismatch:\ngot:  %q\nwant: %q", gotContent, tt.wantContent)
 			}
 		})
+	}
+}
+
+func comparePtrField(t *testing.T, name string, got, want *string) {
+	t.Helper()
+	switch {
+	case got == nil && want == nil:
+		return
+	case got == nil:
+		t.Errorf("%s: got nil, want %q", name, *want)
+	case want == nil:
+		t.Errorf("%s: got %q, want nil", name, *got)
+	case *got != *want:
+		t.Errorf("%s: got %q, want %q", name, *got, *want)
 	}
 }

--- a/generate/demodiscovery/discovery_test.go
+++ b/generate/demodiscovery/discovery_test.go
@@ -580,3 +580,79 @@ func TestValidateDemoDiscoveryConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestParseFrontmatter(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantFM      *demoFrontmatter
+		wantContent string
+	}{
+		{
+			name:        "no frontmatter",
+			input:       "<rh-button>Click</rh-button>",
+			wantFM:      nil,
+			wantContent: "<rh-button>Click</rh-button>",
+		},
+		{
+			name:        "frontmatter with description",
+			input:       "---\ndescription: A demo\n---\n<rh-button>Click</rh-button>\n",
+			wantFM:      &demoFrontmatter{Description: "A demo"},
+			wantContent: "<rh-button>Click</rh-button>\n",
+		},
+		{
+			name:        "frontmatter with all fields",
+			input:       "---\ndescription: A demo\nurl: /demo/\nfor: rh-button rh-card\n---\n<p>Content</p>\n",
+			wantFM:      &demoFrontmatter{Description: "A demo", URL: "/demo/", DemoFor: "rh-button rh-card"},
+			wantContent: "<p>Content</p>\n",
+		},
+		{
+			name:        "unclosed frontmatter",
+			input:       "---\ndescription: A demo\n<rh-button>Click</rh-button>\n",
+			wantFM:      nil,
+			wantContent: "---\ndescription: A demo\n<rh-button>Click</rh-button>\n",
+		},
+		{
+			name:        "--- in HTML body not treated as frontmatter",
+			input:       "<p>---</p>\n<rh-button>Click</rh-button>",
+			wantFM:      nil,
+			wantContent: "<p>---</p>\n<rh-button>Click</rh-button>",
+		},
+		{
+			name:        "CRLF line endings",
+			input:       "---\r\ndescription: CRLF demo\r\n---\r\n<rh-button>Click</rh-button>\r\n",
+			wantFM:      &demoFrontmatter{Description: "CRLF demo"},
+			wantContent: "<rh-button>Click</rh-button>\r\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fm, content := parseFrontmatter([]byte(tt.input))
+			gotContent := string(content)
+
+			if tt.wantFM == nil {
+				if fm != nil {
+					t.Errorf("expected nil frontmatter, got %+v", fm)
+				}
+			} else {
+				if fm == nil {
+					t.Fatalf("expected frontmatter %+v, got nil", tt.wantFM)
+				}
+				if fm.Description != tt.wantFM.Description {
+					t.Errorf("Description: got %q, want %q", fm.Description, tt.wantFM.Description)
+				}
+				if fm.URL != tt.wantFM.URL {
+					t.Errorf("URL: got %q, want %q", fm.URL, tt.wantFM.URL)
+				}
+				if fm.DemoFor != tt.wantFM.DemoFor {
+					t.Errorf("DemoFor: got %q, want %q", fm.DemoFor, tt.wantFM.DemoFor)
+				}
+			}
+
+			if gotContent != tt.wantContent {
+				t.Errorf("content mismatch:\ngot:  %q\nwant: %q", gotContent, tt.wantContent)
+			}
+		})
+	}
+}

--- a/generate/demodiscovery/map.go
+++ b/generate/demodiscovery/map.go
@@ -98,14 +98,23 @@ func extractDemoTagsWithPattern(
 	if err != nil {
 		return nil, fmt.Errorf("could not extract demo tags from file: %w", err)
 	}
+
+	// Strip frontmatter before parsing HTML
+	fm, htmlContent := parseFrontmatter(code)
+
+	// Priority 0: Explicit frontmatter demoFor
+	if fm != nil && fm.DemoFor != "" {
+		return strings.Fields(fm.DemoFor), nil
+	}
+
 	parser := Q.GetHTMLParser()
 	defer Q.PutHTMLParser(parser)
-	tree := parser.Parse(code, nil)
+	tree := parser.Parse(htmlContent, nil)
 	defer tree.Close()
 	root := tree.RootNode()
 
 	// Priority 1: Explicit microdata association
-	if demoFor := extractMicrodata(root, code, "demo-for"); demoFor != "" {
+	if demoFor := extractMicrodata(root, htmlContent, "demo-for"); demoFor != "" {
 		fields := strings.Fields(demoFor)
 		return fields, nil
 	}
@@ -132,7 +141,7 @@ func extractDemoTagsWithPattern(
 			for i := range int(node.ChildCount()) {
 				child := node.Child(uint(i))
 				if child != nil && child.GrammarName() == "tag_name" {
-					name := child.Utf8Text(code)
+					name := child.Utf8Text(htmlContent)
 					if isCustomElementTagName(name) {
 						tagNameSet.Add(name)
 					}

--- a/generate/demodiscovery/map.go
+++ b/generate/demodiscovery/map.go
@@ -102,9 +102,9 @@ func extractDemoTagsWithPattern(
 	// Strip frontmatter before parsing HTML
 	fm, htmlContent := parseFrontmatter(code)
 
-	// Priority 0: Explicit frontmatter demoFor
-	if fm != nil && fm.DemoFor != "" {
-		return strings.Fields(fm.DemoFor), nil
+	// Priority 0: Explicit frontmatter for
+	if fm != nil && fm.DemoFor != nil {
+		return strings.Fields(*fm.DemoFor), nil
 	}
 
 	parser := Q.GetHTMLParser()

--- a/generate/demodiscovery/testdata/extract-metadata/frontmatter-and-microdata/expected.json
+++ b/generate/demodiscovery/testdata/extract-metadata/frontmatter-and-microdata/expected.json
@@ -1,0 +1,5 @@
+{
+  "url": "/frontmatter/url/",
+  "description": "Frontmatter description wins",
+  "demoFor": null
+}

--- a/generate/demodiscovery/testdata/extract-metadata/frontmatter-and-microdata/input.html
+++ b/generate/demodiscovery/testdata/extract-metadata/frontmatter-and-microdata/input.html
@@ -1,0 +1,8 @@
+---
+description: Frontmatter description wins
+url: /frontmatter/url/
+---
+<meta itemprop="demo-url" content="/microdata/url/">
+<meta itemprop="description" content="Microdata description loses">
+
+<rh-button>Click me</rh-button>

--- a/generate/demodiscovery/testdata/extract-metadata/frontmatter-demo-for/expected.json
+++ b/generate/demodiscovery/testdata/extract-metadata/frontmatter-demo-for/expected.json
@@ -1,0 +1,5 @@
+{
+  "url": "",
+  "description": "Shared accordion demo",
+  "demoFor": ["rh-accordion", "rh-accordion-header"]
+}

--- a/generate/demodiscovery/testdata/extract-metadata/frontmatter-demo-for/input.html
+++ b/generate/demodiscovery/testdata/extract-metadata/frontmatter-demo-for/input.html
@@ -1,0 +1,7 @@
+---
+description: Shared accordion demo
+for: rh-accordion rh-accordion-header
+---
+<rh-accordion>
+  <rh-accordion-header>Header</rh-accordion-header>
+</rh-accordion>

--- a/generate/demodiscovery/testdata/extract-metadata/frontmatter-empty-description/expected.json
+++ b/generate/demodiscovery/testdata/extract-metadata/frontmatter-empty-description/expected.json
@@ -1,0 +1,5 @@
+{
+  "url": "",
+  "description": "",
+  "demoFor": null
+}

--- a/generate/demodiscovery/testdata/extract-metadata/frontmatter-empty-description/input.html
+++ b/generate/demodiscovery/testdata/extract-metadata/frontmatter-empty-description/input.html
@@ -1,0 +1,5 @@
+---
+description: ""
+---
+<meta itemprop="description" content="should not appear">
+<rh-button>Click me</rh-button>

--- a/generate/demodiscovery/testdata/extract-metadata/frontmatter-only/expected.json
+++ b/generate/demodiscovery/testdata/extract-metadata/frontmatter-only/expected.json
@@ -1,0 +1,5 @@
+{
+  "url": "/elements/tile/demo/compact/",
+  "description": "A compact tile variant",
+  "demoFor": null
+}

--- a/generate/demodiscovery/testdata/extract-metadata/frontmatter-only/input.html
+++ b/generate/demodiscovery/testdata/extract-metadata/frontmatter-only/input.html
@@ -1,0 +1,5 @@
+---
+description: A compact tile variant
+url: /elements/tile/demo/compact/
+---
+<rh-tile compact>Compact tile</rh-tile>

--- a/generate/demodiscovery/testdata/extract-tags/frontmatter-demo-for/config.json
+++ b/generate/demodiscovery/testdata/extract-tags/frontmatter-demo-for/config.json
@@ -1,0 +1,4 @@
+{
+  "elementAliases": {},
+  "demoPath": "/components/accordion/demo/primary.html"
+}

--- a/generate/demodiscovery/testdata/extract-tags/frontmatter-demo-for/expected.json
+++ b/generate/demodiscovery/testdata/extract-tags/frontmatter-demo-for/expected.json
@@ -1,0 +1,1 @@
+["rh-accordion", "rh-accordion-header"]

--- a/generate/demodiscovery/testdata/extract-tags/frontmatter-demo-for/input.html
+++ b/generate/demodiscovery/testdata/extract-tags/frontmatter-demo-for/input.html
@@ -1,0 +1,4 @@
+---
+for: rh-accordion rh-accordion-header
+---
+<rh-card>Should be ignored because frontmatter takes precedence</rh-card>

--- a/generate/testdata/fixtures/project-demos/golden/demo-discovery.json
+++ b/generate/testdata/fixtures/project-demos/golden/demo-discovery.json
@@ -30,6 +30,13 @@
               }
             },
             {
+              "description": "Demo with YAML frontmatter metadata",
+              "url": "https://bennypowers.dev/cem-demos/demo-discovery/frontmatter/",
+              "source": {
+                "href": "https://github.com/bennypowers/cem/tree/main/generate/src/demo-discovery/demos/frontmatter.html"
+              }
+            },
+            {
               "description": "A complete HTML document demonstrating demo-discovery element",
               "url": "https://bennypowers.dev/cem-demos/demo-discovery/full-document/",
               "source": {

--- a/generate/testdata/fixtures/project-demos/src/demo-discovery/demos/frontmatter.html
+++ b/generate/testdata/fixtures/project-demos/src/demo-discovery/demos/frontmatter.html
@@ -1,0 +1,4 @@
+---
+description: Demo with YAML frontmatter metadata
+---
+<demo-discovery>Frontmatter demo</demo-discovery>


### PR DESCRIPTION
## Summary

- Adds YAML frontmatter parsing as an alternative to `<meta itemprop>` tags for demo metadata (`description`, `url`, `for`)
- Frontmatter takes precedence over microdata when both are present
- Strips frontmatter before HTML parsing so it doesn't interfere with content-based tag discovery
- Updates docs to prefer frontmatter over microdata

Closes #290
See also: RedHat-UX/red-hat-design-system#2947

## Test plan

- [x] Unit tests for `parseFrontmatter()` covering: no frontmatter, all fields, unclosed, CRLF line endings, `---` in body
- [x] Fixture tests for `extractDemoMetadata()`: frontmatter-only, microdata-only, both (frontmatter wins), frontmatter `for`
- [x] Fixture test for `extractDemoTags()` with frontmatter `for`
- [x] Integration golden test updated for project-demos fixture
- [x] All 2330 Go tests pass, golangci-lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added YAML frontmatter support for demo files to declare optional description, URL, and demo-for associations.
  * Frontmatter now takes top priority when determining demo associations and generated URLs, overriding embedded microdata and path/content heuristics.

* **Documentation**
  * Updated configuration and usage guides with frontmatter examples and revised precedence/association rules.

* **Tests**
  * Added unit tests and fixtures covering frontmatter parsing and precedence scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->