### PR TITLE
feat(generate): support @ignore and @internal jsdoc tags

### DIFF
--- a/docs/content/docs/reference/commands/generate.md
+++ b/docs/content/docs/reference/commands/generate.md
@@ -74,6 +74,7 @@ These tags apply to class properties:
 
 - `@deprecated` — Marks property as deprecated
 - `@example` — Code examples for property usage
+- `@ignore` / `@internal` — Exclude property from the manifest
 - `@summary` — Short summary for the property
 - `@type` — Property type annotation
 
@@ -83,6 +84,7 @@ These tags apply to class methods:
 
 - `@deprecated` — Marks method as deprecated
 - `@example` — Code examples for method usage
+- `@ignore` / `@internal` — Exclude method from the manifest
 - `@param` / `@parameter` — Method parameter documentation
 - `@return` / `@returns` — Return value documentation
 - `@summary` — Short summary for the method

--- a/generate/classMemberDeclarations.go
+++ b/generate/classMemberDeclarations.go
@@ -339,6 +339,18 @@ func (mp *ModuleProcessor) getClassMembersFromClassDeclarationNode(
 			continue
 		}
 
+		if members, ok := captures["member"]; ok && len(members) > 0 {
+			jsdocText := jsdoc.ExtractFromNode(Q.GetDescendantById(mp.root, members[0].NodeId), mp.code)
+			ignored, err := jsdoc.HasIgnoreTag(jsdocText, mp.queryManager)
+			if err != nil {
+				errs = errors.Join(errs, err)
+				continue
+			}
+			if ignored {
+				continue
+			}
+		}
+
 		// Debug: log all variant property processing
 		if memberName == "variant" {
 			mp.logger.Debug("Processing variant member: kind=%s, static=%v", kind, isStatic)

--- a/generate/classMemberDeclarations.go
+++ b/generate/classMemberDeclarations.go
@@ -344,9 +344,7 @@ func (mp *ModuleProcessor) getClassMembersFromClassDeclarationNode(
 			ignored, err := jsdoc.HasIgnoreTag(jsdocText, mp.queryManager)
 			if err != nil {
 				errs = errors.Join(errs, err)
-				continue
-			}
-			if ignored {
+			} else if ignored {
 				continue
 			}
 		}

--- a/generate/jsdoc/jsdoc.go
+++ b/generate/jsdoc/jsdoc.go
@@ -124,6 +124,18 @@ func ExtractAliasFromJSDoc(jsdocText string, queryManager *Q.QueryManager) (stri
 	return info.Alias, nil
 }
 
+// HasIgnoreTag checks whether JSDoc contains an @ignore tag.
+func HasIgnoreTag(jsdocText string, queryManager *Q.QueryManager) (bool, error) {
+	if strings.TrimSpace(jsdocText) == "" {
+		return false, nil
+	}
+	info, err := parseForProperty(jsdocText, queryManager)
+	if err != nil {
+		return false, err
+	}
+	return info.Ignore, nil
+}
+
 // HasElementTag checks whether JSDoc contains an @element, @tagName, or @customElement tag.
 func HasElementTag(jsdocText string, queryManager *Q.QueryManager) (bool, error) {
 	if strings.TrimSpace(jsdocText) == "" {

--- a/generate/jsdoc/jsdoc.go
+++ b/generate/jsdoc/jsdoc.go
@@ -124,7 +124,7 @@ func ExtractAliasFromJSDoc(jsdocText string, queryManager *Q.QueryManager) (stri
 	return info.Alias, nil
 }
 
-// HasIgnoreTag checks whether JSDoc contains an @ignore tag.
+// HasIgnoreTag checks whether JSDoc contains an @ignore or @internal tag.
 func HasIgnoreTag(jsdocText string, queryManager *Q.QueryManager) (bool, error) {
 	if strings.TrimSpace(jsdocText) == "" {
 		return false, nil

--- a/generate/jsdoc/parse.go
+++ b/generate/jsdoc/parse.go
@@ -52,6 +52,7 @@ type propertyInfo struct {
 	Summary     string
 	Type        string
 	Deprecated  M.Deprecated
+	Ignore      bool
 }
 
 type cssPropertyInfo struct {
@@ -195,6 +196,9 @@ func parseForProperty(code string, queryManager *Q.QueryManager) (*propertyInfo,
 				} else {
 					info.Deprecated = M.NewDeprecated(content)
 				}
+			case "@ignore",
+				"@internal":
+				info.Ignore = true
 			}
 		}
 	}

--- a/generate/testdata/fixtures/project-jsdoc/golden/jsdoc-ignore.json
+++ b/generate/testdata/fixtures/project-jsdoc/golden/jsdoc-ignore.json
@@ -22,7 +22,7 @@
             }
           ],
           "source": {
-            "href": "https://github.com/bennypowers/cem/tree/main/generate/test/fixtures/project-yaml/src/jsdoc-ignore.ts#L1"
+            "href": "https://github.com/bennypowers/cem/tree/main/generate/test/fixtures/project-jsdoc/src/jsdoc-ignore.ts#L1"
           },
           "kind": "class",
           "tagName": "jsdoc-ignore-field",
@@ -54,7 +54,7 @@
             }
           ],
           "source": {
-            "href": "https://github.com/bennypowers/cem/tree/main/generate/test/fixtures/project-yaml/src/jsdoc-ignore.ts#L11"
+            "href": "https://github.com/bennypowers/cem/tree/main/generate/test/fixtures/project-jsdoc/src/jsdoc-ignore.ts#L11"
           },
           "kind": "class",
           "tagName": "jsdoc-internal-field",
@@ -87,7 +87,7 @@
             }
           ],
           "source": {
-            "href": "https://github.com/bennypowers/cem/tree/main/generate/test/fixtures/project-yaml/src/jsdoc-ignore.ts#L21"
+            "href": "https://github.com/bennypowers/cem/tree/main/generate/test/fixtures/project-jsdoc/src/jsdoc-ignore.ts#L21"
           },
           "kind": "class",
           "tagName": "jsdoc-ignore-method",
@@ -111,7 +111,7 @@
             }
           ],
           "source": {
-            "href": "https://github.com/bennypowers/cem/tree/main/generate/test/fixtures/project-yaml/src/jsdoc-ignore.ts#L31"
+            "href": "https://github.com/bennypowers/cem/tree/main/generate/test/fixtures/project-jsdoc/src/jsdoc-ignore.ts#L31"
           },
           "kind": "class",
           "tagName": "jsdoc-internal-method",

--- a/generate/testdata/fixtures/project-jsdoc/golden/jsdoc-ignore.json
+++ b/generate/testdata/fixtures/project-jsdoc/golden/jsdoc-ignore.json
@@ -1,0 +1,157 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/jsdoc-ignore.js",
+      "declarations": [
+        {
+          "name": "JsdocIgnoreField",
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "members": [
+            {
+              "name": "visibleProp",
+              "type": {
+                "text": "number"
+              },
+              "kind": "field",
+              "attribute": "visibleprop"
+            }
+          ],
+          "source": {
+            "href": "https://github.com/bennypowers/cem/tree/main/generate/test/fixtures/project-yaml/src/jsdoc-ignore.ts#L1"
+          },
+          "kind": "class",
+          "tagName": "jsdoc-ignore-field",
+          "attributes": [
+            {
+              "name": "visibleprop",
+              "type": {
+                "text": "number"
+              },
+              "fieldName": "visibleProp"
+            }
+          ],
+          "customElement": true
+        },
+        {
+          "name": "JsdocInternalField",
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "members": [
+            {
+              "name": "visibleProp",
+              "type": {
+                "text": "number"
+              },
+              "kind": "field",
+              "attribute": "visibleprop"
+            }
+          ],
+          "source": {
+            "href": "https://github.com/bennypowers/cem/tree/main/generate/test/fixtures/project-yaml/src/jsdoc-ignore.ts#L11"
+          },
+          "kind": "class",
+          "tagName": "jsdoc-internal-field",
+          "attributes": [
+            {
+              "name": "visibleprop",
+              "type": {
+                "text": "number"
+              },
+              "fieldName": "visibleProp"
+            }
+          ],
+          "customElement": true
+        },
+        {
+          "name": "JsdocIgnoreMethod",
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "members": [
+            {
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "name": "visibleMethod",
+              "kind": "method"
+            }
+          ],
+          "source": {
+            "href": "https://github.com/bennypowers/cem/tree/main/generate/test/fixtures/project-yaml/src/jsdoc-ignore.ts#L21"
+          },
+          "kind": "class",
+          "tagName": "jsdoc-ignore-method",
+          "customElement": true
+        },
+        {
+          "name": "JsdocInternalMethod",
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "members": [
+            {
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "name": "visibleMethod",
+              "kind": "method"
+            }
+          ],
+          "source": {
+            "href": "https://github.com/bennypowers/cem/tree/main/generate/test/fixtures/project-yaml/src/jsdoc-ignore.ts#L31"
+          },
+          "kind": "class",
+          "tagName": "jsdoc-internal-method",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "jsdoc-ignore-field",
+          "declaration": {
+            "name": "JsdocIgnoreField",
+            "module": "src/jsdoc-ignore.js"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "jsdoc-internal-field",
+          "declaration": {
+            "name": "JsdocInternalField",
+            "module": "src/jsdoc-ignore.js"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "jsdoc-ignore-method",
+          "declaration": {
+            "name": "JsdocIgnoreMethod",
+            "module": "src/jsdoc-ignore.js"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "jsdoc-internal-method",
+          "declaration": {
+            "name": "JsdocInternalMethod",
+            "module": "src/jsdoc-ignore.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/generate/testdata/fixtures/project-jsdoc/src/jsdoc-ignore.ts
+++ b/generate/testdata/fixtures/project-jsdoc/src/jsdoc-ignore.ts
@@ -1,0 +1,39 @@
+@customElement('jsdoc-ignore-field')
+class JsdocIgnoreField extends LitElement {
+  /**
+   * @ignore
+   */
+  @property() ignoredProp: string;
+
+  @property() visibleProp: number;
+}
+
+@customElement('jsdoc-internal-field')
+class JsdocInternalField extends LitElement {
+  /**
+   * @internal
+   */
+  @property() internalProp: boolean = false;
+
+  @property() visibleProp: number;
+}
+
+@customElement('jsdoc-ignore-method')
+class JsdocIgnoreMethod extends LitElement {
+  /**
+   * @ignore
+   */
+  ignoredMethod(): void {}
+
+  visibleMethod(): void {}
+}
+
+@customElement('jsdoc-internal-method')
+class JsdocInternalMethod extends LitElement {
+  /**
+   * @internal
+   */
+  internalMethod(): void {}
+
+  visibleMethod(): void {}
+}


### PR DESCRIPTION
## Summary

- Members annotated with `@ignore` or `@internal` are excluded from the generated custom elements manifest
- Both tags are treated as equivalent aliases
- Applies to both fields and methods

## Changes

- `generate/jsdoc/parse.go` — adds `Ignore bool` to `propertyInfo`; recognises `@ignore` and `@internal` tags
- `generate/jsdoc/jsdoc.go` — exports `HasIgnoreTag()` helper
- `generate/classMemberDeclarations.go` — skips members whose JSDoc contains an ignore tag

## Test plan

- [x] Fixture `generate/testdata/fixtures/project-jsdoc/src/jsdoc-ignore.ts` covers four cases: `@ignore` on a field, `@internal` on a field, `@ignore` on a method, `@internal` on a method
- [x] Golden `generate/testdata/fixtures/project-jsdoc/golden/jsdoc-ignore.json` asserts ignored members are absent while visible members remain
- [x] `go test ./generate/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for JSDoc `@ignore` and `@internal` tags to exclude class members from processing

* **Tests**
  * Added fixtures demonstrating ignore tag functionality for properties and methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->