### PR TITLE
fix(generate): ignore LitElement firstUpdated lifecycle method

### DIFF
--- a/generate/classMemberDeclarations.go
+++ b/generate/classMemberDeclarations.go
@@ -51,9 +51,10 @@ var ignoredInstanceMethodsHTML = S.NewSet(
 )
 
 var ignoredInstanceMethodsLit = S.NewSet(
+	"firstUpdated",
+	"getUpdateComplete",
 	"render",
 	"update",
-	"getUpdateComplete",
 	"updated",
 	"willUpdate",
 )

--- a/generate/testdata/fixtures/project-classes/src/class-ignored-members.ts
+++ b/generate/testdata/fixtures/project-classes/src/class-ignored-members.ts
@@ -17,4 +17,5 @@ class ClassIgnoredMembers extends LitElement {
   getUpdateComplete() {}
   updated() {}
   willUpdate() {}
+  firstUpdated() {}
 }


### PR DESCRIPTION
## Summary

- `firstUpdated` was missing from the list of ignored LitElement lifecycle methods and was incorrectly included in the generated manifest

## Changes

- `generate/classMemberDeclarations.go` — adds `firstUpdated` to `ignoredInstanceMethodsLit`
- `generate/testdata/fixtures/project-classes/src/class-ignored-members.ts` — adds `firstUpdated` to the regression fixture

## Test plan

- [x] `TestGenerate/project-classes/class-ignored-members` now covers `firstUpdated` and passes
- [x] `go test ./generate/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures for code generation with LitElement classes.

* **Chores**
  * Improved code generation to properly exclude specific framework lifecycle methods from processed declarations, resulting in more accurate class member handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->