### PR TITLE
fix(generate): recognize JSDoc element tags separated by comments

### DIFF
--- a/generate/jsdoc/jsdoc.go
+++ b/generate/jsdoc/jsdoc.go
@@ -25,7 +25,7 @@ import (
 )
 
 // ExtractFromNode returns the immediately preceding JSDoc comment (/** ... */) for the given node,
-// skipping over decorator nodes. If there is no such comment, returns "".
+// skipping over decorator nodes and non-JSDoc comments. If there is no such comment, returns "".
 func ExtractFromNode(node *ts.Node, source []byte) string {
 	if node == nil {
 		return ""
@@ -39,9 +39,8 @@ func ExtractFromNode(node *ts.Node, source []byte) string {
 			text := prev.Utf8Text(source)
 			if strings.HasPrefix(text, "/**") {
 				return text
-			} else {
-				return ""
 			}
+			continue
 		default:
 			return ""
 		}

--- a/generate/modules.go
+++ b/generate/modules.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"bennypowers.dev/cem/generate/jsdoc"
 	M "bennypowers.dev/cem/manifest"
 	Q "bennypowers.dev/cem/queries"
 	S "bennypowers.dev/cem/set"
@@ -341,6 +342,20 @@ func (mp *ModuleProcessor) processClasses() error {
 		className := nameNodes[0].Text
 		if _, exists := processed[className]; exists {
 			continue
+		}
+
+		if _, hasJSDoc := captures["class.jsdoc"]; !hasJSDoc {
+			if declCaptures, ok := captures["class.declaration"]; ok && len(declCaptures) > 0 {
+				node := Q.GetDescendantById(mp.root, declCaptures[0].NodeId)
+				if node != nil {
+					if p := node.Parent(); p != nil && p.Kind() == "export_statement" {
+						node = p
+					}
+					if text := jsdoc.ExtractFromNode(node, mp.code); text != "" {
+						captures["class.jsdoc"] = []Q.CaptureInfo{{Text: text}}
+					}
+				}
+			}
 		}
 
 		parsed := &ParsedClass{

--- a/generate/testdata/fixtures/project-classes/golden/class-jsdoc-element-comment-between.json
+++ b/generate/testdata/fixtures/project-classes/golden/class-jsdoc-element-comment-between.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/class-jsdoc-element-comment-between.js",
+      "declarations": [
+        {
+          "name": "GridColumn",
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "source": {
+            "href": "https://github.com/bennypowers/cem/tree/main/generate/test/fixtures/project-classes/src/class-jsdoc-element-comment-between.ts#L7"
+          },
+          "kind": "class",
+          "tagName": "sl-grid-column",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "sl-grid-column",
+          "declaration": {
+            "name": "GridColumn",
+            "module": "src/class-jsdoc-element-comment-between.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "GridColumn",
+          "declaration": {
+            "name": "GridColumn",
+            "module": "src/class-jsdoc-element-comment-between.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/generate/testdata/fixtures/project-classes/golden/class-jsdoc-element-decorator-between.json
+++ b/generate/testdata/fixtures/project-classes/golden/class-jsdoc-element-decorator-between.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/class-jsdoc-element-decorator-between.js",
+      "declarations": [
+        {
+          "name": "Breadcrumbs",
+          "description": "A component to display a breadcrumb trail.",
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "source": {
+            "href": "https://github.com/bennypowers/cem/tree/main/generate/test/fixtures/project-classes/src/class-jsdoc-element-decorator-between.ts#L13"
+          },
+          "kind": "class",
+          "tagName": "sl-breadcrumbs",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "sl-breadcrumbs",
+          "declaration": {
+            "name": "Breadcrumbs",
+            "module": "src/class-jsdoc-element-decorator-between.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "Breadcrumbs",
+          "declaration": {
+            "name": "Breadcrumbs",
+            "module": "src/class-jsdoc-element-decorator-between.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/generate/testdata/fixtures/project-classes/src/class-jsdoc-element-comment-between.ts
+++ b/generate/testdata/fixtures/project-classes/src/class-jsdoc-element-comment-between.ts
@@ -1,0 +1,7 @@
+import { LitElement } from 'lit';
+
+/**
+ * @customElement sl-grid-column
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export class GridColumn<T = any> extends LitElement {}

--- a/generate/testdata/fixtures/project-classes/src/class-jsdoc-element-decorator-between.ts
+++ b/generate/testdata/fixtures/project-classes/src/class-jsdoc-element-decorator-between.ts
@@ -1,0 +1,17 @@
+import { html, LitElement, type TemplateResult } from 'lit';
+
+function localized() {
+  return function(target: any) { return target; };
+}
+
+/**
+ * A component to display a breadcrumb trail.
+ *
+ * @customElement sl-breadcrumbs
+ */
+@localized()
+export class Breadcrumbs extends LitElement {
+  render(): TemplateResult {
+    return html`<p>breadcrumbs</p>`;
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes classes with `@customElement`/`@element`/`@tagName` JSDoc tags not being recognized as custom elements when a non-JSDoc comment (e.g. `// eslint-disable-next-line`) sits between the JSDoc block and the class declaration
- Updates `ExtractFromNode` to skip non-JSDoc comments instead of stopping at them
- Adds fallback JSDoc extraction in `processClasses` when tree-sitter query's immediate-sibling anchor prevents JSDoc capture

Closes #292

## Test plan

- [x] New fixture `class-jsdoc-element-comment-between.ts` verifies JSDoc `@customElement` is recognized with an intervening `// eslint-disable` comment
- [x] New fixture `class-jsdoc-element-decorator-between.ts` verifies the decorator case also works
- [x] Full test suite passes (2334 tests, 0 failures)
- [x] `golangci-lint` and `go vet` clean
- [x] CodeRabbit review: 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved JSDoc extraction logic to properly identify and skip non-JSDoc comments and decorator nodes when processing class declarations, ensuring accurate documentation is captured for all cases.

## Tests
- Added comprehensive test fixtures validating JSDoc extraction for custom element classes, including edge cases with comments and decorators positioned between JSDoc declarations and class definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->