### PR TITLE
fix(ci): support fork PRs in benchmark and build workflows

### DIFF
--- a/.github/workflows/benchmark-comment.yaml
+++ b/.github/workflows/benchmark-comment.yaml
@@ -1,0 +1,44 @@
+name: Benchmark Comment
+
+on:
+  workflow_run:
+    workflows:
+      - Benchmark
+    types:
+      - completed
+
+
+jobs:
+  comment:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Download benchmark artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-artifacts
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat pr_number.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Find previous benchmark comment
+        id: find-comment
+        uses: peter-evans/find-comment@v4
+        with:
+          issue-number: ${{ steps.pr.outputs.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "### Generate Benchmarks"
+
+      - name: Create or update sticky benchmark comment
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          issue-number: ${{ steps.pr.outputs.number }}
+          body-file: combined_bench_report.md
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: replace

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -8,7 +8,6 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
       contents: read
 
     steps:
@@ -183,27 +182,15 @@ jobs:
       - name: Combine benchmark reports
         run: scripts/combine-benchmark-reports.sh
 
-      - name: Find previous benchmark comment
-        id: find-comment
-        uses: peter-evans/find-comment@v4
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: "github-actions[bot]"
-          body-includes: "### Generate Benchmarks"
-
-      - name: Create or update sticky benchmark comment
-        uses: peter-evans/create-or-update-comment@v5
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body-file: combined_bench_report.md
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          edit-mode: replace
+      - name: Save PR number
+        run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
 
       - name: Upload benchmark artifacts
         uses: actions/upload-artifact@v7
         with:
           name: benchmark-artifacts
           path: |
+            pr_number.txt
             pr_bench.txt
             base_bench.txt
             pr_bench_time.txt

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,6 +1,12 @@
 name: Test Build (No Release)
 
-on: push
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- Split benchmark PR comment into a separate `workflow_run`-triggered workflow so it has write permissions on fork PRs (the `GITHUB_TOKEN` is read-only for fork PR events)
- Switch `test-build.yml` from `push` to `pull_request` trigger so the required `build / Build *` checks actually run on PRs instead of being permanently "expected - waiting"

## Test plan

- [ ] Verify benchmark workflow passes on PR #294 (fork PR from jpzwarte)
- [ ] Verify build checks appear on this PR
- [ ] Verify benchmark comment still posts on maintainer PRs

Assisted-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>