### PR TITLE
feat(lsp): add ERB and EJS template support

### DIFF
--- a/docs/content/docs/installation/lsp.md
+++ b/docs/content/docs/installation/lsp.md
@@ -4,7 +4,7 @@ weight: 20
 ---
 
 {{< tip >}}
-**TL;DR**: Install CEM, then configure your editor to run `cem lsp`. VS Code users can install the extension. Neovim/Zed users configure their LSP client to start `cem lsp` for HTML, Nunjucks, Jinja2, Handlebars, Twig, Liquid, PHP, JavaScript, and TypeScript files.
+**TL;DR**: Install CEM, then configure your editor to run `cem lsp`. VS Code users can install the extension. Neovim/Zed users configure their LSP client to start `cem lsp` for HTML, Nunjucks, Jinja2, Handlebars, Twig, Liquid, ERB, EJS, PHP, JavaScript, and TypeScript files.
 {{< /tip >}}
 
 Configure the CEM Language Server Protocol integration for your editor to get intelligent autocomplete, hover documentation, and validation for custom elements.
@@ -15,7 +15,7 @@ Configure the CEM Language Server Protocol integration for your editor to get in
 
 ## What is LSP?
 
-The Language Server Protocol provides a standard way to add language-specific features to any editor. The CEM language server analyzes your custom elements manifests to offer contextual autocomplete, hover documentation, go-to-definition, and other IDE enhancements for HTML, Nunjucks, Jinja2, Handlebars, Twig, Liquid, PHP, JavaScript, and TypeScript files. This includes HTML embedded in template languages like Nunjucks, Jinja2, Handlebars, Twig, and Liquid, as well as PHP (e.g. WordPress themes).
+The Language Server Protocol provides a standard way to add language-specific features to any editor. The CEM language server analyzes your custom elements manifests to offer contextual autocomplete, hover documentation, go-to-definition, and other IDE enhancements for HTML, Nunjucks, Jinja2, Handlebars, Twig, Liquid, ERB, EJS, PHP, JavaScript, and TypeScript files. This includes HTML embedded in template languages like Nunjucks, Jinja2, Handlebars, Twig, Liquid, ERB, and EJS, as well as PHP (e.g. WordPress themes).
 
 ## Features
 
@@ -55,7 +55,7 @@ For Neovim 0.12+'s native LSP configuration support, create `~/.config/nvim/lsp/
 return {
   cmd = { 'cem', 'lsp' },
   root_markers = { 'custom-elements.json', 'package.json', '.git' },
-  filetypes = { 'html', 'twig', 'nunjucks', 'jinja2', 'handlebars', 'liquid', 'php', 'typescript', 'javascript' },
+  filetypes = { 'html', 'twig', 'nunjucks', 'jinja2', 'handlebars', 'liquid', 'eruby', 'ejs', 'php', 'typescript', 'javascript' },
   -- Control debug logging via LSP trace levels
   trace = 'off', -- 'off' | 'messages' | 'verbose'
 }
@@ -83,14 +83,14 @@ Depending on which LSP plugin you use, configure Emacs to run `cem` for HTML, Ja
 (lsp-register-client
  (make-lsp-client
   :new-connection (lsp-stdio-connection '("cem" "lsp"))
-  :major-modes '(html-mode twig-mode nunjucks-mode jinja2-mode handlebars-mode liquid-mode php-mode typescript-mode js-mode)
+  :major-modes '(html-mode twig-mode nunjucks-mode jinja2-mode handlebars-mode liquid-mode erb-mode ejs-mode php-mode typescript-mode js-mode)
   :server-id 'cem-lsp))
 ```
 
 **eglot:**
 ```elisp
 (add-to-list 'eglot-server-programs
-             '((html-mode twig-mode nunjucks-mode jinja2-mode handlebars-mode liquid-mode php-mode typescript-mode js-mode) . ("cem" "lsp")))
+             '((html-mode twig-mode nunjucks-mode jinja2-mode handlebars-mode liquid-mode erb-mode ejs-mode php-mode typescript-mode js-mode) . ("cem" "lsp")))
 ```
 
 ### Claude Code
@@ -119,7 +119,7 @@ Configure your LSP client to run `cem lsp` for file types listed below. The serv
 
 Typical configuration elements:
 - **Command**: `cem lsp`
-- **File types**: `html`, `twig`, `nunjucks`, `jinja2`, `handlebars`, `liquid`, `php`, `typescript`, `javascript`
+- **File types**: `html`, `twig`, `nunjucks`, `jinja2`, `handlebars`, `liquid`, `erb`, `ejs`, `php`, `typescript`, `javascript`
 - **Root markers**: `custom-elements.json`, `package.json`, `.git`
 - **Transport**: stdio
 

--- a/extensions/vscode/client/src/extension.ts
+++ b/extensions/vscode/client/src/extension.ts
@@ -112,6 +112,8 @@ export function activate(context: vscode.ExtensionContext) {
         { scheme: 'file', language: 'jinja' },
         { scheme: 'file', language: 'twig' },
         { scheme: 'file', language: 'liquid' },
+        { scheme: 'file', language: 'erb' },
+        { scheme: 'file', language: 'ejs' },
         { scheme: 'file', language: 'typescript' },
         { scheme: 'file', language: 'javascript' },
       ],

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -41,6 +41,8 @@
     "onLanguage:jinja",
     "onLanguage:twig",
     "onLanguage:liquid",
+    "onLanguage:erb",
+    "onLanguage:ejs",
     "onLanguage:typescript",
     "onLanguage:javascript"
   ],

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/tliron/glsp v0.2.2
 	github.com/tree-sitter/go-tree-sitter v0.25.0
 	github.com/tree-sitter/tree-sitter-css v0.23.2
+	github.com/tree-sitter/tree-sitter-embedded-template v0.25.0
 	github.com/tree-sitter/tree-sitter-html v0.23.2
 	github.com/tree-sitter/tree-sitter-jsdoc v0.23.2
 	github.com/tree-sitter/tree-sitter-php v0.23.12

--- a/go.sum
+++ b/go.sum
@@ -239,8 +239,8 @@ github.com/tree-sitter/tree-sitter-cpp v0.23.4 h1:LaWZsiqQKvR65yHgKmnaqA+uz6tlDJ
 github.com/tree-sitter/tree-sitter-cpp v0.23.4/go.mod h1:doqNW64BriC7WBCQ1klf0KmJpdEvfxyXtoEybnBo6v8=
 github.com/tree-sitter/tree-sitter-css v0.23.2 h1:ep4nnzu384hr/QJm1nRKlpJ2vIGTBwPoZE/frwpJVP4=
 github.com/tree-sitter/tree-sitter-css v0.23.2/go.mod h1:Z8l6RvpxfFAHhecXFsMMiUhl6bdoPiGGscJgSlnwHhE=
-github.com/tree-sitter/tree-sitter-embedded-template v0.23.2 h1:nFkkH6Sbe56EXLmZBqHHcamTpmz3TId97I16EnGy4rg=
-github.com/tree-sitter/tree-sitter-embedded-template v0.23.2/go.mod h1:HNPOhN0qF3hWluYLdxWs5WbzP/iE4aaRVPMsdxuzIaQ=
+github.com/tree-sitter/tree-sitter-embedded-template v0.25.0 h1:fP3u58oKV05k7HLsZkCXwwDAEDoOVGWXHhb7ccXnLuw=
+github.com/tree-sitter/tree-sitter-embedded-template v0.25.0/go.mod h1:HNPOhN0qF3hWluYLdxWs5WbzP/iE4aaRVPMsdxuzIaQ=
 github.com/tree-sitter/tree-sitter-go v0.23.4 h1:yt5KMGnTHS+86pJmLIAZMWxukr8W7Ae1STPvQUuNROA=
 github.com/tree-sitter/tree-sitter-go v0.23.4/go.mod h1:Jrx8QqYN0v7npv1fJRH1AznddllYiCMUChtVjxPK040=
 github.com/tree-sitter/tree-sitter-html v0.23.2 h1:1UYDV+Yd05GGRhVnTcbP58GkKLSHHZwVaN+lBZV11Lc=

--- a/lsp/document/common.go
+++ b/lsp/document/common.go
@@ -62,7 +62,7 @@ func getLanguageFromURI(uri string) string {
 		return "typescript"
 	case ".tsx", ".jsx":
 		return "tsx"
-	case ".njk", ".j2", ".jinja", ".jinja2", ".liquid", ".hbs", ".twig":
+	case ".njk", ".j2", ".jinja", ".jinja2", ".liquid", ".hbs", ".twig", ".erb", ".ejs":
 		return "template"
 	default:
 		return "html"

--- a/lsp/document/template/handler.go
+++ b/lsp/document/template/handler.go
@@ -87,6 +87,7 @@ func NewHandler(htmlHandler types.LanguageHandler) (*Handler, error) {
 		jinjaQuery.Close()
 		hbsParser.Close()
 		hbsQuery.Close()
+		etParser.Close()
 		return nil, fmt.Errorf("failed to set embedded-template language: %w", err)
 	}
 

--- a/lsp/document/template/handler.go
+++ b/lsp/document/template/handler.go
@@ -26,13 +26,14 @@ import (
 	tree_sitter_handlebars "bennypowers.dev/tree-sitter-handlebars/bindings/go"
 	tree_sitter_jinja "bennypowers.dev/tree-sitter-jinja-dialects/bindings/go"
 	protocol "github.com/tliron/glsp/protocol_3_16"
+	tree_sitter_embedded_template "github.com/tree-sitter/tree-sitter-embedded-template/bindings/go"
 	sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 // Handler implements language-specific operations for template documents
-// (Nunjucks, Jinja2, Twig, Liquid, Handlebars).
+// (Nunjucks, Jinja2, Twig, Liquid, Handlebars, ERB, EJS).
 // It uses a two-stage pipeline:
-//  1. tree-sitter grammar extracts text nodes (HTML content) from template source
+//  1. tree-sitter grammar extracts text/content nodes (HTML) from template source
 //  2. The HTML handler parses the reconstructed HTML for custom elements
 //
 // Template blocks are replaced with whitespace to preserve line/column positions.
@@ -42,12 +43,15 @@ type Handler struct {
 	jinjaQuery  *sitter.Query
 	hbsParser   *sitter.Parser
 	hbsQuery    *sitter.Query
+	etParser    *sitter.Parser
+	etQuery     *sitter.Query
 	mu          sync.Mutex
 }
 
 var (
 	jinjaLang = sitter.NewLanguage(tree_sitter_jinja.Language())
 	hbsLang   = sitter.NewLanguage(tree_sitter_handlebars.Language())
+	etLang    = sitter.NewLanguage(tree_sitter_embedded_template.Language())
 )
 
 func NewHandler(htmlHandler types.LanguageHandler) (*Handler, error) {
@@ -77,12 +81,33 @@ func NewHandler(htmlHandler types.LanguageHandler) (*Handler, error) {
 		return nil, fmt.Errorf("failed to compile handlebars text query: %w", qerr)
 	}
 
+	etParser := sitter.NewParser()
+	if err := etParser.SetLanguage(etLang); err != nil {
+		jinjaParser.Close()
+		jinjaQuery.Close()
+		hbsParser.Close()
+		hbsQuery.Close()
+		return nil, fmt.Errorf("failed to set embedded-template language: %w", err)
+	}
+
+	etQuery, qerr := sitter.NewQuery(etLang, `(content) @html`)
+	if qerr != nil {
+		jinjaParser.Close()
+		jinjaQuery.Close()
+		hbsParser.Close()
+		hbsQuery.Close()
+		etParser.Close()
+		return nil, fmt.Errorf("failed to compile embedded-template content query: %w", qerr)
+	}
+
 	return &Handler{
 		htmlHandler: htmlHandler,
 		jinjaParser: jinjaParser,
 		jinjaQuery:  jinjaQuery,
 		hbsParser:   hbsParser,
 		hbsQuery:    hbsQuery,
+		etParser:    etParser,
+		etQuery:     etQuery,
 	}, nil
 }
 
@@ -97,16 +122,21 @@ func (h *Handler) Language() string {
 // grammar; HTML inside raw blocks is extracted on a best-effort basis
 // depending on how the grammar parses the block content.
 func templateFamily(uri string) string {
-	if strings.HasSuffix(strings.ToLower(uri), ".hbs") {
+	lower := strings.ToLower(uri)
+	switch {
+	case strings.HasSuffix(lower, ".hbs"):
 		return "handlebars"
+	case strings.HasSuffix(lower, ".erb"), strings.HasSuffix(lower, ".ejs"):
+		return "embedded-template"
+	default:
+		return "jinja"
 	}
-	return "jinja"
 }
 
-// extractHTML uses tree-sitter to find text nodes (HTML content), then replaces
-// template blocks with whitespace to produce valid HTML with preserved positions.
-// The mutex is held for the entire operation to prevent Close from freeing
-// the parser or query while they are in use.
+// extractHTML uses tree-sitter to find text/content nodes (HTML content), then
+// replaces template blocks with whitespace to produce valid HTML with preserved
+// positions. The mutex is held for the entire operation to prevent Close from
+// freeing the parser or query while they are in use.
 func (h *Handler) extractHTML(source []byte, uri string) []byte {
 	family := templateFamily(uri)
 
@@ -120,6 +150,9 @@ func (h *Handler) extractHTML(source []byte, uri string) []byte {
 	case "handlebars":
 		parser = h.hbsParser
 		query = h.hbsQuery
+	case "embedded-template":
+		parser = h.etParser
+		query = h.etQuery
 	default:
 		parser = h.jinjaParser
 		query = h.jinjaQuery
@@ -203,5 +236,13 @@ func (h *Handler) Close() {
 	if h.hbsQuery != nil {
 		h.hbsQuery.Close()
 		h.hbsQuery = nil
+	}
+	if h.etParser != nil {
+		h.etParser.Close()
+		h.etParser = nil
+	}
+	if h.etQuery != nil {
+		h.etQuery.Close()
+		h.etQuery = nil
 	}
 }

--- a/lsp/template_support_test.go
+++ b/lsp/template_support_test.go
@@ -335,6 +335,104 @@ func TestTwig_InTagTemplateSyntax_TwigExtension(t *testing.T) {
 	}
 }
 
+// ERB Custom Element Extraction
+// ============================================================================
+
+func TestERB_FindCustomElements(t *testing.T) {
+	dm := newTemplateDM(t)
+	content := readTemplateFixture(t, "erb-conditional-attr.erb")
+	elements := openAndFindElements(t, dm, "test://page.erb", content)
+
+	assertElementsFound(t, elements, []string{"site-header", "rh-tile", "uxdot-example"})
+}
+
+func TestERB_InTagTemplateSyntax(t *testing.T) {
+	dm := newTemplateDM(t)
+	content := readTemplateFixture(t, "erb-conditional-attr.erb")
+	elements := openAndFindElements(t, dm, "test://page.erb", content)
+
+	el := findElement(elements, "rh-tile")
+	if el == nil {
+		t.Fatal("rh-tile not found")
+	}
+
+	for _, bad := range []string{"<%", "if", "tile.coming_soon", "%>disabled<%", "end", "%>"} {
+		if _, ok := el.Attributes[bad]; ok {
+			t.Errorf("Template syntax %q should not be an attribute", bad)
+		}
+	}
+
+	if _, ok := el.Attributes["compact"]; !ok {
+		t.Error("Expected 'compact' attribute on rh-tile")
+	}
+	if _, ok := el.Attributes["bleed"]; !ok {
+		t.Error("Expected 'bleed' attribute on rh-tile")
+	}
+	if _, ok := el.Attributes["disabled"]; !ok {
+		t.Error("Expected 'disabled' attribute on rh-tile (from conditional template block)")
+	}
+}
+
+func TestERB_PositionPreservation(t *testing.T) {
+	dm := newTemplateDM(t)
+	content := readTemplateFixture(t, "erb-conditional-attr.erb")
+	elements := openAndFindElements(t, dm, "test://page.erb", content)
+
+	// site-header is on line 3 (1-indexed) = line 2 (0-indexed)
+	el := findElement(elements, "site-header")
+	if el == nil {
+		t.Fatal("site-header not found")
+	}
+	if el.Range.Start.Line != 2 {
+		t.Errorf("Expected site-header on line 2, got line %d", el.Range.Start.Line)
+	}
+}
+
+func TestERB_NoCustomElements(t *testing.T) {
+	dm := newTemplateDM(t)
+	content := readTemplateFixture(t, "no-elements.erb")
+	elements := openAndFindElements(t, dm, "test://plain.erb", content)
+
+	if len(elements) != 0 {
+		t.Errorf("Expected 0 custom elements, got %d: %v", len(elements), tagNames(elements))
+	}
+}
+
+// EJS Custom Element Extraction
+// ============================================================================
+
+func TestEJS_FindCustomElements(t *testing.T) {
+	dm := newTemplateDM(t)
+	content := readTemplateFixture(t, "ejs-conditional-attr.ejs")
+	elements := openAndFindElements(t, dm, "test://page.ejs", content)
+
+	assertElementsFound(t, elements, []string{"site-header", "rh-tile", "uxdot-example"})
+}
+
+func TestEJS_InTagTemplateSyntax(t *testing.T) {
+	dm := newTemplateDM(t)
+	content := readTemplateFixture(t, "ejs-conditional-attr.ejs")
+	elements := openAndFindElements(t, dm, "test://page.ejs", content)
+
+	el := findElement(elements, "rh-tile")
+	if el == nil {
+		t.Fatal("rh-tile not found")
+	}
+
+	for _, bad := range []string{"<%", "if", "(tile.comingSoon)", "%>disabled<%", "%>"} {
+		if _, ok := el.Attributes[bad]; ok {
+			t.Errorf("Template syntax %q should not be an attribute", bad)
+		}
+	}
+
+	if _, ok := el.Attributes["compact"]; !ok {
+		t.Error("Expected 'compact' attribute on rh-tile")
+	}
+	if _, ok := el.Attributes["disabled"]; !ok {
+		t.Error("Expected 'disabled' attribute on rh-tile (from conditional template block)")
+	}
+}
+
 // Extension Routing
 // ============================================================================
 

--- a/lsp/testdata/integration/template-support/ejs-conditional-attr.ejs
+++ b/lsp/testdata/integration/template-support/ejs-conditional-attr.ejs
@@ -1,0 +1,14 @@
+<%# EJS template with conditional attributes inside start tags %>
+
+<site-header theme="<%= theme_mode %>">
+  <h1><%= site_name %></h1>
+</site-header>
+
+<% tiles.forEach(function(tile) { %>
+  <rh-tile compact bleed <% if (tile.comingSoon) { %>disabled<% } %>>
+    <uxdot-example slot="image" no-border transparent>
+      <img src="<%= tile.screenshotPath %>" alt="<%= tile.tagName %>">
+    </uxdot-example>
+    <h3 slot="headline"><%= tile.title %></h3>
+  </rh-tile>
+<% }); %>

--- a/lsp/testdata/integration/template-support/erb-conditional-attr.erb
+++ b/lsp/testdata/integration/template-support/erb-conditional-attr.erb
@@ -1,0 +1,14 @@
+<%# ERB template with conditional attributes inside start tags %>
+
+<site-header theme="<%= theme_mode %>">
+  <h1><%= site_name %></h1>
+</site-header>
+
+<% tiles.each do |tile| %>
+  <rh-tile compact bleed <% if tile.coming_soon %>disabled<% end %>>
+    <uxdot-example slot="image" no-border transparent>
+      <img src="<%= tile.screenshot_path %>" alt="<%= tile.tag_name %>">
+    </uxdot-example>
+    <h3 slot="headline"><%= tile.title %></h3>
+  </rh-tile>
+<% end %>

--- a/lsp/testdata/integration/template-support/no-elements.erb
+++ b/lsp/testdata/integration/template-support/no-elements.erb
@@ -1,0 +1,10 @@
+<%# ERB template with no custom elements %>
+
+<div class="container">
+  <h1><%= title %></h1>
+  <ul>
+    <% items.each do |item| %>
+      <li><%= item.name %></li>
+    <% end %>
+  </ul>
+</div>


### PR DESCRIPTION
## Summary

- Add ERB (`.erb`) and EJS (`.ejs`) support to the template handler using the official `tree-sitter/tree-sitter-embedded-template` grammar
- Queries `(content) @html` to extract HTML regions from `<% %>` delimited templates
- Same two-stage pipeline as Jinja/Handlebars: strip template syntax, parse HTML

Closes #298

## Test plan

- [ ] `go test ./lsp/... -count=1` passes (6 new ERB/EJS tests + all existing)
- [ ] Open a `.erb` file with the built LSP and verify no false attribute warnings
- [ ] Open a `.ejs` file with the built LSP and verify no false attribute warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Ruby ERB and EJS template languages to the language server plugin.
  * VS Code extension now activates for `.erb` and `.ejs` files.

* **Documentation**
  * Updated installation guide to include ERB and EJS in all supported language lists and editor configuration examples.

* **Tests**
  * Added integration tests for ERB and EJS template parsing and custom element extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->