### PR TITLE
refactor(lsp): use language injection for template/PHP handlers

### DIFF
--- a/lsp/document/html/document.go
+++ b/lsp/document/html/document.go
@@ -126,10 +126,13 @@ func (d *HTMLDocument) Parser() *ts.Parser {
 	return d.parser
 }
 
-// SetParser sets the document's parser
+// SetParser sets the document's parser, returning any previous parser to the pool.
 func (d *HTMLDocument) SetParser(parser *ts.Parser) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	if d.parser != nil && d.parser != parser {
+		Q.PutHTMLParser(d.parser)
+	}
 	d.parser = parser
 }
 
@@ -568,7 +571,7 @@ func (d *HTMLDocument) analyzeCompletionContext(position protocol.Position, hand
 				parentKind = p.Kind()
 			}
 			if (kind == "<" || parentKind == "ERROR" || parentKind == "start_tag") &&
-				byteOffset > 0 && content[byteOffset-1] == '<' {
+				content[byteOffset-1] == '<' {
 				analysis.Type = types.CompletionTagName
 			}
 		}
@@ -782,26 +785,8 @@ func (d *HTMLDocument) FindInlineModuleScript() (protocol.Position, bool) {
 	return d.FindModuleScript()
 }
 
-func getQueryManager(dm any) *Q.QueryManager {
-	dmValue := reflect.ValueOf(dm)
-	if dmValue.Kind() != reflect.Pointer || dmValue.IsNil() {
-		return nil
-	}
-	method := dmValue.MethodByName("QueryManager")
-	if !method.IsValid() {
-		return nil
-	}
-	results := method.Call(nil)
-	if len(results) == 0 || results[0].IsNil() {
-		return nil
-	}
-	qm, _ := results[0].Interface().(*Q.QueryManager)
-	return qm
-}
-
-// FindHeadInsertionPoint finds insertion point in <head> section using
-// tree-sitter queries. Returns position just before </head>.
-func (d *HTMLDocument) FindHeadInsertionPoint(dm any) (protocol.Position, bool) {
+// findHeadInsertionPoint finds insertion point just before </head> using tree-sitter.
+func (d *HTMLDocument) findHeadInsertionPoint(handler *Handler) (protocol.Position, bool) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
@@ -812,15 +797,9 @@ func (d *HTMLDocument) FindHeadInsertionPoint(dm any) (protocol.Position, bool) 
 
 	content := d.content
 
-	qm := getQueryManager(dm)
-	if qm == nil {
-		helpers.SafeDebugLog("[HTML] FindHeadInsertionPoint: QueryManager not available")
-		return protocol.Position{}, false
-	}
-
-	matcher, err := Q.GetCachedQueryMatcher(qm, "html", "headElements")
+	matcher, err := Q.GetCachedQueryMatcher(handler.queryManager, "html", "headElements")
 	if err != nil {
-		helpers.SafeDebugLog("[HTML] FindHeadInsertionPoint: failed to create matcher: %v", err)
+		helpers.SafeDebugLog("[HTML] findHeadInsertionPoint: failed to create matcher: %v", err)
 		return protocol.Position{}, false
 	}
 	defer matcher.Close()
@@ -833,5 +812,25 @@ func (d *HTMLDocument) FindHeadInsertionPoint(dm any) (protocol.Position, bool) 
 		}
 	}
 
+	return protocol.Position{}, false
+}
+
+// FindHeadInsertionPoint finds insertion point in <head> section (interface method).
+func (d *HTMLDocument) FindHeadInsertionPoint(dm any) (protocol.Position, bool) {
+	dmValue := reflect.ValueOf(dm)
+	if dmValue.Kind() == reflect.Pointer && !dmValue.IsNil() {
+		method := dmValue.MethodByName("GetLanguageHandler")
+		if method.IsValid() {
+			results := method.Call([]reflect.Value{reflect.ValueOf("html")})
+			if len(results) > 0 && !results[0].IsNil() {
+				handler := results[0].Interface()
+				if h, ok := handler.(interface {
+					FindHeadInsertionPoint(types.Document) (protocol.Position, bool)
+				}); ok {
+					return h.FindHeadInsertionPoint(d)
+				}
+			}
+		}
+	}
 	return protocol.Position{}, false
 }

--- a/lsp/document/html/document.go
+++ b/lsp/document/html/document.go
@@ -418,12 +418,8 @@ func (d *HTMLDocument) analyzeCompletionContext(position protocol.Position, hand
 				!strings.Contains(captureText, "=") &&
 				!strings.Contains(captureText, ">") &&
 				!strings.Contains(captureText, "\n") {
-				// This looks like a pure tag name without attributes or other syntax
 				analysis.Type = types.CompletionTagName
-				// Don't set TagName if it's just "<" or contains "<" - let CompletionPrefix extract it
-				if !strings.Contains(captureText, "<") {
-					analysis.TagName = captureText
-				}
+				analysis.TagName = strings.TrimLeft(captureText, "<")
 				return analysis
 			}
 		}
@@ -558,35 +554,25 @@ func (d *HTMLDocument) analyzeCompletionContext(position protocol.Position, hand
 		}
 	}
 
-	// Final fallback: if no captures found, check if cursor is right after a '<' for tag name completion
-	if analysis.Type == types.CompletionUnknown {
-		// Check if the character immediately before the cursor is '<'
-		if byteOffset > 0 && byteOffset <= uint(len(content)) {
-			beforeCursor := content[:byteOffset]
-			// Look for the last '<' character
-			lastOpenBracket := strings.LastIndex(beforeCursor, "<")
-			if lastOpenBracket != -1 {
-				// Check if everything after the last '<' until cursor is just a valid tag name start (no spaces, attributes, etc.)
-				afterBracket := beforeCursor[lastOpenBracket+1:]
-
-				// If cursor is immediately after '<' or after a valid partial tag name
-				if afterBracket == "" || (strings.TrimSpace(afterBracket) == afterBracket &&
-					!strings.Contains(afterBracket, " ") &&
-					!strings.Contains(afterBracket, "=") &&
-					!strings.Contains(afterBracket, ">")) {
-					analysis.Type = types.CompletionTagName
-					// Don't set TagName - let the prefix extraction handle it
-					return analysis
-				}
+	// Tree-sitter fallback: check if cursor is at a bare "<" inside an ERROR
+	// node. The tree has an anonymous "<" child but no tag_name yet, so no
+	// query capture matches. Use DescendantForByteRange to verify the cursor
+	// is inside an ERROR or start_tag context.
+	if analysis.Type == types.CompletionUnknown && byteOffset > 0 {
+		node := tree.RootNode().DescendantForByteRange(byteOffset-1, byteOffset)
+		if node != nil {
+			kind := node.Kind()
+			parentKind := ""
+			if p := node.Parent(); p != nil {
+				parentKind = p.Kind()
+			}
+			if (kind == "<" || parentKind == "ERROR" || parentKind == "start_tag") &&
+				byteOffset > 0 && content[byteOffset-1] == '<' {
+				analysis.Type = types.CompletionTagName
 			}
 		}
 	}
 
-	if captureCount == 0 {
-		helpers.SafeDebugLog("[HTML] No captures found for completion context analysis")
-	}
-
-	// Debug logging for the result
 	helpers.SafeDebugLog("[HTML] analyzeCompletionContext result: Type=%d, TagName=%q", analysis.Type, analysis.TagName)
 
 	return analysis
@@ -615,61 +601,57 @@ func (d *HTMLDocument) positionToByteOffset(pos protocol.Position, content strin
 	return offset
 }
 
-// CompletionPrefix extracts the prefix being typed for filtering completions
+// CompletionPrefix extracts the prefix being typed for filtering completions.
+// Uses analysis struct fields and LineContent only — never searches full
+// document content, which may contain template tokens after injection parsing.
 func (d *HTMLDocument) CompletionPrefix(analysis *types.CompletionAnalysis) string {
 	if analysis == nil {
 		return ""
 	}
 
-	content, err := d.Content()
-	if err != nil {
-		return ""
-	}
-
 	switch analysis.Type {
 	case types.CompletionTagName:
-		// Extract the tag name being typed (after the last "<")
-		// Use LineContent if available to avoid searching the entire document
-		searchContent := content
-		if analysis.LineContent != "" {
-			searchContent = analysis.LineContent
+		if analysis.TagName != "" {
+			return analysis.TagName
 		}
-
-		if lastOpenBracket := strings.LastIndex(searchContent, "<"); lastOpenBracket != -1 {
-			afterBracket := searchContent[lastOpenBracket+1:]
-			// Extract up to first space, >, or end of content
-			for i, r := range afterBracket {
+		if analysis.LineContent == "" {
+			return ""
+		}
+		if i := strings.LastIndex(analysis.LineContent, "<"); i != -1 {
+			after := analysis.LineContent[i+1:]
+			for j, r := range after {
 				if r == ' ' || r == '>' || r == '\n' || r == '\t' {
-					return afterBracket[:i]
+					return after[:j]
 				}
 			}
-			return afterBracket
+			return after
 		}
 		return ""
 
 	case types.CompletionAttributeName:
-		// Extract the attribute name being typed (after the last space in the tag)
-		// Find the last occurrence of "<tagname" to locate the tag start
-		words := strings.Fields(content)
+		if analysis.AttributeName != "" {
+			return analysis.AttributeName
+		}
+		if analysis.LineContent == "" {
+			return ""
+		}
+		words := strings.Fields(analysis.LineContent)
 		if len(words) > 0 {
-			lastWord := words[len(words)-1]
-			// If the last word doesn't contain "<" or "=", it's likely a partial attribute name
-			if !strings.Contains(lastWord, "<") && !strings.Contains(lastWord, "=") {
-				return lastWord
+			last := words[len(words)-1]
+			if !strings.Contains(last, "<") && !strings.Contains(last, "=") {
+				return last
 			}
 		}
 		return ""
 
 	case types.CompletionAttributeValue:
-		// Extract the value being typed (after the last quote)
-		// Look for the last occurrence of " or '
-		lastDoubleQuote := strings.LastIndex(content, "\"")
-		lastSingleQuote := strings.LastIndex(content, "'")
-		lastQuote := max(lastSingleQuote, lastDoubleQuote)
+		line := analysis.LineContent
+		if line == "" {
+			return ""
+		}
+		lastQuote := max(strings.LastIndex(line, "\""), strings.LastIndex(line, "'"))
 		if lastQuote != -1 {
-			afterQuote := content[lastQuote+1:]
-			// Return everything after the quote (the partial value being typed)
-			return afterQuote
+			return line[lastQuote+1:]
 		}
 		return ""
 
@@ -799,19 +781,50 @@ func (d *HTMLDocument) FindInlineModuleScript() (protocol.Position, bool) {
 	return d.FindModuleScript()
 }
 
-// FindHeadInsertionPoint finds insertion point in <head> section
+// FindHeadInsertionPoint finds insertion point in <head> section using
+// tree-sitter queries. Returns position just before </head>.
 func (d *HTMLDocument) FindHeadInsertionPoint(dm any) (protocol.Position, bool) {
-	// Simple implementation - find </head> tag and insert before it
-	content, err := d.Content()
-	if err != nil {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	tree := d.tree
+	if tree == nil {
 		return protocol.Position{}, false
 	}
 
-	lines := strings.Split(content, "\n")
-	for i, line := range lines {
-		if strings.Contains(line, "</head>") {
-			return protocol.Position{Line: uint32(i), Character: 0}, true
+	content := d.content
+
+	// Get queryManager from dm via reflection
+	dmValue := reflect.ValueOf(dm)
+	if dmValue.Kind() != reflect.Pointer || dmValue.IsNil() {
+		return protocol.Position{}, false
+	}
+	method := dmValue.MethodByName("QueryManager")
+	if !method.IsValid() {
+		return protocol.Position{}, false
+	}
+	results := method.Call(nil)
+	if len(results) == 0 || results[0].IsNil() {
+		return protocol.Position{}, false
+	}
+	qm, ok := results[0].Interface().(*Q.QueryManager)
+	if !ok {
+		return protocol.Position{}, false
+	}
+
+	matcher, err := Q.GetCachedQueryMatcher(qm, "html", "headElements")
+	if err != nil {
+		return protocol.Position{}, false
+	}
+	defer matcher.Close()
+
+	root := tree.RootNode()
+	for captureMap := range matcher.ParentCaptures(root, []byte(content), "head.element") {
+		if endTags, exists := captureMap["end.tag"]; exists && len(endTags) > 0 {
+			pos := d.byteOffsetToPosition(endTags[0].StartByte)
+			return pos, true
 		}
 	}
+
 	return protocol.Position{}, false
 }

--- a/lsp/document/html/document.go
+++ b/lsp/document/html/document.go
@@ -224,6 +224,10 @@ func (d *HTMLDocument) Parse(content string) error {
 func (d *HTMLDocument) ParseWithRanges(content string, ranges []ts.Range) error {
 	d.UpdateContent(content, d.version)
 
+	if len(ranges) == 0 {
+		return nil
+	}
+
 	parser := Q.GetHTMLParser()
 	if parser == nil {
 		return fmt.Errorf("failed to get HTML parser")

--- a/lsp/document/html/document.go
+++ b/lsp/document/html/document.go
@@ -213,6 +213,33 @@ func (d *HTMLDocument) Parse(content string) error {
 	return nil
 }
 
+// ParseWithRanges parses using tree-sitter language injection: the HTML parser
+// is restricted to the given byte ranges (e.g. HTML regions extracted from a
+// template grammar). Byte positions in the resulting tree refer to the original
+// source, so line/column mapping works without a whitespace-filled buffer.
+func (d *HTMLDocument) ParseWithRanges(content string, ranges []ts.Range) error {
+	d.UpdateContent(content, d.version)
+
+	parser := Q.GetHTMLParser()
+	if parser == nil {
+		return fmt.Errorf("failed to get HTML parser")
+	}
+	d.SetParser(parser)
+
+	if err := parser.SetIncludedRanges(ranges); err != nil {
+		return fmt.Errorf("failed to set included ranges: %w", err)
+	}
+
+	tree := parser.Parse([]byte(content), nil)
+
+	// Clear included ranges so the parser doesn't carry stale state
+	_ = parser.SetIncludedRanges(nil)
+
+	d.SetTree(tree)
+
+	return nil
+}
+
 // findCustomElements finds custom elements in the HTML document
 func (d *HTMLDocument) findCustomElements(handler *Handler) ([]types.CustomElementMatch, error) {
 	var elements []types.CustomElementMatch

--- a/lsp/document/html/document.go
+++ b/lsp/document/html/document.go
@@ -158,6 +158,7 @@ func (d *HTMLDocument) Close() {
 	}
 
 	if d.parser != nil {
+		Q.PutHTMLParser(d.parser)
 		d.parser = nil
 	}
 }
@@ -781,6 +782,23 @@ func (d *HTMLDocument) FindInlineModuleScript() (protocol.Position, bool) {
 	return d.FindModuleScript()
 }
 
+func getQueryManager(dm any) *Q.QueryManager {
+	dmValue := reflect.ValueOf(dm)
+	if dmValue.Kind() != reflect.Pointer || dmValue.IsNil() {
+		return nil
+	}
+	method := dmValue.MethodByName("QueryManager")
+	if !method.IsValid() {
+		return nil
+	}
+	results := method.Call(nil)
+	if len(results) == 0 || results[0].IsNil() {
+		return nil
+	}
+	qm, _ := results[0].Interface().(*Q.QueryManager)
+	return qm
+}
+
 // FindHeadInsertionPoint finds insertion point in <head> section using
 // tree-sitter queries. Returns position just before </head>.
 func (d *HTMLDocument) FindHeadInsertionPoint(dm any) (protocol.Position, bool) {
@@ -794,26 +812,15 @@ func (d *HTMLDocument) FindHeadInsertionPoint(dm any) (protocol.Position, bool) 
 
 	content := d.content
 
-	// Get queryManager from dm via reflection
-	dmValue := reflect.ValueOf(dm)
-	if dmValue.Kind() != reflect.Pointer || dmValue.IsNil() {
-		return protocol.Position{}, false
-	}
-	method := dmValue.MethodByName("QueryManager")
-	if !method.IsValid() {
-		return protocol.Position{}, false
-	}
-	results := method.Call(nil)
-	if len(results) == 0 || results[0].IsNil() {
-		return protocol.Position{}, false
-	}
-	qm, ok := results[0].Interface().(*Q.QueryManager)
-	if !ok {
+	qm := getQueryManager(dm)
+	if qm == nil {
+		helpers.SafeDebugLog("[HTML] FindHeadInsertionPoint: QueryManager not available")
 		return protocol.Position{}, false
 	}
 
 	matcher, err := Q.GetCachedQueryMatcher(qm, "html", "headElements")
 	if err != nil {
+		helpers.SafeDebugLog("[HTML] FindHeadInsertionPoint: failed to create matcher: %v", err)
 		return protocol.Position{}, false
 	}
 	defer matcher.Close()

--- a/lsp/document/html/handler.go
+++ b/lsp/document/html/handler.go
@@ -26,6 +26,7 @@ import (
 	"bennypowers.dev/cem/lsp/types"
 	Q "bennypowers.dev/cem/queries"
 	protocol "github.com/tliron/glsp/protocol_3_16"
+	ts "github.com/tree-sitter/go-tree-sitter"
 )
 
 // Handler implements language-specific operations for HTML documents
@@ -70,6 +71,37 @@ func (h *Handler) CreateDocument(uri, content string, version int32) types.Docum
 	}
 
 	// Parse import map (must be called after script tags are parsed)
+	if importMap, err := h.ParseImportMap(doc); err != nil {
+		helpers.SafeDebugLog("[HTML] Failed to parse import map: %v", err)
+	} else if importMap != nil {
+		doc.SetImportMap(importMap)
+	}
+
+	return doc
+}
+
+// CreateDocumentWithRanges creates an HTML document using tree-sitter language
+// injection. The HTML parser is restricted to the given byte ranges, so only
+// those regions are parsed as HTML while byte positions map to the original
+// source. Used by template and PHP handlers instead of whitespace-fill.
+func (h *Handler) CreateDocumentWithRanges(uri, content string, version int32, ranges []ts.Range) types.Document {
+	doc := &HTMLDocument{
+		uri:      uri,
+		content:  content,
+		version:  version,
+		language: "html",
+	}
+
+	if err := doc.ParseWithRanges(content, ranges); err != nil {
+		helpers.SafeDebugLog("[HTML] Failed to parse document with ranges %s: %v", uri, err)
+	}
+
+	if scriptTags, err := h.ParseScriptTags(doc); err != nil {
+		helpers.SafeDebugLog("[HTML] Failed to parse script tags with handler: %v", err)
+	} else {
+		doc.SetScriptTags(scriptTags)
+	}
+
 	if importMap, err := h.ParseImportMap(doc); err != nil {
 		helpers.SafeDebugLog("[HTML] Failed to parse import map: %v", err)
 	} else if importMap != nil {

--- a/lsp/document/html/handler.go
+++ b/lsp/document/html/handler.go
@@ -164,6 +164,15 @@ func (h *Handler) FindAttributeAtPosition(doc types.Document, position protocol.
 	return nil, ""
 }
 
+// FindHeadInsertionPoint finds the position just before </head> using tree-sitter.
+func (h *Handler) FindHeadInsertionPoint(doc types.Document) (protocol.Position, bool) {
+	htmlDoc, ok := doc.(*HTMLDocument)
+	if !ok {
+		return protocol.Position{}, false
+	}
+	return htmlDoc.findHeadInsertionPoint(h)
+}
+
 // ParseScriptTags parses script tags in the HTML document using tree-sitter
 func (h *Handler) ParseScriptTags(doc types.Document) ([]types.ScriptTag, error) {
 	htmlDoc, ok := doc.(*HTMLDocument)

--- a/lsp/document/html/handler.go
+++ b/lsp/document/html/handler.go
@@ -58,25 +58,11 @@ func (h *Handler) CreateDocument(uri, content string, version int32) types.Docum
 		language: "html",
 	}
 
-	// Parse the document
 	if err := doc.Parse(content); err != nil {
 		helpers.SafeDebugLog("[HTML] Failed to parse document %s: %v", uri, err)
 	}
 
-	// Parse script tags using the handler's tree-sitter implementation
-	if scriptTags, err := h.ParseScriptTags(doc); err != nil {
-		helpers.SafeDebugLog("[HTML] Failed to parse script tags with handler: %v", err)
-	} else {
-		doc.SetScriptTags(scriptTags)
-	}
-
-	// Parse import map (must be called after script tags are parsed)
-	if importMap, err := h.ParseImportMap(doc); err != nil {
-		helpers.SafeDebugLog("[HTML] Failed to parse import map: %v", err)
-	} else if importMap != nil {
-		doc.SetImportMap(importMap)
-	}
-
+	h.finalizeDocument(doc)
 	return doc
 }
 
@@ -96,6 +82,11 @@ func (h *Handler) CreateDocumentWithRanges(uri, content string, version int32, r
 		helpers.SafeDebugLog("[HTML] Failed to parse document with ranges %s: %v", uri, err)
 	}
 
+	h.finalizeDocument(doc)
+	return doc
+}
+
+func (h *Handler) finalizeDocument(doc *HTMLDocument) {
 	if scriptTags, err := h.ParseScriptTags(doc); err != nil {
 		helpers.SafeDebugLog("[HTML] Failed to parse script tags with handler: %v", err)
 	} else {
@@ -107,8 +98,6 @@ func (h *Handler) CreateDocumentWithRanges(uri, content string, version int32, r
 	} else if importMap != nil {
 		doc.SetImportMap(importMap)
 	}
-
-	return doc
 }
 
 // FindCustomElements finds custom elements in the document

--- a/lsp/document/php/handler.go
+++ b/lsp/document/php/handler.go
@@ -37,7 +37,7 @@ type Handler struct {
 	htmlHandler types.LanguageHandler
 	phpParser   *sitter.Parser
 	textQuery   *sitter.Query
-	mu          sync.RWMutex
+	mu          sync.Mutex
 }
 
 var phpLang = sitter.NewLanguage(tree_sitter_php.LanguagePHP())
@@ -77,15 +77,15 @@ type rangeParser interface {
 // byte ranges for use with tree-sitter language injection.
 func (h *Handler) htmlRanges(source []byte) []sitter.Range {
 	h.mu.Lock()
+	defer h.mu.Unlock()
+
 	parser := h.phpParser
 	query := h.textQuery
 	if parser == nil || query == nil {
-		h.mu.Unlock()
 		return nil
 	}
 	parser.Reset()
 	tree := parser.Parse(source, nil)
-	h.mu.Unlock()
 
 	if tree == nil {
 		return nil

--- a/lsp/document/php/handler.go
+++ b/lsp/document/php/handler.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"sync"
 
-	"bennypowers.dev/cem/lsp/helpers"
 	"bennypowers.dev/cem/lsp/types"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 	sitter "github.com/tree-sitter/go-tree-sitter"
@@ -105,17 +104,7 @@ func (h *Handler) htmlRanges(source []byte) []sitter.Range {
 // delegating to the HTML handler with tree-sitter language injection.
 func (h *Handler) CreateDocument(uri, content string, version int32) types.Document {
 	ranges := h.htmlRanges([]byte(content))
-	if len(ranges) == 0 {
-		helpers.SafeDebugLog("[PHP] failed to extract HTML ranges from %s, falling back to raw content", uri)
-		return h.htmlHandler.CreateDocument(uri, content, version)
-	}
-
-	if rp, ok := h.htmlHandler.(types.RangeParser); ok {
-		return rp.CreateDocumentWithRanges(uri, content, version, ranges)
-	}
-
-	helpers.SafeDebugLog("[PHP] htmlHandler does not support range parsing, falling back to raw content")
-	return h.htmlHandler.CreateDocument(uri, content, version)
+	return h.htmlHandler.(types.RangeParser).CreateDocumentWithRanges(uri, content, version, ranges)
 }
 
 // FindCustomElements delegates to the HTML handler

--- a/lsp/document/php/handler.go
+++ b/lsp/document/php/handler.go
@@ -67,12 +67,6 @@ func (h *Handler) Language() string {
 	return "php"
 }
 
-// rangeParser is implemented by handlers that support tree-sitter language
-// injection via SetIncludedRanges.
-type rangeParser interface {
-	CreateDocumentWithRanges(uri, content string, version int32, ranges []sitter.Range) types.Document
-}
-
 // htmlRanges uses tree-sitter-php to find HTML text nodes and returns their
 // byte ranges for use with tree-sitter language injection.
 func (h *Handler) htmlRanges(source []byte) []sitter.Range {
@@ -111,12 +105,12 @@ func (h *Handler) htmlRanges(source []byte) []sitter.Range {
 // delegating to the HTML handler with tree-sitter language injection.
 func (h *Handler) CreateDocument(uri, content string, version int32) types.Document {
 	ranges := h.htmlRanges([]byte(content))
-	if ranges == nil {
+	if len(ranges) == 0 {
 		helpers.SafeDebugLog("[PHP] failed to extract HTML ranges from %s, falling back to raw content", uri)
 		return h.htmlHandler.CreateDocument(uri, content, version)
 	}
 
-	if rp, ok := h.htmlHandler.(rangeParser); ok {
+	if rp, ok := h.htmlHandler.(types.RangeParser); ok {
 		return rp.CreateDocumentWithRanges(uri, content, version, ranges)
 	}
 

--- a/lsp/document/php/handler.go
+++ b/lsp/document/php/handler.go
@@ -28,11 +28,11 @@ import (
 )
 
 // Handler implements language-specific operations for PHP documents.
-// It uses a two-stage pipeline:
-//  1. tree-sitter-php extracts HTML text nodes from PHP source
-//  2. The HTML handler parses the reconstructed HTML for custom elements
+// It uses tree-sitter language injection:
+//  1. tree-sitter-php extracts HTML region byte ranges from PHP source
+//  2. The HTML parser is restricted to those ranges via SetIncludedRanges
 //
-// PHP blocks are replaced with whitespace to preserve line/column positions.
+// Byte positions in the resulting tree map to the original source automatically.
 type Handler struct {
 	htmlHandler types.LanguageHandler
 	phpParser   *sitter.Parser
@@ -67,9 +67,15 @@ func (h *Handler) Language() string {
 	return "php"
 }
 
-// extractHTML uses tree-sitter-php to find HTML text nodes, then replaces
-// PHP blocks with whitespace to produce valid HTML with preserved positions.
-func (h *Handler) extractHTML(source []byte) []byte {
+// rangeParser is implemented by handlers that support tree-sitter language
+// injection via SetIncludedRanges.
+type rangeParser interface {
+	CreateDocumentWithRanges(uri, content string, version int32, ranges []sitter.Range) types.Document
+}
+
+// htmlRanges uses tree-sitter-php to find HTML text nodes and returns their
+// byte ranges for use with tree-sitter language injection.
+func (h *Handler) htmlRanges(source []byte) []sitter.Range {
 	h.mu.Lock()
 	parser := h.phpParser
 	query := h.textQuery
@@ -86,41 +92,36 @@ func (h *Handler) extractHTML(source []byte) []byte {
 	}
 	defer tree.Close()
 
-	// Start with a buffer where PHP blocks are whitespace
-	buf := make([]byte, len(source))
-	for i, b := range source {
-		if b == '\n' {
-			buf[i] = '\n'
-		} else {
-			buf[i] = ' '
-		}
-	}
-
-	// Copy HTML text nodes back into position
 	cursor := sitter.NewQueryCursor()
 	defer cursor.Close()
 
+	var ranges []sitter.Range
 	matches := cursor.Matches(query, tree.RootNode(), source)
 	for m := matches.Next(); m != nil; m = matches.Next() {
 		for _, c := range m.Captures {
 			n := c.Node
-			copy(buf[n.StartByte():n.EndByte()], source[n.StartByte():n.EndByte()])
+			ranges = append(ranges, n.Range())
 		}
 	}
 
-	return buf
+	return ranges
 }
 
-// CreateDocument creates a new PHP document by extracting HTML and delegating
-// to the HTML handler
+// CreateDocument creates a new PHP document by extracting HTML ranges and
+// delegating to the HTML handler with tree-sitter language injection.
 func (h *Handler) CreateDocument(uri, content string, version int32) types.Document {
-	htmlContent := h.extractHTML([]byte(content))
-	if htmlContent == nil {
-		helpers.SafeDebugLog("[PHP] Failed to extract HTML from %s, falling back to raw content", uri)
+	ranges := h.htmlRanges([]byte(content))
+	if ranges == nil {
+		helpers.SafeDebugLog("[PHP] failed to extract HTML ranges from %s, falling back to raw content", uri)
 		return h.htmlHandler.CreateDocument(uri, content, version)
 	}
 
-	return h.htmlHandler.CreateDocument(uri, string(htmlContent), version)
+	if rp, ok := h.htmlHandler.(rangeParser); ok {
+		return rp.CreateDocumentWithRanges(uri, content, version, ranges)
+	}
+
+	helpers.SafeDebugLog("[PHP] htmlHandler does not support range parsing, falling back to raw content")
+	return h.htmlHandler.CreateDocument(uri, content, version)
 }
 
 // FindCustomElements delegates to the HTML handler

--- a/lsp/document/php/handler.go
+++ b/lsp/document/php/handler.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"sync"
 
+	"bennypowers.dev/cem/lsp/helpers"
 	"bennypowers.dev/cem/lsp/types"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 	sitter "github.com/tree-sitter/go-tree-sitter"
@@ -104,7 +105,11 @@ func (h *Handler) htmlRanges(source []byte) []sitter.Range {
 // delegating to the HTML handler with tree-sitter language injection.
 func (h *Handler) CreateDocument(uri, content string, version int32) types.Document {
 	ranges := h.htmlRanges([]byte(content))
-	return h.htmlHandler.(types.RangeParser).CreateDocumentWithRanges(uri, content, version, ranges)
+	if rp, ok := h.htmlHandler.(types.RangeParser); ok {
+		return rp.CreateDocumentWithRanges(uri, content, version, ranges)
+	}
+	helpers.SafeDebugLog("[PHP] htmlHandler does not implement RangeParser for %s", uri)
+	return h.htmlHandler.CreateDocument(uri, content, version)
 }
 
 // FindCustomElements delegates to the HTML handler

--- a/lsp/document/template/handler.go
+++ b/lsp/document/template/handler.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"sync"
 
-	"bennypowers.dev/cem/lsp/helpers"
 	"bennypowers.dev/cem/lsp/types"
 	tree_sitter_handlebars "bennypowers.dev/tree-sitter-handlebars/bindings/go"
 	tree_sitter_jinja "bennypowers.dev/tree-sitter-jinja-dialects/bindings/go"
@@ -185,17 +184,7 @@ func (h *Handler) htmlRanges(source []byte, uri string) []sitter.Range {
 
 func (h *Handler) CreateDocument(uri, content string, version int32) types.Document {
 	ranges := h.htmlRanges([]byte(content), uri)
-	if len(ranges) == 0 {
-		helpers.SafeDebugLog("[TEMPLATE] failed to extract HTML ranges from %s, falling back to raw content", uri)
-		return h.htmlHandler.CreateDocument(uri, content, version)
-	}
-
-	if rp, ok := h.htmlHandler.(types.RangeParser); ok {
-		return rp.CreateDocumentWithRanges(uri, content, version, ranges)
-	}
-
-	helpers.SafeDebugLog("[TEMPLATE] htmlHandler does not support range parsing, falling back to raw content")
-	return h.htmlHandler.CreateDocument(uri, content, version)
+	return h.htmlHandler.(types.RangeParser).CreateDocumentWithRanges(uri, content, version, ranges)
 }
 
 func (h *Handler) FindCustomElements(doc types.Document) ([]types.CustomElementMatch, error) {

--- a/lsp/document/template/handler.go
+++ b/lsp/document/template/handler.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"sync"
 
+	"bennypowers.dev/cem/lsp/helpers"
 	"bennypowers.dev/cem/lsp/types"
 	tree_sitter_handlebars "bennypowers.dev/tree-sitter-handlebars/bindings/go"
 	tree_sitter_jinja "bennypowers.dev/tree-sitter-jinja-dialects/bindings/go"
@@ -184,7 +185,11 @@ func (h *Handler) htmlRanges(source []byte, uri string) []sitter.Range {
 
 func (h *Handler) CreateDocument(uri, content string, version int32) types.Document {
 	ranges := h.htmlRanges([]byte(content), uri)
-	return h.htmlHandler.(types.RangeParser).CreateDocumentWithRanges(uri, content, version, ranges)
+	if rp, ok := h.htmlHandler.(types.RangeParser); ok {
+		return rp.CreateDocumentWithRanges(uri, content, version, ranges)
+	}
+	helpers.SafeDebugLog("[TEMPLATE] htmlHandler does not implement RangeParser for %s", uri)
+	return h.htmlHandler.CreateDocument(uri, content, version)
 }
 
 func (h *Handler) FindCustomElements(doc types.Document) ([]types.CustomElementMatch, error) {

--- a/lsp/document/template/handler.go
+++ b/lsp/document/template/handler.go
@@ -134,12 +134,6 @@ func templateFamily(uri string) string {
 	}
 }
 
-// rangeParser is implemented by handlers that support tree-sitter language
-// injection via SetIncludedRanges.
-type rangeParser interface {
-	CreateDocumentWithRanges(uri, content string, version int32, ranges []sitter.Range) types.Document
-}
-
 // htmlRanges uses tree-sitter to find text/content nodes (HTML content) and
 // returns their byte ranges for use with tree-sitter language injection.
 func (h *Handler) htmlRanges(source []byte, uri string) []sitter.Range {
@@ -191,12 +185,12 @@ func (h *Handler) htmlRanges(source []byte, uri string) []sitter.Range {
 
 func (h *Handler) CreateDocument(uri, content string, version int32) types.Document {
 	ranges := h.htmlRanges([]byte(content), uri)
-	if ranges == nil {
+	if len(ranges) == 0 {
 		helpers.SafeDebugLog("[TEMPLATE] failed to extract HTML ranges from %s, falling back to raw content", uri)
 		return h.htmlHandler.CreateDocument(uri, content, version)
 	}
 
-	if rp, ok := h.htmlHandler.(rangeParser); ok {
+	if rp, ok := h.htmlHandler.(types.RangeParser); ok {
 		return rp.CreateDocumentWithRanges(uri, content, version, ranges)
 	}
 

--- a/lsp/document/template/handler.go
+++ b/lsp/document/template/handler.go
@@ -32,11 +32,11 @@ import (
 
 // Handler implements language-specific operations for template documents
 // (Nunjucks, Jinja2, Twig, Liquid, Handlebars, ERB, EJS).
-// It uses a two-stage pipeline:
-//  1. tree-sitter grammar extracts text/content nodes (HTML) from template source
-//  2. The HTML handler parses the reconstructed HTML for custom elements
+// It uses tree-sitter language injection:
+//  1. tree-sitter grammar extracts HTML region byte ranges from template source
+//  2. The HTML parser is restricted to those ranges via SetIncludedRanges
 //
-// Template blocks are replaced with whitespace to preserve line/column positions.
+// Byte positions in the resulting tree map to the original source automatically.
 type Handler struct {
 	htmlHandler types.LanguageHandler
 	jinjaParser *sitter.Parser
@@ -134,11 +134,15 @@ func templateFamily(uri string) string {
 	}
 }
 
-// extractHTML uses tree-sitter to find text/content nodes (HTML content), then
-// replaces template blocks with whitespace to produce valid HTML with preserved
-// positions. The mutex is held for the entire operation to prevent Close from
-// freeing the parser or query while they are in use.
-func (h *Handler) extractHTML(source []byte, uri string) []byte {
+// rangeParser is implemented by handlers that support tree-sitter language
+// injection via SetIncludedRanges.
+type rangeParser interface {
+	CreateDocumentWithRanges(uri, content string, version int32, ranges []sitter.Range) types.Document
+}
+
+// htmlRanges uses tree-sitter to find text/content nodes (HTML content) and
+// returns their byte ranges for use with tree-sitter language injection.
+func (h *Handler) htmlRanges(source []byte, uri string) []sitter.Range {
 	family := templateFamily(uri)
 
 	h.mu.Lock()
@@ -170,37 +174,34 @@ func (h *Handler) extractHTML(source []byte, uri string) []byte {
 	}
 	defer tree.Close()
 
-	buf := make([]byte, len(source))
-	for i, b := range source {
-		if b == '\n' {
-			buf[i] = '\n'
-		} else {
-			buf[i] = ' '
-		}
-	}
-
 	cursor := sitter.NewQueryCursor()
 	defer cursor.Close()
 
+	var ranges []sitter.Range
 	matches := cursor.Matches(query, tree.RootNode(), source)
 	for m := matches.Next(); m != nil; m = matches.Next() {
 		for _, c := range m.Captures {
 			n := c.Node
-			copy(buf[n.StartByte():n.EndByte()], source[n.StartByte():n.EndByte()])
+			ranges = append(ranges, n.Range())
 		}
 	}
 
-	return buf
+	return ranges
 }
 
 func (h *Handler) CreateDocument(uri, content string, version int32) types.Document {
-	htmlContent := h.extractHTML([]byte(content), uri)
-	if htmlContent == nil {
-		helpers.SafeDebugLog("[TEMPLATE] failed to extract HTML from %s, falling back to raw content", uri)
+	ranges := h.htmlRanges([]byte(content), uri)
+	if ranges == nil {
+		helpers.SafeDebugLog("[TEMPLATE] failed to extract HTML ranges from %s, falling back to raw content", uri)
 		return h.htmlHandler.CreateDocument(uri, content, version)
 	}
 
-	return h.htmlHandler.CreateDocument(uri, string(htmlContent), version)
+	if rp, ok := h.htmlHandler.(rangeParser); ok {
+		return rp.CreateDocumentWithRanges(uri, content, version, ranges)
+	}
+
+	helpers.SafeDebugLog("[TEMPLATE] htmlHandler does not support range parsing, falling back to raw content")
+	return h.htmlHandler.CreateDocument(uri, content, version)
 }
 
 func (h *Handler) FindCustomElements(doc types.Document) ([]types.CustomElementMatch, error) {

--- a/lsp/methods/textDocument/completion/completion_context_test.go
+++ b/lsp/methods/textDocument/completion/completion_context_test.go
@@ -173,6 +173,20 @@ func TestCompletionPrefixExtraction(t *testing.T) {
 			attributeName:  "disabled",
 			expectedPrefix: "tr",
 		},
+		{
+			name:           "Tag name from struct field",
+			beforeCursor:   "",
+			completionType: types.CompletionTagName,
+			tagName:        "my-element",
+			expectedPrefix: "my-element",
+		},
+		{
+			name:           "Attribute name from struct field",
+			beforeCursor:   "",
+			completionType: types.CompletionAttributeName,
+			attributeName:  "dis",
+			expectedPrefix: "dis",
+		},
 	}
 
 	for _, tt := range tests {

--- a/lsp/php_twig_support_test.go
+++ b/lsp/php_twig_support_test.go
@@ -319,86 +319,76 @@ func TestTwig_TwigExtension(t *testing.T) {
 // PHP Completion Context (injection safety)
 // ============================================================================
 
-func TestPHP_CompletionContext_PHPLessThan(t *testing.T) {
+func newPHPDM(t *testing.T) types.Manager {
+	t.Helper()
 	dm, err := document.NewDocumentManager()
 	if err != nil {
 		t.Fatalf("Failed to create document manager: %v", err)
 	}
-	defer dm.Close()
+	t.Cleanup(dm.Close)
+	return dm
+}
 
-	// PHP comparison operator < must not be mistaken for HTML tag start
-	content := "<?php if ($count < $max) { ?>\n<my-element>\n<?php } ?>"
-	doc := dm.OpenDocument("test://cmp.php", content, 1)
+func TestPHP_CompletionContext(t *testing.T) {
+	dm := newPHPDM(t)
 
-	// Cursor at start of <my-element> on line 1
-	analysis := doc.AnalyzeCompletionContextTS(protocol.Position{Line: 1, Character: 1}, dm)
-	if analysis.Type != types.CompletionTagName {
-		t.Errorf("Expected CompletionTagName at element position, got %d", analysis.Type)
+	tests := []struct {
+		name     string
+		fixture  string
+		position protocol.Position
+		wantType types.CompletionContextType
+		wantTag  string
+	}{
+		{"at-element", "comparison-operator.php", protocol.Position{Line: 1, Character: 1}, types.CompletionTagName, "my-element"},
+		{"in-php-region", "comparison-operator.php", protocol.Position{Line: 0, Character: 15}, types.CompletionUnknown, ""},
 	}
-	if analysis.TagName != "my-element" {
-		t.Errorf("Expected TagName 'my-element', got %q", analysis.TagName)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := readPHPTwigFixture(t, tt.fixture)
+			doc := dm.OpenDocument("test://cmp.php", content, 1)
+
+			analysis := doc.AnalyzeCompletionContextTS(tt.position, dm)
+			if analysis.Type != tt.wantType {
+				t.Errorf("Expected completion type %d, got %d", tt.wantType, analysis.Type)
+			}
+			if tt.wantTag != "" && analysis.TagName != tt.wantTag {
+				t.Errorf("Expected TagName %q, got %q", tt.wantTag, analysis.TagName)
+			}
+		})
 	}
 }
 
-func TestPHP_CompletionContext_CursorInPHPRegion(t *testing.T) {
-	dm, err := document.NewDocumentManager()
-	if err != nil {
-		t.Fatalf("Failed to create document manager: %v", err)
+func TestPHP_EdgeCases(t *testing.T) {
+	dm := newPHPDM(t)
+
+	tests := []struct {
+		name         string
+		fixture      string
+		wantElements []string
+	}{
+		{"pure-php", "pure-php.php", nil},
+		{"pure-html", "pure-html.php", []string{"my-element"}},
 	}
-	defer dm.Close()
 
-	content := "<?php if ($count < $max) { ?>\n<my-element>\n<?php } ?>"
-	doc := dm.OpenDocument("test://cmp.php", content, 1)
-
-	// Cursor inside PHP region (line 0, inside <?php ... ?>)
-	analysis := doc.AnalyzeCompletionContextTS(protocol.Position{Line: 0, Character: 15}, dm)
-	if analysis.Type != types.CompletionUnknown {
-		t.Errorf("Expected CompletionUnknown in PHP region, got %d", analysis.Type)
-	}
-}
-
-func TestPHP_EntirelyPHP(t *testing.T) {
-	dm, err := document.NewDocumentManager()
-	if err != nil {
-		t.Fatalf("Failed to create document manager: %v", err)
-	}
-	defer dm.Close()
-
-	content := "<?php\n$x = 1;\nif ($x < 2) {\n  echo 'hello';\n}\n?>"
-	elements := openAndFindElements(t, dm, "test://pure.php", content)
-	if len(elements) != 0 {
-		t.Errorf("Expected no elements in pure PHP file, got %d", len(elements))
-	}
-}
-
-func TestPHP_EntirelyHTML(t *testing.T) {
-	dm, err := document.NewDocumentManager()
-	if err != nil {
-		t.Fatalf("Failed to create document manager: %v", err)
-	}
-	defer dm.Close()
-
-	content := "<html>\n<body>\n<my-element attr=\"val\"></my-element>\n</body>\n</html>"
-	elements := openAndFindElements(t, dm, "test://pure.php", content)
-	assertElementsFound(t, elements, []string{"my-element"})
-
-	el := findElement(elements, "my-element")
-	if el == nil {
-		t.Fatal("my-element not found")
-	}
-	if v, ok := el.Attributes["attr"]; !ok || v.Value != "val" {
-		t.Errorf("Expected attr='val', got %+v", el.Attributes)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := readPHPTwigFixture(t, tt.fixture)
+			elements := openAndFindElements(t, dm, "test://edge.php", content)
+			if tt.wantElements == nil {
+				if len(elements) != 0 {
+					t.Errorf("Expected no elements, got %d", len(elements))
+				}
+			} else {
+				assertElementsFound(t, elements, tt.wantElements)
+			}
+		})
 	}
 }
 
 func TestPHP_HeadInsertionPoint(t *testing.T) {
-	dm, err := document.NewDocumentManager()
-	if err != nil {
-		t.Fatalf("Failed to create document manager: %v", err)
-	}
-	defer dm.Close()
-
-	content := "<?php include 'header.php'; ?>\n<html>\n<head>\n  <title>Test</title>\n</head>\n<body>\n  <my-element></my-element>\n</body>\n</html>"
+	dm := newPHPDM(t)
+	content := readPHPTwigFixture(t, "head-section.php")
 	doc := dm.OpenDocument("test://head.php", content, 1)
 
 	pos, found := doc.FindHeadInsertionPoint(dm)

--- a/lsp/php_twig_support_test.go
+++ b/lsp/php_twig_support_test.go
@@ -24,6 +24,7 @@ import (
 
 	"bennypowers.dev/cem/lsp/document"
 	"bennypowers.dev/cem/lsp/types"
+	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
 const phpTwigFixtureDir = "testdata/integration/php-twig-support"
@@ -312,5 +313,65 @@ func TestTwig_TwigExtension(t *testing.T) {
 
 	if len(elements) == 0 {
 		t.Error("Expected custom elements to be found for .twig extension")
+	}
+}
+
+// PHP Completion Context (injection safety)
+// ============================================================================
+
+func TestPHP_CompletionContext_PHPLessThan(t *testing.T) {
+	dm, err := document.NewDocumentManager()
+	if err != nil {
+		t.Fatalf("Failed to create document manager: %v", err)
+	}
+	defer dm.Close()
+
+	// PHP comparison operator < must not be mistaken for HTML tag start
+	content := "<?php if ($count < $max) { ?>\n<my-element>\n<?php } ?>"
+	doc := dm.OpenDocument("test://cmp.php", content, 1)
+
+	// Cursor at start of <my-element> on line 1
+	analysis := doc.AnalyzeCompletionContextTS(protocol.Position{Line: 1, Character: 1}, dm)
+	if analysis.Type != types.CompletionTagName {
+		t.Errorf("Expected CompletionTagName at element position, got %d", analysis.Type)
+	}
+	if analysis.TagName != "my-element" {
+		t.Errorf("Expected TagName 'my-element', got %q", analysis.TagName)
+	}
+}
+
+func TestPHP_CompletionContext_CursorInPHPRegion(t *testing.T) {
+	dm, err := document.NewDocumentManager()
+	if err != nil {
+		t.Fatalf("Failed to create document manager: %v", err)
+	}
+	defer dm.Close()
+
+	content := "<?php if ($count < $max) { ?>\n<my-element>\n<?php } ?>"
+	doc := dm.OpenDocument("test://cmp.php", content, 1)
+
+	// Cursor inside PHP region (line 0, inside <?php ... ?>)
+	analysis := doc.AnalyzeCompletionContextTS(protocol.Position{Line: 0, Character: 15}, dm)
+	if analysis.Type != types.CompletionUnknown {
+		t.Errorf("Expected CompletionUnknown in PHP region, got %d", analysis.Type)
+	}
+}
+
+func TestPHP_HeadInsertionPoint(t *testing.T) {
+	dm, err := document.NewDocumentManager()
+	if err != nil {
+		t.Fatalf("Failed to create document manager: %v", err)
+	}
+	defer dm.Close()
+
+	content := "<?php include 'header.php'; ?>\n<html>\n<head>\n  <title>Test</title>\n</head>\n<body>\n  <my-element></my-element>\n</body>\n</html>"
+	doc := dm.OpenDocument("test://head.php", content, 1)
+
+	pos, found := doc.FindHeadInsertionPoint(dm)
+	if !found {
+		t.Fatal("Expected to find head insertion point")
+	}
+	if pos.Line != 4 {
+		t.Errorf("Expected head insertion at line 4, got %d", pos.Line)
 	}
 }

--- a/lsp/php_twig_support_test.go
+++ b/lsp/php_twig_support_test.go
@@ -357,6 +357,40 @@ func TestPHP_CompletionContext_CursorInPHPRegion(t *testing.T) {
 	}
 }
 
+func TestPHP_EntirelyPHP(t *testing.T) {
+	dm, err := document.NewDocumentManager()
+	if err != nil {
+		t.Fatalf("Failed to create document manager: %v", err)
+	}
+	defer dm.Close()
+
+	content := "<?php\n$x = 1;\nif ($x < 2) {\n  echo 'hello';\n}\n?>"
+	elements := openAndFindElements(t, dm, "test://pure.php", content)
+	if len(elements) != 0 {
+		t.Errorf("Expected no elements in pure PHP file, got %d", len(elements))
+	}
+}
+
+func TestPHP_EntirelyHTML(t *testing.T) {
+	dm, err := document.NewDocumentManager()
+	if err != nil {
+		t.Fatalf("Failed to create document manager: %v", err)
+	}
+	defer dm.Close()
+
+	content := "<html>\n<body>\n<my-element attr=\"val\"></my-element>\n</body>\n</html>"
+	elements := openAndFindElements(t, dm, "test://pure.php", content)
+	assertElementsFound(t, elements, []string{"my-element"})
+
+	el := findElement(elements, "my-element")
+	if el == nil {
+		t.Fatal("my-element not found")
+	}
+	if v, ok := el.Attributes["attr"]; !ok || v.Value != "val" {
+		t.Errorf("Expected attr='val', got %+v", el.Attributes)
+	}
+}
+
 func TestPHP_HeadInsertionPoint(t *testing.T) {
 	dm, err := document.NewDocumentManager()
 	if err != nil {

--- a/lsp/template_support_test.go
+++ b/lsp/template_support_test.go
@@ -563,3 +563,61 @@ func TestNunjucks_HeadInsertionPoint(t *testing.T) {
 		t.Errorf("Expected head insertion at line 4, got %d", pos.Line)
 	}
 }
+
+func TestHandlebars_CompletionContext_TemplateLessThan(t *testing.T) {
+	dm := newTemplateDM(t)
+	content := "{{#if (lt count max)}}\n<my-element>\n{{/if}}"
+	doc := dm.OpenDocument("test://cmp.hbs", content, 1)
+
+	analysis := doc.AnalyzeCompletionContextTS(protocol.Position{Line: 1, Character: 1}, dm)
+	if analysis.Type != types.CompletionTagName {
+		t.Errorf("Expected CompletionTagName, got %d", analysis.Type)
+	}
+}
+
+func TestERB_CompletionContext_TemplateLessThan(t *testing.T) {
+	dm := newTemplateDM(t)
+	content := "<% if count < max %>\n<my-element>\n<% end %>"
+	doc := dm.OpenDocument("test://cmp.erb", content, 1)
+
+	analysis := doc.AnalyzeCompletionContextTS(protocol.Position{Line: 1, Character: 1}, dm)
+	if analysis.Type != types.CompletionTagName {
+		t.Errorf("Expected CompletionTagName, got %d", analysis.Type)
+	}
+}
+
+func TestEJS_CompletionContext_TemplateLessThan(t *testing.T) {
+	dm := newTemplateDM(t)
+	content := "<% if (count < max) { %>\n<my-element>\n<% } %>"
+	doc := dm.OpenDocument("test://cmp.ejs", content, 1)
+
+	analysis := doc.AnalyzeCompletionContextTS(protocol.Position{Line: 1, Character: 1}, dm)
+	if analysis.Type != types.CompletionTagName {
+		t.Errorf("Expected CompletionTagName, got %d", analysis.Type)
+	}
+}
+
+func TestNunjucks_HeadInsertionPoint_NoHead(t *testing.T) {
+	dm := newTemplateDM(t)
+	content := "{% block content %}\n<my-element></my-element>\n{% endblock %}"
+	doc := dm.OpenDocument("test://nohead.njk", content, 1)
+
+	_, found := doc.FindHeadInsertionPoint(dm)
+	if found {
+		t.Error("Expected no head insertion point in headless template")
+	}
+}
+
+func TestNunjucks_CompletionContext_MultiByte(t *testing.T) {
+	dm := newTemplateDM(t)
+	content := "{% if title == \"Héllo Wörld\" %}\n<my-element></my-element>\n{% endif %}"
+	doc := dm.OpenDocument("test://utf8.njk", content, 1)
+
+	analysis := doc.AnalyzeCompletionContextTS(protocol.Position{Line: 1, Character: 1}, dm)
+	if analysis.Type != types.CompletionTagName {
+		t.Errorf("Expected CompletionTagName with multi-byte content, got %d", analysis.Type)
+	}
+	if analysis.TagName != "my-element" {
+		t.Errorf("Expected TagName 'my-element', got %q", analysis.TagName)
+	}
+}

--- a/lsp/template_support_test.go
+++ b/lsp/template_support_test.go
@@ -621,3 +621,27 @@ func TestNunjucks_CompletionContext_MultiByte(t *testing.T) {
 		t.Errorf("Expected TagName 'my-element', got %q", analysis.TagName)
 	}
 }
+
+func TestNunjucks_EntirelyTemplateSyntax(t *testing.T) {
+	dm := newTemplateDM(t)
+	content := "{% set x = 1 %}\n{% if x < 2 %}\n{% set y = x + 1 %}\n{% endif %}"
+	elements := openAndFindElements(t, dm, "test://pure.njk", content)
+	if len(elements) != 0 {
+		t.Errorf("Expected no elements in pure template file, got %d", len(elements))
+	}
+}
+
+func TestNunjucks_EntirelyHTML(t *testing.T) {
+	dm := newTemplateDM(t)
+	content := "<html>\n<body>\n<my-element attr=\"val\"></my-element>\n</body>\n</html>"
+	elements := openAndFindElements(t, dm, "test://pure.njk", content)
+	assertElementsFound(t, elements, []string{"my-element"})
+
+	el := findElement(elements, "my-element")
+	if el == nil {
+		t.Fatal("my-element not found")
+	}
+	if v, ok := el.Attributes["attr"]; !ok || v.Value != "val" {
+		t.Errorf("Expected attr='val', got %+v", el.Attributes)
+	}
+}

--- a/lsp/template_support_test.go
+++ b/lsp/template_support_test.go
@@ -499,37 +499,44 @@ func TestTemplateCompoundExtensionRouting(t *testing.T) {
 // Template Completion Context (injection safety)
 // ============================================================================
 
-func TestNunjucks_CompletionContext_TemplateLessThan(t *testing.T) {
+func TestTemplate_CompletionContext_ComparisonOperator(t *testing.T) {
 	dm := newTemplateDM(t)
-	// Template comparison operator < must not be mistaken for HTML tag start
-	content := "{% if count < max %}\n<my-element>\n{% endif %}"
-	doc := dm.OpenDocument("test://cmp.njk", content, 1)
 
-	// Cursor at start of <my-element> on line 1
-	analysis := doc.AnalyzeCompletionContextTS(protocol.Position{Line: 1, Character: 1}, dm)
-	if analysis.Type != types.CompletionTagName {
-		t.Errorf("Expected CompletionTagName at element position, got %d", analysis.Type)
+	tests := []struct {
+		name     string
+		fixture  string
+		uri      string
+		position protocol.Position
+		wantType types.CompletionContextType
+		wantTag  string
+	}{
+		{"nunjucks", "comparison-operator.njk", "test://cmp.njk", protocol.Position{Line: 2, Character: 1}, types.CompletionTagName, "my-element"},
+		{"handlebars", "comparison-operator.hbs", "test://cmp.hbs", protocol.Position{Line: 1, Character: 1}, types.CompletionTagName, ""},
+		{"erb", "comparison-operator.erb", "test://cmp.erb", protocol.Position{Line: 1, Character: 1}, types.CompletionTagName, ""},
+		{"ejs", "comparison-operator.ejs", "test://cmp.ejs", protocol.Position{Line: 1, Character: 1}, types.CompletionTagName, ""},
+		{"nunjucks-in-template", "comparison-operator.njk", "test://cmp.njk", protocol.Position{Line: 1, Character: 10}, types.CompletionUnknown, ""},
+		{"multibyte", "multibyte.njk", "test://utf8.njk", protocol.Position{Line: 1, Character: 1}, types.CompletionTagName, "my-element"},
 	}
-	if analysis.TagName != "my-element" {
-		t.Errorf("Expected TagName 'my-element', got %q", analysis.TagName)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := readTemplateFixture(t, tt.fixture)
+			doc := dm.OpenDocument(tt.uri, content, 1)
+
+			analysis := doc.AnalyzeCompletionContextTS(tt.position, dm)
+			if analysis.Type != tt.wantType {
+				t.Errorf("Expected completion type %d, got %d", tt.wantType, analysis.Type)
+			}
+			if tt.wantTag != "" && analysis.TagName != tt.wantTag {
+				t.Errorf("Expected TagName %q, got %q", tt.wantTag, analysis.TagName)
+			}
+		})
 	}
 }
 
-func TestNunjucks_CompletionContext_CursorInTemplateRegion(t *testing.T) {
+func TestTemplate_AttributeAfterTemplateBlock(t *testing.T) {
 	dm := newTemplateDM(t)
-	content := "{% if count < max %}\n<my-element>\n{% endif %}"
-	doc := dm.OpenDocument("test://cmp.njk", content, 1)
-
-	// Cursor inside template region (line 0, inside {% if ... %})
-	analysis := doc.AnalyzeCompletionContextTS(protocol.Position{Line: 0, Character: 10}, dm)
-	if analysis.Type != types.CompletionUnknown {
-		t.Errorf("Expected CompletionUnknown in template region, got %d", analysis.Type)
-	}
-}
-
-func TestNunjucks_CompletionContext_AttributeAfterTemplate(t *testing.T) {
-	dm := newTemplateDM(t)
-	content := "<my-element {% if x %}disabled{% endif %} variant=\"primary\">"
+	content := readTemplateFixture(t, "intag-conditional-attr.njk")
 
 	elements := openAndFindElements(t, dm, "test://attr.njk", content)
 	assertElementsFound(t, elements, []string{"my-element"})
@@ -542,7 +549,6 @@ func TestNunjucks_CompletionContext_AttributeAfterTemplate(t *testing.T) {
 		t.Error("Expected variant attribute to be found")
 	}
 
-	// Verify template tokens don't leak as attributes
 	for _, bad := range []string{"{%", "if", "endif", "%}"} {
 		if _, ok := el.Attributes[bad]; ok {
 			t.Errorf("Template syntax %q should not be an attribute", bad)
@@ -550,98 +556,60 @@ func TestNunjucks_CompletionContext_AttributeAfterTemplate(t *testing.T) {
 	}
 }
 
-func TestNunjucks_HeadInsertionPoint(t *testing.T) {
+func TestTemplate_HeadInsertionPoint(t *testing.T) {
 	dm := newTemplateDM(t)
-	content := "{% extends 'base.njk' %}\n<html>\n<head>\n  <title>Test</title>\n</head>\n<body>\n  <my-element></my-element>\n</body>\n</html>"
-	doc := dm.OpenDocument("test://head.njk", content, 1)
 
-	pos, found := doc.FindHeadInsertionPoint(dm)
-	if !found {
-		t.Fatal("Expected to find head insertion point")
+	tests := []struct {
+		name      string
+		fixture   string
+		uri       string
+		wantFound bool
+		wantLine  uint32
+	}{
+		{"with-head", "head-section.njk", "test://head.njk", true, 4},
+		{"headless", "headless.njk", "test://nohead.njk", false, 0},
 	}
-	if pos.Line != 4 {
-		t.Errorf("Expected head insertion at line 4, got %d", pos.Line)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := readTemplateFixture(t, tt.fixture)
+			doc := dm.OpenDocument(tt.uri, content, 1)
+
+			pos, found := doc.FindHeadInsertionPoint(dm)
+			if found != tt.wantFound {
+				t.Errorf("Expected found=%v, got %v", tt.wantFound, found)
+			}
+			if found && pos.Line != tt.wantLine {
+				t.Errorf("Expected line %d, got %d", tt.wantLine, pos.Line)
+			}
+		})
 	}
 }
 
-func TestHandlebars_CompletionContext_TemplateLessThan(t *testing.T) {
+func TestTemplate_EdgeCases(t *testing.T) {
 	dm := newTemplateDM(t)
-	content := "{{#if (lt count max)}}\n<my-element>\n{{/if}}"
-	doc := dm.OpenDocument("test://cmp.hbs", content, 1)
 
-	analysis := doc.AnalyzeCompletionContextTS(protocol.Position{Line: 1, Character: 1}, dm)
-	if analysis.Type != types.CompletionTagName {
-		t.Errorf("Expected CompletionTagName, got %d", analysis.Type)
+	tests := []struct {
+		name         string
+		fixture      string
+		uri          string
+		wantElements []string
+	}{
+		{"pure-template", "pure-template.njk", "test://pure.njk", nil},
+		{"pure-html", "pure-html.njk", "test://pure.njk", []string{"my-element"}},
 	}
-}
 
-func TestERB_CompletionContext_TemplateLessThan(t *testing.T) {
-	dm := newTemplateDM(t)
-	content := "<% if count < max %>\n<my-element>\n<% end %>"
-	doc := dm.OpenDocument("test://cmp.erb", content, 1)
-
-	analysis := doc.AnalyzeCompletionContextTS(protocol.Position{Line: 1, Character: 1}, dm)
-	if analysis.Type != types.CompletionTagName {
-		t.Errorf("Expected CompletionTagName, got %d", analysis.Type)
-	}
-}
-
-func TestEJS_CompletionContext_TemplateLessThan(t *testing.T) {
-	dm := newTemplateDM(t)
-	content := "<% if (count < max) { %>\n<my-element>\n<% } %>"
-	doc := dm.OpenDocument("test://cmp.ejs", content, 1)
-
-	analysis := doc.AnalyzeCompletionContextTS(protocol.Position{Line: 1, Character: 1}, dm)
-	if analysis.Type != types.CompletionTagName {
-		t.Errorf("Expected CompletionTagName, got %d", analysis.Type)
-	}
-}
-
-func TestNunjucks_HeadInsertionPoint_NoHead(t *testing.T) {
-	dm := newTemplateDM(t)
-	content := "{% block content %}\n<my-element></my-element>\n{% endblock %}"
-	doc := dm.OpenDocument("test://nohead.njk", content, 1)
-
-	_, found := doc.FindHeadInsertionPoint(dm)
-	if found {
-		t.Error("Expected no head insertion point in headless template")
-	}
-}
-
-func TestNunjucks_CompletionContext_MultiByte(t *testing.T) {
-	dm := newTemplateDM(t)
-	content := "{% if title == \"Héllo Wörld\" %}\n<my-element></my-element>\n{% endif %}"
-	doc := dm.OpenDocument("test://utf8.njk", content, 1)
-
-	analysis := doc.AnalyzeCompletionContextTS(protocol.Position{Line: 1, Character: 1}, dm)
-	if analysis.Type != types.CompletionTagName {
-		t.Errorf("Expected CompletionTagName with multi-byte content, got %d", analysis.Type)
-	}
-	if analysis.TagName != "my-element" {
-		t.Errorf("Expected TagName 'my-element', got %q", analysis.TagName)
-	}
-}
-
-func TestNunjucks_EntirelyTemplateSyntax(t *testing.T) {
-	dm := newTemplateDM(t)
-	content := "{% set x = 1 %}\n{% if x < 2 %}\n{% set y = x + 1 %}\n{% endif %}"
-	elements := openAndFindElements(t, dm, "test://pure.njk", content)
-	if len(elements) != 0 {
-		t.Errorf("Expected no elements in pure template file, got %d", len(elements))
-	}
-}
-
-func TestNunjucks_EntirelyHTML(t *testing.T) {
-	dm := newTemplateDM(t)
-	content := "<html>\n<body>\n<my-element attr=\"val\"></my-element>\n</body>\n</html>"
-	elements := openAndFindElements(t, dm, "test://pure.njk", content)
-	assertElementsFound(t, elements, []string{"my-element"})
-
-	el := findElement(elements, "my-element")
-	if el == nil {
-		t.Fatal("my-element not found")
-	}
-	if v, ok := el.Attributes["attr"]; !ok || v.Value != "val" {
-		t.Errorf("Expected attr='val', got %+v", el.Attributes)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := readTemplateFixture(t, tt.fixture)
+			elements := openAndFindElements(t, dm, tt.uri, content)
+			if tt.wantElements == nil {
+				if len(elements) != 0 {
+					t.Errorf("Expected no elements, got %d", len(elements))
+				}
+			} else {
+				assertElementsFound(t, elements, tt.wantElements)
+			}
+		})
 	}
 }

--- a/lsp/template_support_test.go
+++ b/lsp/template_support_test.go
@@ -23,6 +23,7 @@ import (
 
 	"bennypowers.dev/cem/lsp/document"
 	"bennypowers.dev/cem/lsp/types"
+	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
 const templateFixtureDir = "testdata/integration/template-support"
@@ -492,5 +493,73 @@ func TestTemplateCompoundExtensionRouting(t *testing.T) {
 				t.Errorf("Template syntax leaked as attribute for %s", uri)
 			}
 		})
+	}
+}
+
+// Template Completion Context (injection safety)
+// ============================================================================
+
+func TestNunjucks_CompletionContext_TemplateLessThan(t *testing.T) {
+	dm := newTemplateDM(t)
+	// Template comparison operator < must not be mistaken for HTML tag start
+	content := "{% if count < max %}\n<my-element>\n{% endif %}"
+	doc := dm.OpenDocument("test://cmp.njk", content, 1)
+
+	// Cursor at start of <my-element> on line 1
+	analysis := doc.AnalyzeCompletionContextTS(protocol.Position{Line: 1, Character: 1}, dm)
+	if analysis.Type != types.CompletionTagName {
+		t.Errorf("Expected CompletionTagName at element position, got %d", analysis.Type)
+	}
+	if analysis.TagName != "my-element" {
+		t.Errorf("Expected TagName 'my-element', got %q", analysis.TagName)
+	}
+}
+
+func TestNunjucks_CompletionContext_CursorInTemplateRegion(t *testing.T) {
+	dm := newTemplateDM(t)
+	content := "{% if count < max %}\n<my-element>\n{% endif %}"
+	doc := dm.OpenDocument("test://cmp.njk", content, 1)
+
+	// Cursor inside template region (line 0, inside {% if ... %})
+	analysis := doc.AnalyzeCompletionContextTS(protocol.Position{Line: 0, Character: 10}, dm)
+	if analysis.Type != types.CompletionUnknown {
+		t.Errorf("Expected CompletionUnknown in template region, got %d", analysis.Type)
+	}
+}
+
+func TestNunjucks_CompletionContext_AttributeAfterTemplate(t *testing.T) {
+	dm := newTemplateDM(t)
+	content := "<my-element {% if x %}disabled{% endif %} variant=\"primary\">"
+
+	elements := openAndFindElements(t, dm, "test://attr.njk", content)
+	assertElementsFound(t, elements, []string{"my-element"})
+
+	el := findElement(elements, "my-element")
+	if el == nil {
+		t.Fatal("my-element not found")
+	}
+	if _, ok := el.Attributes["variant"]; !ok {
+		t.Error("Expected variant attribute to be found")
+	}
+
+	// Verify template tokens don't leak as attributes
+	for _, bad := range []string{"{%", "if", "endif", "%}"} {
+		if _, ok := el.Attributes[bad]; ok {
+			t.Errorf("Template syntax %q should not be an attribute", bad)
+		}
+	}
+}
+
+func TestNunjucks_HeadInsertionPoint(t *testing.T) {
+	dm := newTemplateDM(t)
+	content := "{% extends 'base.njk' %}\n<html>\n<head>\n  <title>Test</title>\n</head>\n<body>\n  <my-element></my-element>\n</body>\n</html>"
+	doc := dm.OpenDocument("test://head.njk", content, 1)
+
+	pos, found := doc.FindHeadInsertionPoint(dm)
+	if !found {
+		t.Fatal("Expected to find head insertion point")
+	}
+	if pos.Line != 4 {
+		t.Errorf("Expected head insertion at line 4, got %d", pos.Line)
 	}
 }

--- a/lsp/testdata/integration/php-twig-support/comparison-operator.php
+++ b/lsp/testdata/integration/php-twig-support/comparison-operator.php
@@ -1,0 +1,3 @@
+<?php if ($count < $max) { ?>
+<my-element></my-element>
+<?php } ?>

--- a/lsp/testdata/integration/php-twig-support/head-section.php
+++ b/lsp/testdata/integration/php-twig-support/head-section.php
@@ -1,0 +1,9 @@
+<?php include 'header.php'; ?>
+<html>
+<head>
+  <title>Test</title>
+</head>
+<body>
+  <my-element></my-element>
+</body>
+</html>

--- a/lsp/testdata/integration/php-twig-support/pure-html.php
+++ b/lsp/testdata/integration/php-twig-support/pure-html.php
@@ -1,0 +1,5 @@
+<html>
+<body>
+<my-element attr="val"></my-element>
+</body>
+</html>

--- a/lsp/testdata/integration/php-twig-support/pure-php.php
+++ b/lsp/testdata/integration/php-twig-support/pure-php.php
@@ -1,0 +1,6 @@
+<?php
+$x = 1;
+if ($x < 2) {
+  echo 'hello';
+}
+?>

--- a/lsp/testdata/integration/template-support/comparison-operator.ejs
+++ b/lsp/testdata/integration/template-support/comparison-operator.ejs
@@ -1,0 +1,3 @@
+<% if (count < max) { %>
+<my-element></my-element>
+<% } %>

--- a/lsp/testdata/integration/template-support/comparison-operator.erb
+++ b/lsp/testdata/integration/template-support/comparison-operator.erb
@@ -1,0 +1,3 @@
+<% if count < max %>
+<my-element></my-element>
+<% end %>

--- a/lsp/testdata/integration/template-support/comparison-operator.hbs
+++ b/lsp/testdata/integration/template-support/comparison-operator.hbs
@@ -1,0 +1,3 @@
+{{#if (lt count max)}}
+<my-element></my-element>
+{{/if}}

--- a/lsp/testdata/integration/template-support/comparison-operator.njk
+++ b/lsp/testdata/integration/template-support/comparison-operator.njk
@@ -1,0 +1,4 @@
+{# Template with < comparison operator before custom element #}
+{% if count < max %}
+<my-element></my-element>
+{% endif %}

--- a/lsp/testdata/integration/template-support/head-section.njk
+++ b/lsp/testdata/integration/template-support/head-section.njk
@@ -1,0 +1,9 @@
+{% extends 'base.njk' %}
+<html>
+<head>
+  <title>Test</title>
+</head>
+<body>
+  <my-element></my-element>
+</body>
+</html>

--- a/lsp/testdata/integration/template-support/headless.njk
+++ b/lsp/testdata/integration/template-support/headless.njk
@@ -1,0 +1,3 @@
+{% block content %}
+<my-element></my-element>
+{% endblock %}

--- a/lsp/testdata/integration/template-support/intag-conditional-attr.njk
+++ b/lsp/testdata/integration/template-support/intag-conditional-attr.njk
@@ -1,0 +1,1 @@
+<my-element {% if x %}disabled{% endif %} variant="primary">

--- a/lsp/testdata/integration/template-support/multibyte.njk
+++ b/lsp/testdata/integration/template-support/multibyte.njk
@@ -1,0 +1,3 @@
+{% if title == "Héllo Wörld" %}
+<my-element></my-element>
+{% endif %}

--- a/lsp/testdata/integration/template-support/pure-html.njk
+++ b/lsp/testdata/integration/template-support/pure-html.njk
@@ -1,0 +1,5 @@
+<html>
+<body>
+<my-element attr="val"></my-element>
+</body>
+</html>

--- a/lsp/testdata/integration/template-support/pure-template.njk
+++ b/lsp/testdata/integration/template-support/pure-template.njk
@@ -1,0 +1,5 @@
+{# Nunjucks file with no HTML content at all #}
+{% set x = 1 %}
+{% if x < 2 %}
+{% set y = x + 1 %}
+{% endif %}

--- a/lsp/types/document.go
+++ b/lsp/types/document.go
@@ -61,6 +61,13 @@ type LanguageHandler interface {
 	Close()
 }
 
+// RangeParser is implemented by LanguageHandlers that support tree-sitter
+// language injection via SetIncludedRanges. Template and PHP handlers use this
+// to parse only the HTML regions of their source files.
+type RangeParser interface {
+	CreateDocumentWithRanges(uri, content string, version int32, ranges []ts.Range) Document
+}
+
 // Manager interface for document lifecycle management
 type Manager interface {
 	// Document lifecycle


### PR DESCRIPTION
Replace whitespace-fill extraction with SetIncludedRanges, the standard tree-sitter injection mechanism used by Neovim, Helix, and Zed. Template and PHP handlers now collect HTML region byte ranges from the outer grammar and pass them to the HTML parser, which only parses those regions. Byte positions map to the original source automatically, eliminating the intermediate whitespace buffer.

Assisted-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More accurate HTML parsing in embedded contexts (PHP/templates) enabling better completion and head-insertion detection.

* **Refactor**
  * Range-aware parsing path to restrict HTML analysis to relevant regions for improved performance and precision.
  * Completion prefix logic now derives prefixes from parsed context for more reliable suggestions.

* **Bug Fixes**
  * Fixes for false-positive tag/attribute completions around template or PHP syntax.

* **Tests**
  * Added integration tests covering completion contexts and head insertion detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->