### PR TITLE
refactor: adopt BaseDocument embedding across all document types

### DIFF
--- a/lsp/document/base/base_document.go
+++ b/lsp/document/base/base_document.go
@@ -75,18 +75,13 @@ func (d *BaseDocument) URI() string {
 
 // Content returns the document content
 func (d *BaseDocument) Content() (string, error) {
-	// Defensive programming: check for nil pointer
 	if d == nil {
 		return "", fmt.Errorf("document is nil")
 	}
 
-	// Additional safety check - ensure the mutex is properly initialized
-	// This is a workaround for potential concurrent access issues
 	defer func() {
 		if r := recover(); r != nil {
 			helpers.SafeDebugLog("[DOCUMENT] PANIC in Content(): %v", r)
-			// Log document state for debugging
-			helpers.SafeDebugLog("[DOCUMENT] Document state: uri=%s, content_len=%d", d.uri, len(d.content))
 		}
 	}()
 
@@ -239,6 +234,10 @@ func (d *BaseDocument) FindInlineModuleScript() (protocol.Position, bool) {
 
 // TreeAndContent returns the tree and content atomically under one lock.
 // Use this from sub-package methods that need both values consistently.
+//
+// The returned tree is safe to use after the lock releases because
+// DocumentManager serializes all operations on the same URI via per-URI
+// locks, preventing concurrent Close() from freeing the tree mid-use.
 func (d *BaseDocument) TreeAndContent() (*ts.Tree, string) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()

--- a/lsp/document/base/base_document.go
+++ b/lsp/document/base/base_document.go
@@ -17,18 +17,16 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package base
 
 import (
-	"fmt"
-	"reflect"
 	"strings"
 	"sync"
 
-	"bennypowers.dev/cem/lsp/helpers"
 	"bennypowers.dev/cem/lsp/types"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 	ts "github.com/tree-sitter/go-tree-sitter"
 )
 
-// BaseDocument provides common document functionality that language-specific documents can embed
+// BaseDocument provides common document functionality that language-specific documents can embed.
+// Always use NewBaseDocument to construct; a zero-value BaseDocument will panic.
 type BaseDocument struct {
 	uri          string
 	content      string
@@ -58,16 +56,6 @@ func NewBaseDocument(uri, content string, version int32, language string, return
 
 // URI returns the document URI
 func (d *BaseDocument) URI() string {
-	if d == nil {
-		return ""
-	}
-
-	defer func() {
-		if r := recover(); r != nil {
-			helpers.SafeDebugLog("[DOCUMENT] PANIC in URI(): %v", r)
-		}
-	}()
-
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	return d.uri
@@ -75,16 +63,6 @@ func (d *BaseDocument) URI() string {
 
 // Content returns the document content
 func (d *BaseDocument) Content() (string, error) {
-	if d == nil {
-		return "", fmt.Errorf("document is nil")
-	}
-
-	defer func() {
-		if r := recover(); r != nil {
-			helpers.SafeDebugLog("[DOCUMENT] PANIC in Content(): %v", r)
-		}
-	}()
-
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	return d.content, nil
@@ -92,16 +70,6 @@ func (d *BaseDocument) Content() (string, error) {
 
 // Version returns the document version
 func (d *BaseDocument) Version() int32 {
-	if d == nil {
-		return 0
-	}
-
-	defer func() {
-		if r := recover(); r != nil {
-			helpers.SafeDebugLog("[DOCUMENT] PANIC in Version(): %v", r)
-		}
-	}()
-
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	return d.version
@@ -109,10 +77,6 @@ func (d *BaseDocument) Version() int32 {
 
 // Language returns the document language
 func (d *BaseDocument) Language() string {
-	if d == nil {
-		return ""
-	}
-
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	return d.language
@@ -120,10 +84,6 @@ func (d *BaseDocument) Language() string {
 
 // Tree returns the document's syntax tree
 func (d *BaseDocument) Tree() *ts.Tree {
-	if d == nil {
-		return nil
-	}
-
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	return d.tree
@@ -297,24 +257,6 @@ func (d *BaseDocument) PositionToByteOffset(pos protocol.Position, content strin
 	return offset
 }
 
-// languageHandler uses reflection to retrieve the language handler from a document manager.
-// This avoids circular imports between document and handler packages.
-func (d *BaseDocument) languageHandler(dm any) any {
-	dmValue := reflect.ValueOf(dm)
-	if dmValue.Kind() != reflect.Pointer || dmValue.IsNil() {
-		return nil
-	}
-	method := dmValue.MethodByName("GetLanguageHandler")
-	if !method.IsValid() {
-		return nil
-	}
-	results := method.Call([]reflect.Value{reflect.ValueOf(d.language)})
-	if len(results) == 0 || results[0].IsNil() {
-		return nil
-	}
-	return results[0].Interface()
-}
-
 // outer returns the concrete document type for handler delegation.
 // When embedded, self points to the outer struct; standalone, it falls back to d.
 func (d *BaseDocument) outer() types.Document {
@@ -325,64 +267,59 @@ func (d *BaseDocument) outer() types.Document {
 }
 
 // FindElementAtPosition finds a custom element at the given position.
-func (d *BaseDocument) FindElementAtPosition(position protocol.Position, dm any) *types.CustomElementMatch {
-	handler := d.languageHandler(dm)
+func (d *BaseDocument) FindElementAtPosition(position protocol.Position, hp types.HandlerProvider) *types.CustomElementMatch {
+	if hp == nil {
+		return nil
+	}
+	handler := hp.GetLanguageHandler(d.language)
 	if handler == nil {
 		return nil
 	}
-	if h, ok := handler.(interface {
-		FindElementAtPosition(types.Document, protocol.Position) *types.CustomElementMatch
-	}); ok {
-		return h.FindElementAtPosition(d.outer(), position)
-	}
-	return nil
+	return handler.FindElementAtPosition(d.outer(), position)
 }
 
 // FindAttributeAtPosition finds an attribute at the given position.
-func (d *BaseDocument) FindAttributeAtPosition(position protocol.Position, dm any) (*types.AttributeMatch, string) {
-	handler := d.languageHandler(dm)
+func (d *BaseDocument) FindAttributeAtPosition(position protocol.Position, hp types.HandlerProvider) (*types.AttributeMatch, string) {
+	if hp == nil {
+		return nil, ""
+	}
+	handler := hp.GetLanguageHandler(d.language)
 	if handler == nil {
 		return nil, ""
 	}
-	if h, ok := handler.(interface {
-		FindAttributeAtPosition(types.Document, protocol.Position) (*types.AttributeMatch, string)
-	}); ok {
-		return h.FindAttributeAtPosition(d.outer(), position)
-	}
-	return nil, ""
+	return handler.FindAttributeAtPosition(d.outer(), position)
 }
 
 // FindCustomElements finds custom elements in the document.
-func (d *BaseDocument) FindCustomElements(dm any) ([]types.CustomElementMatch, error) {
-	handler := d.languageHandler(dm)
+func (d *BaseDocument) FindCustomElements(hp types.HandlerProvider) ([]types.CustomElementMatch, error) {
+	if hp == nil {
+		return []types.CustomElementMatch{}, nil
+	}
+	handler := hp.GetLanguageHandler(d.language)
 	if handler == nil {
 		return []types.CustomElementMatch{}, nil
 	}
-	if h, ok := handler.(interface {
-		FindCustomElements(types.Document) ([]types.CustomElementMatch, error)
-	}); ok {
-		return h.FindCustomElements(d.outer())
-	}
-	return []types.CustomElementMatch{}, nil
+	return handler.FindCustomElements(d.outer())
 }
 
 // AnalyzeCompletionContextTS analyzes completion context using tree-sitter queries.
-func (d *BaseDocument) AnalyzeCompletionContextTS(position protocol.Position, dm any) *types.CompletionAnalysis {
-	handler := d.languageHandler(dm)
+func (d *BaseDocument) AnalyzeCompletionContextTS(position protocol.Position, hp types.HandlerProvider) *types.CompletionAnalysis {
+	if hp == nil {
+		return &types.CompletionAnalysis{Type: types.CompletionUnknown}
+	}
+	handler := hp.GetLanguageHandler(d.language)
 	if handler == nil {
 		return &types.CompletionAnalysis{Type: types.CompletionUnknown}
 	}
-	if h, ok := handler.(interface {
-		AnalyzeCompletionContext(types.Document, protocol.Position) *types.CompletionAnalysis
-	}); ok {
-		return h.AnalyzeCompletionContext(d.outer(), position)
-	}
-	return &types.CompletionAnalysis{Type: types.CompletionUnknown}
+	return handler.AnalyzeCompletionContext(d.outer(), position)
 }
 
 // FindHeadInsertionPoint finds insertion point in <head> section.
-func (d *BaseDocument) FindHeadInsertionPoint(dm any) (protocol.Position, bool) {
-	handler := d.languageHandler(dm)
+func (d *BaseDocument) FindHeadInsertionPoint(hp types.HandlerProvider) (protocol.Position, bool) {
+	if hp == nil {
+		return protocol.Position{}, false
+	}
+	handler := hp.GetLanguageHandler(d.language)
 	if handler == nil {
 		return protocol.Position{}, false
 	}

--- a/lsp/document/base/base_document.go
+++ b/lsp/document/base/base_document.go
@@ -14,7 +14,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
-package document
+package base
 
 import (
 	"fmt"

--- a/lsp/document/base/base_document.go
+++ b/lsp/document/base/base_document.go
@@ -248,17 +248,17 @@ func (d *BaseDocument) TreeAndContent() (*ts.Tree, string) {
 // ByteRangeToProtocolRange converts byte range to protocol range.
 func (d *BaseDocument) ByteRangeToProtocolRange(content string, startByte, endByte uint) protocol.Range {
 	return protocol.Range{
-		Start: d.ByteOffsetToPosition(startByte),
-		End:   d.ByteOffsetToPosition(endByte),
+		Start: d.ByteOffsetToPosition(startByte, content),
+		End:   d.ByteOffsetToPosition(endByte, content),
 	}
 }
 
-// ByteOffsetToPosition converts a byte offset to a protocol position.
-func (d *BaseDocument) ByteOffsetToPosition(offset uint) protocol.Position {
+// ByteOffsetToPosition converts a byte offset to a protocol position within the given content.
+func (d *BaseDocument) ByteOffsetToPosition(offset uint, content string) protocol.Position {
 	line := uint32(0)
 	char := uint32(0)
 
-	for i, r := range d.content {
+	for i, r := range content {
 		if uint(i) >= offset {
 			break
 		}
@@ -298,9 +298,9 @@ func (d *BaseDocument) PositionToByteOffset(pos protocol.Position, content strin
 	return offset
 }
 
-// getLanguageHandler uses reflection to retrieve the language handler from a document manager.
+// languageHandler uses reflection to retrieve the language handler from a document manager.
 // This avoids circular imports between document and handler packages.
-func (d *BaseDocument) getLanguageHandler(dm any) any {
+func (d *BaseDocument) languageHandler(dm any) any {
 	dmValue := reflect.ValueOf(dm)
 	if dmValue.Kind() != reflect.Pointer || dmValue.IsNil() {
 		return nil
@@ -316,9 +316,9 @@ func (d *BaseDocument) getLanguageHandler(dm any) any {
 	return results[0].Interface()
 }
 
-// doc returns the concrete document type for handler delegation.
+// outer returns the concrete document type for handler delegation.
 // When embedded, self points to the outer struct; standalone, it falls back to d.
-func (d *BaseDocument) doc() types.Document {
+func (d *BaseDocument) outer() types.Document {
 	if d.self != nil {
 		return d.self
 	}
@@ -327,70 +327,70 @@ func (d *BaseDocument) doc() types.Document {
 
 // FindElementAtPosition finds a custom element at the given position.
 func (d *BaseDocument) FindElementAtPosition(position protocol.Position, dm any) *types.CustomElementMatch {
-	handler := d.getLanguageHandler(dm)
+	handler := d.languageHandler(dm)
 	if handler == nil {
 		return nil
 	}
 	if h, ok := handler.(interface {
 		FindElementAtPosition(types.Document, protocol.Position) *types.CustomElementMatch
 	}); ok {
-		return h.FindElementAtPosition(d.doc(), position)
+		return h.FindElementAtPosition(d.outer(), position)
 	}
 	return nil
 }
 
 // FindAttributeAtPosition finds an attribute at the given position.
 func (d *BaseDocument) FindAttributeAtPosition(position protocol.Position, dm any) (*types.AttributeMatch, string) {
-	handler := d.getLanguageHandler(dm)
+	handler := d.languageHandler(dm)
 	if handler == nil {
 		return nil, ""
 	}
 	if h, ok := handler.(interface {
 		FindAttributeAtPosition(types.Document, protocol.Position) (*types.AttributeMatch, string)
 	}); ok {
-		return h.FindAttributeAtPosition(d.doc(), position)
+		return h.FindAttributeAtPosition(d.outer(), position)
 	}
 	return nil, ""
 }
 
 // FindCustomElements finds custom elements in the document.
 func (d *BaseDocument) FindCustomElements(dm any) ([]types.CustomElementMatch, error) {
-	handler := d.getLanguageHandler(dm)
+	handler := d.languageHandler(dm)
 	if handler == nil {
 		return []types.CustomElementMatch{}, nil
 	}
 	if h, ok := handler.(interface {
 		FindCustomElements(types.Document) ([]types.CustomElementMatch, error)
 	}); ok {
-		return h.FindCustomElements(d.doc())
+		return h.FindCustomElements(d.outer())
 	}
 	return []types.CustomElementMatch{}, nil
 }
 
 // AnalyzeCompletionContextTS analyzes completion context using tree-sitter queries.
 func (d *BaseDocument) AnalyzeCompletionContextTS(position protocol.Position, dm any) *types.CompletionAnalysis {
-	handler := d.getLanguageHandler(dm)
+	handler := d.languageHandler(dm)
 	if handler == nil {
 		return &types.CompletionAnalysis{Type: types.CompletionUnknown}
 	}
 	if h, ok := handler.(interface {
 		AnalyzeCompletionContext(types.Document, protocol.Position) *types.CompletionAnalysis
 	}); ok {
-		return h.AnalyzeCompletionContext(d.doc(), position)
+		return h.AnalyzeCompletionContext(d.outer(), position)
 	}
 	return &types.CompletionAnalysis{Type: types.CompletionUnknown}
 }
 
 // FindHeadInsertionPoint finds insertion point in <head> section.
 func (d *BaseDocument) FindHeadInsertionPoint(dm any) (protocol.Position, bool) {
-	handler := d.getLanguageHandler(dm)
+	handler := d.languageHandler(dm)
 	if handler == nil {
 		return protocol.Position{}, false
 	}
 	if h, ok := handler.(interface {
 		FindHeadInsertionPoint(types.Document) (protocol.Position, bool)
 	}); ok {
-		return h.FindHeadInsertionPoint(d.doc())
+		return h.FindHeadInsertionPoint(d.outer())
 	}
 	return protocol.Position{}, false
 }

--- a/lsp/document/base/base_document.go
+++ b/lsp/document/base/base_document.go
@@ -208,15 +208,6 @@ func (d *BaseDocument) Close() {
 	}
 }
 
-// Default implementations that can be overridden by language-specific documents
-
-// Parse performs initial parsing of the document (default implementation)
-func (d *BaseDocument) Parse(content string) error {
-	d.UpdateContent(content, d.version)
-	// Language-specific parsing will be implemented by subclasses
-	return nil
-}
-
 // CompletionPrefix extracts the prefix being typed for filtering completions (default implementation)
 func (d *BaseDocument) CompletionPrefix(analysis *types.CompletionAnalysis) string {
 	// Default implementation - can be overridden by language-specific documents

--- a/lsp/document/base/base_document.go
+++ b/lsp/document/base/base_document.go
@@ -187,9 +187,21 @@ func (d *BaseDocument) FindModuleScript() (protocol.Position, bool) {
 	return protocol.Position{}, false
 }
 
-// FindInlineModuleScript delegates to FindModuleScript by default.
+// FindInlineModuleScript finds the first inline module script (no src attribute).
 func (d *BaseDocument) FindInlineModuleScript() (protocol.Position, bool) {
-	return d.FindModuleScript()
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	for _, script := range d.scriptTags {
+		if script.IsModule && script.Src == "" {
+			return protocol.Position{
+				Line:      script.ContentRange.End.Line,
+				Character: 0,
+			}, true
+		}
+	}
+
+	return protocol.Position{}, false
 }
 
 // TreeAndContent returns the tree and content atomically under one lock.

--- a/lsp/document/base/base_document_test.go
+++ b/lsp/document/base/base_document_test.go
@@ -1,4 +1,4 @@
-package document
+package base
 
 import (
 	"testing"

--- a/lsp/document/base/base_document_test.go
+++ b/lsp/document/base/base_document_test.go
@@ -13,14 +13,14 @@ func TestSetParser_CallbackFiresWithOldParser(t *testing.T) {
 
 	doc := NewBaseDocument("test.html", "", 1, "html", callback, nil)
 	oldParser := ts.NewParser()
-	defer oldParser.Close()
+	t.Cleanup(oldParser.Close)
 	newParser := ts.NewParser()
-	defer newParser.Close()
+	t.Cleanup(newParser.Close)
 
 	doc.SetParser(oldParser)
 	doc.SetParser(newParser)
 
-	assert.Equal(t, oldParser, returned, "callback should receive the old parser")
+	assert.Same(t, oldParser, returned, "callback should receive the old parser")
 }
 
 func TestSetParser_SameParserDoesNotFireCallback(t *testing.T) {
@@ -29,7 +29,7 @@ func TestSetParser_SameParserDoesNotFireCallback(t *testing.T) {
 
 	doc := NewBaseDocument("test.html", "", 1, "html", callback, nil)
 	parser := ts.NewParser()
-	defer parser.Close()
+	t.Cleanup(parser.Close)
 
 	doc.SetParser(parser)
 	doc.SetParser(parser)
@@ -43,7 +43,7 @@ func TestSetParser_NoPreviousParserDoesNotFireCallback(t *testing.T) {
 
 	doc := NewBaseDocument("test.html", "", 1, "html", callback, nil)
 	parser := ts.NewParser()
-	defer parser.Close()
+	t.Cleanup(parser.Close)
 
 	doc.SetParser(parser)
 
@@ -52,15 +52,22 @@ func TestSetParser_NoPreviousParserDoesNotFireCallback(t *testing.T) {
 
 func TestClose_FiresCallbackWithParser(t *testing.T) {
 	var returned *ts.Parser
-	callback := func(p *ts.Parser) { returned = p }
+	callback := func(p *ts.Parser) {
+		returned = p
+	}
 
 	doc := NewBaseDocument("test.html", "", 1, "html", callback, nil)
 	parser := ts.NewParser()
+	t.Cleanup(func() {
+		if returned != nil {
+			returned.Close()
+		}
+	})
 
 	doc.SetParser(parser)
 	doc.Close()
 
-	assert.Equal(t, parser, returned, "Close should return parser via callback")
+	assert.Same(t, parser, returned, "Close should return parser via callback")
 	assert.Nil(t, doc.Parser(), "parser should be nil after Close")
 }
 
@@ -77,6 +84,7 @@ func TestClose_NoParserDoesNotFireCallback(t *testing.T) {
 func TestClose_NilCallbackDoesNotPanic(t *testing.T) {
 	doc := NewBaseDocument("test.html", "", 1, "html", nil, nil)
 	parser := ts.NewParser()
+	t.Cleanup(parser.Close)
 
 	doc.SetParser(parser)
 

--- a/lsp/document/base/pool_lifecycle_test.go
+++ b/lsp/document/base/pool_lifecycle_test.go
@@ -17,8 +17,11 @@ func TestPoolLifecycle_CloseReturnsParserViaCallback(t *testing.T) {
 
 	doc.Close()
 
-	assert.Equal(t, parser, returned, "Close should return parser via callback")
+	assert.Same(t, parser, returned, "Close should return parser via callback")
 	assert.Nil(t, doc.Parser(), "parser should be nil after Close")
+	if returned != nil {
+		returned.Close()
+	}
 }
 
 func TestPoolLifecycle_SetParserReturnsOldParserViaCallback(t *testing.T) {
@@ -27,14 +30,14 @@ func TestPoolLifecycle_SetParserReturnsOldParserViaCallback(t *testing.T) {
 
 	doc := NewBaseDocument("test.ts", "", 1, "typescript", callback, nil)
 	old := ts.NewParser()
-	defer old.Close()
+	t.Cleanup(old.Close)
 	new := ts.NewParser()
-	defer new.Close()
+	t.Cleanup(new.Close)
 
 	doc.SetParser(old)
 	doc.SetParser(new)
 
-	assert.Equal(t, old, returned, "SetParser should return old parser via callback")
+	assert.Same(t, old, returned, "SetParser should return old parser via callback")
 }
 
 func TestPoolLifecycle_CrossPoolAssignment(t *testing.T) {
@@ -50,18 +53,20 @@ func TestPoolLifecycle_CrossPoolAssignment(t *testing.T) {
 	parser := ts.NewParser()
 
 	htmlDoc.SetParser(parser)
-	// Move parser from HTML doc to TS doc
 	tsDoc.SetParser(parser)
 
-	// Close TS doc -- should return via TS callback, not HTML callback
 	tsDoc.Close()
 
 	assert.Nil(t, htmlReturned, "HTML callback should not be called when TS doc closes")
-	assert.Equal(t, parser, tsReturned, "TS callback should receive the parser")
+	assert.Same(t, parser, tsReturned, "TS callback should receive the parser")
+	if tsReturned != nil {
+		tsReturned.Close()
+	}
 }
 
 func TestPoolLifecycle_DoubleCloseDoesNotPanic(t *testing.T) {
-	callback := func(p *ts.Parser) {}
+	var returned *ts.Parser
+	callback := func(p *ts.Parser) { returned = p }
 	doc := NewBaseDocument("test.html", "", 1, "html", callback, nil)
 	parser := ts.NewParser()
 	doc.SetParser(parser)
@@ -70,4 +75,7 @@ func TestPoolLifecycle_DoubleCloseDoesNotPanic(t *testing.T) {
 		doc.Close()
 		doc.Close()
 	}, "double Close should not panic")
+	if returned != nil {
+		returned.Close()
+	}
 }

--- a/lsp/document/base/pool_lifecycle_test.go
+++ b/lsp/document/base/pool_lifecycle_test.go
@@ -1,0 +1,73 @@
+package base
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	ts "github.com/tree-sitter/go-tree-sitter"
+)
+
+func TestPoolLifecycle_CloseReturnsParserViaCallback(t *testing.T) {
+	var returned *ts.Parser
+	callback := func(p *ts.Parser) { returned = p }
+
+	doc := NewBaseDocument("test.html", "<div></div>", 1, "html", callback, nil)
+	parser := ts.NewParser()
+	doc.SetParser(parser)
+
+	doc.Close()
+
+	assert.Equal(t, parser, returned, "Close should return parser via callback")
+	assert.Nil(t, doc.Parser(), "parser should be nil after Close")
+}
+
+func TestPoolLifecycle_SetParserReturnsOldParserViaCallback(t *testing.T) {
+	var returned *ts.Parser
+	callback := func(p *ts.Parser) { returned = p }
+
+	doc := NewBaseDocument("test.ts", "", 1, "typescript", callback, nil)
+	old := ts.NewParser()
+	defer old.Close()
+	new := ts.NewParser()
+	defer new.Close()
+
+	doc.SetParser(old)
+	doc.SetParser(new)
+
+	assert.Equal(t, old, returned, "SetParser should return old parser via callback")
+}
+
+func TestPoolLifecycle_CrossPoolAssignment(t *testing.T) {
+	var htmlReturned *ts.Parser
+	htmlCallback := func(p *ts.Parser) { htmlReturned = p }
+
+	var tsReturned *ts.Parser
+	tsCallback := func(p *ts.Parser) { tsReturned = p }
+
+	htmlDoc := NewBaseDocument("test.html", "", 1, "html", htmlCallback, nil)
+	tsDoc := NewBaseDocument("test.ts", "", 1, "typescript", tsCallback, nil)
+
+	parser := ts.NewParser()
+
+	htmlDoc.SetParser(parser)
+	// Move parser from HTML doc to TS doc
+	tsDoc.SetParser(parser)
+
+	// Close TS doc -- should return via TS callback, not HTML callback
+	tsDoc.Close()
+
+	assert.Nil(t, htmlReturned, "HTML callback should not be called when TS doc closes")
+	assert.Equal(t, parser, tsReturned, "TS callback should receive the parser")
+}
+
+func TestPoolLifecycle_DoubleCloseDoesNotPanic(t *testing.T) {
+	callback := func(p *ts.Parser) {}
+	doc := NewBaseDocument("test.html", "", 1, "html", callback, nil)
+	parser := ts.NewParser()
+	doc.SetParser(parser)
+
+	assert.NotPanics(t, func() {
+		doc.Close()
+		doc.Close()
+	}, "double Close should not panic")
+}

--- a/lsp/document/base_document.go
+++ b/lsp/document/base_document.go
@@ -18,6 +18,7 @@ package document
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"bennypowers.dev/cem/lsp/helpers"
@@ -28,23 +29,25 @@ import (
 
 // BaseDocument provides common document functionality that language-specific documents can embed
 type BaseDocument struct {
-	uri        string
-	content    string
-	version    int32
-	language   string
-	tree       *ts.Tree
-	parser     *ts.Parser
-	scriptTags []types.ScriptTag
-	mu         sync.RWMutex
+	uri          string
+	content      string
+	version      int32
+	language     string
+	tree         *ts.Tree
+	parser       *ts.Parser
+	scriptTags   []types.ScriptTag
+	returnParser func(*ts.Parser)
+	mu           sync.RWMutex
 }
 
-// NewBaseDocument creates a new base document
-func NewBaseDocument(uri, content string, version int32, language string) *BaseDocument {
+// NewBaseDocument creates a new base document with a callback for returning parsers to the correct pool.
+func NewBaseDocument(uri, content string, version int32, language string, returnParser func(*ts.Parser)) *BaseDocument {
 	return &BaseDocument{
-		uri:      uri,
-		content:  content,
-		version:  version,
-		language: language,
+		uri:          uri,
+		content:      content,
+		version:      version,
+		language:     language,
+		returnParser: returnParser,
 	}
 }
 
@@ -136,10 +139,15 @@ func (d *BaseDocument) SetTree(tree *ts.Tree) {
 	d.tree = tree
 }
 
-// SetParser sets the document's parser (protected method for subclasses)
+// SetParser sets the document's parser, returning any previous parser to the pool.
 func (d *BaseDocument) SetParser(parser *ts.Parser) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	if d.parser != nil && d.parser != parser {
+		if d.returnParser != nil {
+			d.returnParser(d.parser)
+		}
+	}
 	d.parser = parser
 }
 
@@ -177,7 +185,7 @@ func (d *BaseDocument) SetScriptTags(scriptTags []types.ScriptTag) {
 	d.scriptTags = scriptTags
 }
 
-// Close cleans up document resources
+// Close cleans up document resources, returning the parser to its pool.
 func (d *BaseDocument) Close() {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -188,7 +196,9 @@ func (d *BaseDocument) Close() {
 	}
 
 	if d.parser != nil {
-		// Return parser to pool based on language - this will be handled by language handlers
+		if d.returnParser != nil {
+			d.returnParser(d.parser)
+		}
 		d.parser = nil
 	}
 }
@@ -244,17 +254,24 @@ func (d *BaseDocument) FindInlineModuleScript() (protocol.Position, bool) {
 	return protocol.Position{}, false
 }
 
-// ByteRangeToProtocolRange converts byte range to protocol range (default implementation)
+// TreeAndContent returns the tree and content atomically under one lock.
+// Use this from sub-package methods that need both values consistently.
+func (d *BaseDocument) TreeAndContent() (*ts.Tree, string) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.tree, d.content
+}
+
+// ByteRangeToProtocolRange converts byte range to protocol range.
 func (d *BaseDocument) ByteRangeToProtocolRange(content string, startByte, endByte uint) protocol.Range {
-	// Basic implementation - can be enhanced by language-specific documents
 	return protocol.Range{
-		Start: d.byteOffsetToPosition(startByte),
-		End:   d.byteOffsetToPosition(endByte),
+		Start: d.ByteOffsetToPosition(startByte),
+		End:   d.ByteOffsetToPosition(endByte),
 	}
 }
 
-// Helper method for byte offset to position conversion
-func (d *BaseDocument) byteOffsetToPosition(offset uint) protocol.Position {
+// ByteOffsetToPosition converts a byte offset to a protocol position.
+func (d *BaseDocument) ByteOffsetToPosition(offset uint) protocol.Position {
 	line := uint32(0)
 	char := uint32(0)
 
@@ -275,4 +292,25 @@ func (d *BaseDocument) byteOffsetToPosition(offset uint) protocol.Position {
 		Line:      line,
 		Character: char,
 	}
+}
+
+// PositionToByteOffset converts a protocol position to a byte offset within the given content.
+func (d *BaseDocument) PositionToByteOffset(pos protocol.Position, content string) uint {
+	var offset uint
+	lines := strings.Split(content, "\n")
+
+	for i := uint32(0); i < pos.Line && i < uint32(len(lines)); i++ {
+		offset += uint(len(lines[i])) + 1
+	}
+
+	if pos.Line < uint32(len(lines)) {
+		line := lines[pos.Line]
+		if pos.Character < uint32(len(line)) {
+			offset += uint(pos.Character)
+		} else {
+			offset += uint(len(line))
+		}
+	}
+
+	return offset
 }

--- a/lsp/document/base_document.go
+++ b/lsp/document/base_document.go
@@ -18,6 +18,7 @@ package document
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 
@@ -37,17 +38,21 @@ type BaseDocument struct {
 	parser       *ts.Parser
 	scriptTags   []types.ScriptTag
 	returnParser func(*ts.Parser)
+	self         types.Document
 	mu           sync.RWMutex
 }
 
 // NewBaseDocument creates a new base document with a callback for returning parsers to the correct pool.
-func NewBaseDocument(uri, content string, version int32, language string, returnParser func(*ts.Parser)) *BaseDocument {
+// The self parameter should be set to the embedding struct (the concrete document type) so that
+// reflection-based handler delegation passes the correct type for handler type assertions.
+func NewBaseDocument(uri, content string, version int32, language string, returnParser func(*ts.Parser), self types.Document) *BaseDocument {
 	return &BaseDocument{
 		uri:          uri,
 		content:      content,
 		version:      version,
 		language:     language,
 		returnParser: returnParser,
+		self:         self,
 	}
 }
 
@@ -236,22 +241,9 @@ func (d *BaseDocument) FindModuleScript() (protocol.Position, bool) {
 	return protocol.Position{}, false
 }
 
-// FindInlineModuleScript finds the first inline module script (no src) and returns insertion position (default implementation)
+// FindInlineModuleScript delegates to FindModuleScript by default.
 func (d *BaseDocument) FindInlineModuleScript() (protocol.Position, bool) {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
-	for _, script := range d.scriptTags {
-		if script.IsModule && script.Src == "" {
-			// Return position at the end of the script content for insertion
-			return protocol.Position{
-				Line:      script.ContentRange.End.Line,
-				Character: 0, // Start of line for clean insertion
-			}, true
-		}
-	}
-
-	return protocol.Position{}, false
+	return d.FindModuleScript()
 }
 
 // TreeAndContent returns the tree and content atomically under one lock.
@@ -313,4 +305,101 @@ func (d *BaseDocument) PositionToByteOffset(pos protocol.Position, content strin
 	}
 
 	return offset
+}
+
+// getLanguageHandler uses reflection to retrieve the language handler from a document manager.
+// This avoids circular imports between document and handler packages.
+func (d *BaseDocument) getLanguageHandler(dm any) any {
+	dmValue := reflect.ValueOf(dm)
+	if dmValue.Kind() != reflect.Pointer || dmValue.IsNil() {
+		return nil
+	}
+	method := dmValue.MethodByName("GetLanguageHandler")
+	if !method.IsValid() {
+		return nil
+	}
+	results := method.Call([]reflect.Value{reflect.ValueOf(d.language)})
+	if len(results) == 0 || results[0].IsNil() {
+		return nil
+	}
+	return results[0].Interface()
+}
+
+// doc returns the concrete document type for handler delegation.
+// When embedded, self points to the outer struct; standalone, it falls back to d.
+func (d *BaseDocument) doc() types.Document {
+	if d.self != nil {
+		return d.self
+	}
+	return d
+}
+
+// FindElementAtPosition finds a custom element at the given position.
+func (d *BaseDocument) FindElementAtPosition(position protocol.Position, dm any) *types.CustomElementMatch {
+	handler := d.getLanguageHandler(dm)
+	if handler == nil {
+		return nil
+	}
+	if h, ok := handler.(interface {
+		FindElementAtPosition(types.Document, protocol.Position) *types.CustomElementMatch
+	}); ok {
+		return h.FindElementAtPosition(d.doc(), position)
+	}
+	return nil
+}
+
+// FindAttributeAtPosition finds an attribute at the given position.
+func (d *BaseDocument) FindAttributeAtPosition(position protocol.Position, dm any) (*types.AttributeMatch, string) {
+	handler := d.getLanguageHandler(dm)
+	if handler == nil {
+		return nil, ""
+	}
+	if h, ok := handler.(interface {
+		FindAttributeAtPosition(types.Document, protocol.Position) (*types.AttributeMatch, string)
+	}); ok {
+		return h.FindAttributeAtPosition(d.doc(), position)
+	}
+	return nil, ""
+}
+
+// FindCustomElements finds custom elements in the document.
+func (d *BaseDocument) FindCustomElements(dm any) ([]types.CustomElementMatch, error) {
+	handler := d.getLanguageHandler(dm)
+	if handler == nil {
+		return []types.CustomElementMatch{}, nil
+	}
+	if h, ok := handler.(interface {
+		FindCustomElements(types.Document) ([]types.CustomElementMatch, error)
+	}); ok {
+		return h.FindCustomElements(d.doc())
+	}
+	return []types.CustomElementMatch{}, nil
+}
+
+// AnalyzeCompletionContextTS analyzes completion context using tree-sitter queries.
+func (d *BaseDocument) AnalyzeCompletionContextTS(position protocol.Position, dm any) *types.CompletionAnalysis {
+	handler := d.getLanguageHandler(dm)
+	if handler == nil {
+		return &types.CompletionAnalysis{Type: types.CompletionUnknown}
+	}
+	if h, ok := handler.(interface {
+		AnalyzeCompletionContext(types.Document, protocol.Position) *types.CompletionAnalysis
+	}); ok {
+		return h.AnalyzeCompletionContext(d.doc(), position)
+	}
+	return &types.CompletionAnalysis{Type: types.CompletionUnknown}
+}
+
+// FindHeadInsertionPoint finds insertion point in <head> section.
+func (d *BaseDocument) FindHeadInsertionPoint(dm any) (protocol.Position, bool) {
+	handler := d.getLanguageHandler(dm)
+	if handler == nil {
+		return protocol.Position{}, false
+	}
+	if h, ok := handler.(interface {
+		FindHeadInsertionPoint(types.Document) (protocol.Position, bool)
+	}); ok {
+		return h.FindHeadInsertionPoint(d.doc())
+	}
+	return protocol.Position{}, false
 }

--- a/lsp/document/base_document_test.go
+++ b/lsp/document/base_document_test.go
@@ -11,7 +11,7 @@ func TestSetParser_CallbackFiresWithOldParser(t *testing.T) {
 	var returned *ts.Parser
 	callback := func(p *ts.Parser) { returned = p }
 
-	doc := NewBaseDocument("test.html", "", 1, "html", callback)
+	doc := NewBaseDocument("test.html", "", 1, "html", callback, nil)
 	oldParser := ts.NewParser()
 	defer oldParser.Close()
 	newParser := ts.NewParser()
@@ -27,7 +27,7 @@ func TestSetParser_SameParserDoesNotFireCallback(t *testing.T) {
 	called := false
 	callback := func(p *ts.Parser) { called = true }
 
-	doc := NewBaseDocument("test.html", "", 1, "html", callback)
+	doc := NewBaseDocument("test.html", "", 1, "html", callback, nil)
 	parser := ts.NewParser()
 	defer parser.Close()
 
@@ -41,7 +41,7 @@ func TestSetParser_NoPreviousParserDoesNotFireCallback(t *testing.T) {
 	called := false
 	callback := func(p *ts.Parser) { called = true }
 
-	doc := NewBaseDocument("test.html", "", 1, "html", callback)
+	doc := NewBaseDocument("test.html", "", 1, "html", callback, nil)
 	parser := ts.NewParser()
 	defer parser.Close()
 
@@ -54,7 +54,7 @@ func TestClose_FiresCallbackWithParser(t *testing.T) {
 	var returned *ts.Parser
 	callback := func(p *ts.Parser) { returned = p }
 
-	doc := NewBaseDocument("test.html", "", 1, "html", callback)
+	doc := NewBaseDocument("test.html", "", 1, "html", callback, nil)
 	parser := ts.NewParser()
 
 	doc.SetParser(parser)
@@ -68,14 +68,14 @@ func TestClose_NoParserDoesNotFireCallback(t *testing.T) {
 	called := false
 	callback := func(p *ts.Parser) { called = true }
 
-	doc := NewBaseDocument("test.html", "", 1, "html", callback)
+	doc := NewBaseDocument("test.html", "", 1, "html", callback, nil)
 	doc.Close()
 
 	assert.False(t, called, "callback should not fire when no parser exists")
 }
 
 func TestClose_NilCallbackDoesNotPanic(t *testing.T) {
-	doc := NewBaseDocument("test.html", "", 1, "html", nil)
+	doc := NewBaseDocument("test.html", "", 1, "html", nil, nil)
 	parser := ts.NewParser()
 
 	doc.SetParser(parser)
@@ -86,7 +86,7 @@ func TestClose_NilCallbackDoesNotPanic(t *testing.T) {
 }
 
 func TestTreeAndContent_ReturnsAtomicSnapshot(t *testing.T) {
-	doc := NewBaseDocument("test.html", "<div>hello</div>", 1, "html", nil)
+	doc := NewBaseDocument("test.html", "<div>hello</div>", 1, "html", nil, nil)
 
 	tree, content := doc.TreeAndContent()
 

--- a/lsp/document/base_document_test.go
+++ b/lsp/document/base_document_test.go
@@ -1,0 +1,95 @@
+package document
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	ts "github.com/tree-sitter/go-tree-sitter"
+)
+
+func TestSetParser_CallbackFiresWithOldParser(t *testing.T) {
+	var returned *ts.Parser
+	callback := func(p *ts.Parser) { returned = p }
+
+	doc := NewBaseDocument("test.html", "", 1, "html", callback)
+	oldParser := ts.NewParser()
+	defer oldParser.Close()
+	newParser := ts.NewParser()
+	defer newParser.Close()
+
+	doc.SetParser(oldParser)
+	doc.SetParser(newParser)
+
+	assert.Equal(t, oldParser, returned, "callback should receive the old parser")
+}
+
+func TestSetParser_SameParserDoesNotFireCallback(t *testing.T) {
+	called := false
+	callback := func(p *ts.Parser) { called = true }
+
+	doc := NewBaseDocument("test.html", "", 1, "html", callback)
+	parser := ts.NewParser()
+	defer parser.Close()
+
+	doc.SetParser(parser)
+	doc.SetParser(parser)
+
+	assert.False(t, called, "callback should not fire when setting the same parser")
+}
+
+func TestSetParser_NoPreviousParserDoesNotFireCallback(t *testing.T) {
+	called := false
+	callback := func(p *ts.Parser) { called = true }
+
+	doc := NewBaseDocument("test.html", "", 1, "html", callback)
+	parser := ts.NewParser()
+	defer parser.Close()
+
+	doc.SetParser(parser)
+
+	assert.False(t, called, "callback should not fire when no previous parser existed")
+}
+
+func TestClose_FiresCallbackWithParser(t *testing.T) {
+	var returned *ts.Parser
+	callback := func(p *ts.Parser) { returned = p }
+
+	doc := NewBaseDocument("test.html", "", 1, "html", callback)
+	parser := ts.NewParser()
+
+	doc.SetParser(parser)
+	doc.Close()
+
+	assert.Equal(t, parser, returned, "Close should return parser via callback")
+	assert.Nil(t, doc.Parser(), "parser should be nil after Close")
+}
+
+func TestClose_NoParserDoesNotFireCallback(t *testing.T) {
+	called := false
+	callback := func(p *ts.Parser) { called = true }
+
+	doc := NewBaseDocument("test.html", "", 1, "html", callback)
+	doc.Close()
+
+	assert.False(t, called, "callback should not fire when no parser exists")
+}
+
+func TestClose_NilCallbackDoesNotPanic(t *testing.T) {
+	doc := NewBaseDocument("test.html", "", 1, "html", nil)
+	parser := ts.NewParser()
+
+	doc.SetParser(parser)
+
+	assert.NotPanics(t, func() {
+		doc.Close()
+	}, "Close with nil callback should not panic")
+}
+
+func TestTreeAndContent_ReturnsAtomicSnapshot(t *testing.T) {
+	doc := NewBaseDocument("test.html", "<div>hello</div>", 1, "html", nil)
+
+	tree, content := doc.TreeAndContent()
+
+	assert.Nil(t, tree, "tree should be nil when not set")
+	assert.Equal(t, "<div>hello</div>", content)
+}

--- a/lsp/document/html/document.go
+++ b/lsp/document/html/document.go
@@ -31,7 +31,8 @@ import (
 	ts "github.com/tree-sitter/go-tree-sitter"
 )
 
-// HTMLDocument represents an HTML document with tree-sitter parsing
+// HTMLDocument represents an HTML document with tree-sitter parsing.
+// Always use NewHTMLDocument to construct; a zero-value HTMLDocument will panic.
 type HTMLDocument struct {
 	*base.BaseDocument
 	importMap map[string]string

--- a/lsp/document/html/document.go
+++ b/lsp/document/html/document.go
@@ -475,7 +475,7 @@ func (d *HTMLDocument) findHeadInsertionPoint(handler *Handler) (protocol.Positi
 	root := tree.RootNode()
 	for captureMap := range matcher.ParentCaptures(root, []byte(content), "head.element") {
 		if endTags, exists := captureMap["end.tag"]; exists && len(endTags) > 0 {
-			pos := d.ByteOffsetToPosition(endTags[0].StartByte)
+			pos := d.ByteOffsetToPosition(endTags[0].StartByte, content)
 			return pos, true
 		}
 	}

--- a/lsp/document/html/document.go
+++ b/lsp/document/html/document.go
@@ -58,11 +58,16 @@ func (d *HTMLDocument) ImportMap() map[string]string {
 	return result
 }
 
-// SetImportMap sets the import map
+// SetImportMap sets the import map, copying the input to prevent external mutation.
 func (d *HTMLDocument) SetImportMap(importMap map[string]string) {
 	d.importMu.Lock()
 	defer d.importMu.Unlock()
-	d.importMap = importMap
+	if importMap == nil {
+		d.importMap = nil
+		return
+	}
+	d.importMap = make(map[string]string, len(importMap))
+	maps.Copy(d.importMap, importMap)
 }
 
 // Parse parses the HTML content using tree-sitter
@@ -89,6 +94,7 @@ func (d *HTMLDocument) ParseWithRanges(content string, ranges []ts.Range) error 
 	d.UpdateContent(content, d.Version())
 
 	if len(ranges) == 0 {
+		d.SetTree(nil)
 		return nil
 	}
 

--- a/lsp/document/html/document.go
+++ b/lsp/document/html/document.go
@@ -209,13 +209,8 @@ func (d *HTMLDocument) analyzeCompletionContext(position protocol.Position, hand
 		Type: types.CompletionUnknown,
 	}
 
-	tree := d.Tree()
+	tree, content := d.TreeAndContent()
 	if tree == nil {
-		return analysis
-	}
-
-	content, err := d.Content()
-	if err != nil {
 		return analysis
 	}
 

--- a/lsp/document/html/document.go
+++ b/lsp/document/html/document.go
@@ -18,190 +18,55 @@ package html
 
 import (
 	"fmt"
-	"reflect"
+	"maps"
 	"strings"
 	"sync"
 
 	htmllang "bennypowers.dev/cem/internal/languages/html"
+	Q "bennypowers.dev/cem/internal/treesitter"
+	"bennypowers.dev/cem/lsp/document/base"
 	"bennypowers.dev/cem/lsp/helpers"
 	"bennypowers.dev/cem/lsp/types"
-	Q "bennypowers.dev/cem/internal/treesitter"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 	ts "github.com/tree-sitter/go-tree-sitter"
 )
 
 // HTMLDocument represents an HTML document with tree-sitter parsing
 type HTMLDocument struct {
-	uri        string
-	content    string
-	version    int32
-	language   string
-	tree       *ts.Tree
-	parser     *ts.Parser
-	scriptTags []types.ScriptTag
-	importMap  map[string]string // Import map from <script type="importmap">
-	mu         sync.RWMutex
+	*base.BaseDocument
+	importMap map[string]string
+	importMu  sync.RWMutex
 }
 
-// Base document interface methods
-
-// URI returns the document URI
-func (d *HTMLDocument) URI() string {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.uri
-}
-
-// Content returns the document content
-func (d *HTMLDocument) Content() (string, error) {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.content, nil
-}
-
-// Version returns the document version
-func (d *HTMLDocument) Version() int32 {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.version
-}
-
-// Language returns the document language
-func (d *HTMLDocument) Language() string {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.language
-}
-
-// Tree returns the document's syntax tree
-func (d *HTMLDocument) Tree() *ts.Tree {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.tree
-}
-
-// ScriptTags returns the parsed script tags
-func (d *HTMLDocument) ScriptTags() []types.ScriptTag {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.scriptTags
+// NewHTMLDocument creates a new HTML document
+func NewHTMLDocument(uri, content string, version int32, language string) *HTMLDocument {
+	doc := &HTMLDocument{}
+	doc.BaseDocument = base.NewBaseDocument(uri, content, version, language, htmllang.ReturnParser, doc)
+	return doc
 }
 
 // ImportMap returns the import map from <script type="importmap"> tag
 func (d *HTMLDocument) ImportMap() map[string]string {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
+	d.importMu.RLock()
+	defer d.importMu.RUnlock()
 	if d.importMap == nil {
 		return nil
 	}
-	// Return a copy to prevent external mutation
 	result := make(map[string]string, len(d.importMap))
-	for k, v := range d.importMap {
-		result[k] = v
-	}
+	maps.Copy(result, d.importMap)
 	return result
-}
-
-// UpdateContent updates the document content
-func (d *HTMLDocument) UpdateContent(content string, version int32) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	d.content = content
-	d.version = version
-}
-
-// SetTree sets the document's syntax tree
-func (d *HTMLDocument) SetTree(tree *ts.Tree) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	if d.tree != nil {
-		d.tree.Close()
-	}
-	d.tree = tree
-}
-
-// Parser returns the document's parser
-func (d *HTMLDocument) Parser() *ts.Parser {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.parser
-}
-
-// SetParser sets the document's parser, returning any previous parser to the pool.
-func (d *HTMLDocument) SetParser(parser *ts.Parser) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	if d.parser != nil && d.parser != parser {
-		htmllang.ReturnParser(d.parser)
-	}
-	d.parser = parser
-}
-
-// SetScriptTags sets the script tags
-func (d *HTMLDocument) SetScriptTags(scriptTags []types.ScriptTag) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	d.scriptTags = scriptTags
 }
 
 // SetImportMap sets the import map
 func (d *HTMLDocument) SetImportMap(importMap map[string]string) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
+	d.importMu.Lock()
+	defer d.importMu.Unlock()
 	d.importMap = importMap
-}
-
-// Close cleans up document resources
-func (d *HTMLDocument) Close() {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	if d.tree != nil {
-		d.tree.Close()
-		d.tree = nil
-	}
-
-	if d.parser != nil {
-		htmllang.ReturnParser(d.parser)
-		d.parser = nil
-	}
-}
-
-// ByteRangeToProtocolRange converts byte range to protocol range
-func (d *HTMLDocument) ByteRangeToProtocolRange(content string, startByte, endByte uint) protocol.Range {
-	return protocol.Range{
-		Start: d.byteOffsetToPosition(startByte),
-		End:   d.byteOffsetToPosition(endByte),
-	}
-}
-
-// Helper method for byte offset to position conversion
-func (d *HTMLDocument) byteOffsetToPosition(offset uint) protocol.Position {
-	line := uint32(0)
-	char := uint32(0)
-
-	for i, r := range d.content {
-		if uint(i) >= offset {
-			break
-		}
-
-		if r == '\n' {
-			line++
-			char = 0
-		} else {
-			char++
-		}
-	}
-
-	return protocol.Position{
-		Line:      line,
-		Character: char,
-	}
 }
 
 // Parse parses the HTML content using tree-sitter
 func (d *HTMLDocument) Parse(content string) error {
-	d.UpdateContent(content, d.version)
+	d.UpdateContent(content, d.Version())
 
 	parser := htmllang.BorrowParser()
 	if parser == nil {
@@ -212,9 +77,6 @@ func (d *HTMLDocument) Parse(content string) error {
 	tree := parser.Parse([]byte(content), nil)
 	d.SetTree(tree)
 
-	// Script tags are now parsed by the handler after document creation
-	// This avoids circular import issues while using tree-sitter
-
 	return nil
 }
 
@@ -223,7 +85,7 @@ func (d *HTMLDocument) Parse(content string) error {
 // template grammar). Byte positions in the resulting tree refer to the original
 // source, so line/column mapping works without a whitespace-filled buffer.
 func (d *HTMLDocument) ParseWithRanges(content string, ranges []ts.Range) error {
-	d.UpdateContent(content, d.version)
+	d.UpdateContent(content, d.Version())
 
 	if len(ranges) == 0 {
 		return nil
@@ -241,7 +103,6 @@ func (d *HTMLDocument) ParseWithRanges(content string, ranges []ts.Range) error 
 
 	tree := parser.Parse([]byte(content), nil)
 
-	// Clear included ranges so the parser doesn't carry stale state
 	_ = parser.SetIncludedRanges(nil)
 
 	d.SetTree(tree)
@@ -253,24 +114,16 @@ func (d *HTMLDocument) ParseWithRanges(content string, ranges []ts.Range) error 
 func (d *HTMLDocument) findCustomElements(handler *Handler) ([]types.CustomElementMatch, error) {
 	var elements []types.CustomElementMatch
 
-	// Safety checks
 	if handler == nil {
 		helpers.SafeDebugLog("[HTML] Handler is nil in findCustomElements")
 		return elements, nil
 	}
 
-	// Hold read lock for the ENTIRE duration of tree usage to prevent Close() from freeing it
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
-	tree := d.tree // Access tree directly while holding lock
+	tree, content := d.TreeAndContent()
 	if tree == nil {
 		return elements, nil
 	}
 
-	content := d.content // Access content directly while holding lock
-
-	// Create a fresh query matcher for thread safety
 	matcher, err := Q.GetCachedQueryMatcher(handler.queryManager, handler.language, "customElements")
 	if err != nil {
 		helpers.SafeDebugLog("[HTML] Failed to create custom elements matcher: %v", err)
@@ -281,9 +134,7 @@ func (d *HTMLDocument) findCustomElements(handler *Handler) ([]types.CustomEleme
 	root := tree.RootNode()
 	contentBytes := []byte(content)
 
-	// Ensure tree size doesn't exceed content length
 	if root.EndByte() > uint(len(contentBytes)) {
-		// Tree is out of sync with content, return empty results
 		return elements, nil
 	}
 
@@ -292,25 +143,20 @@ func (d *HTMLDocument) findCustomElements(handler *Handler) ([]types.CustomEleme
 			tagName := tagNames[0].Text
 			tagRange := d.ByteRangeToProtocolRange(content, tagNames[0].StartByte, tagNames[0].EndByte)
 
-			// Collect attributes
 			attributes := make(map[string]types.AttributeMatch)
 			if attrNames, ok := captureMap["attr.name"]; ok {
-				// Build a map of attribute values by their byte position for proper matching
 				valuesByPosition := make(map[uint]string)
 
-				// Collect quoted attribute values
 				if attrValues, ok := captureMap["attr.value"]; ok {
 					for _, attrValue := range attrValues {
-						// Strip quotes from quoted attribute values
 						value := attrValue.Text
 						if len(value) >= 2 && (value[0] == '"' || value[0] == '\'') {
-							value = value[1 : len(value)-1] // Remove first and last character (quotes)
+							value = value[1 : len(value)-1]
 						}
 						valuesByPosition[attrValue.StartByte] = value
 					}
 				}
 
-				// Collect unquoted attribute values
 				if unquotedValues, ok := captureMap["attr.unquoted.value"]; ok {
 					for _, unquotedValue := range unquotedValues {
 						valuesByPosition[unquotedValue.StartByte] = unquotedValue.Text
@@ -323,19 +169,13 @@ func (d *HTMLDocument) findCustomElements(handler *Handler) ([]types.CustomEleme
 						Range: d.ByteRangeToProtocolRange(content, attrName.StartByte, attrName.EndByte),
 					}
 
-					// Find the value that comes immediately after this attribute name
-					// Look for the closest value that starts after the attribute name ends
-					// BUT only if there's an = sign IMMEDIATELY after the attribute name
 					var closestValue string
-					var closestDistance = ^uint(0) // Max uint value
+					var closestDistance = ^uint(0)
 					for valuePos, value := range valuesByPosition {
 						if valuePos > attrName.EndByte {
 							distance := valuePos - attrName.EndByte
 							if distance < closestDistance {
-								// Extract the text between attribute name end and value start
 								betweenText := string(contentBytes[attrName.EndByte:valuePos])
-								// Only consider this value if the FIRST non-whitespace character is '='
-								// This ensures we're matching attr="value" and not attr value="other"
 								trimmed := strings.TrimLeft(betweenText, " \t\r\n")
 								if len(trimmed) > 0 && trimmed[0] == '=' {
 									closestDistance = distance
@@ -379,13 +219,10 @@ func (d *HTMLDocument) analyzeCompletionContext(position protocol.Position, hand
 		return analysis
 	}
 
-	// Convert position to byte offset
-	byteOffset := d.positionToByteOffset(position, content)
+	byteOffset := d.PositionToByteOffset(position, content)
 
-	// Debug logging for the failing test case
 	helpers.SafeDebugLog("[HTML] analyzeCompletionContext: content=%q, position=%+v, byteOffset=%d", content, position, byteOffset)
 
-	// Create a fresh completion context query matcher for thread safety
 	completionMatcher, err := Q.GetCachedQueryMatcher(handler.queryManager, handler.language, "completionContext")
 	if err != nil {
 		helpers.SafeDebugLog("[HTML] Failed to create completion context matcher: %v", err)
@@ -393,8 +230,6 @@ func (d *HTMLDocument) analyzeCompletionContext(position protocol.Position, hand
 	}
 	defer completionMatcher.Close()
 
-	// Use tree-sitter to analyze context
-	// First, collect all captures across all capture maps
 	allTagNames := []Q.CaptureInfo{}
 	allAttrNames := []Q.CaptureInfo{}
 	allAttrValues := []Q.CaptureInfo{}
@@ -402,7 +237,6 @@ func (d *HTMLDocument) analyzeCompletionContext(position protocol.Position, hand
 	captureCount := 0
 	for captureMap := range completionMatcher.ParentCaptures(tree.RootNode(), []byte(content), "context") {
 		captureCount++
-		// Collect all captures of each type
 		if tagNames, exists := captureMap["tag.name"]; exists {
 			allTagNames = append(allTagNames, tagNames...)
 		}
@@ -414,14 +248,8 @@ func (d *HTMLDocument) analyzeCompletionContext(position protocol.Position, hand
 		}
 	}
 
-	// Process captures in priority order: tag.name > attr.value > attr.name
-	// But prefer more specific (smaller) captures over broader ones
-
-	// Check tag names first, but only if they're legitimate tag name captures
 	for _, capture := range allTagNames {
 		if capture.StartByte <= byteOffset && byteOffset <= capture.EndByte {
-			// Only consider tag name completion if the capture text looks like a tag name
-			// and doesn't contain attribute syntax or other HTML syntax
 			captureText := capture.Text
 			if !strings.Contains(captureText, " ") &&
 				!strings.Contains(captureText, "=") &&
@@ -434,22 +262,14 @@ func (d *HTMLDocument) analyzeCompletionContext(position protocol.Position, hand
 		}
 	}
 
-	// Check attribute values second
 	for _, capture := range allAttrValues {
 		if capture.StartByte <= byteOffset && byteOffset <= capture.EndByte {
-			// For attribute values, we're more lenient since they can contain various content
-			// Only reject captures that are clearly overly broad (contain multiple HTML elements)
 			captureText := capture.Text
-			// Count occurrences of < and newlines to detect overly broad captures
 			openBrackets := strings.Count(captureText, "<")
-			// If it contains multiple opening brackets, it's likely overly broad
-			// For attribute values, one opening bracket is normal (the start of the element)
-			// Reject only if there are multiple opening brackets or if we detect other problematic patterns
 			newlineCount := strings.Count(captureText, "\n")
 
 			if openBrackets <= 1 && newlineCount <= 1 {
 				analysis.Type = types.CompletionAttributeValue
-				// Find the closest preceding attribute name and tag name
 				for _, attrCapture := range allAttrNames {
 					if attrCapture.EndByte <= byteOffset {
 						analysis.AttributeName = attrCapture.Text
@@ -465,11 +285,8 @@ func (d *HTMLDocument) analyzeCompletionContext(position protocol.Position, hand
 		}
 	}
 
-	// Check attribute names last
 	for _, capture := range allAttrNames {
 		if capture.StartByte <= byteOffset && byteOffset <= capture.EndByte {
-			// Only consider attribute name completion if the capture text looks like a real attribute name
-			// and doesn't contain HTML syntax that suggests it's an overly broad capture
 			captureText := capture.Text
 			if !strings.Contains(captureText, "<") &&
 				!strings.Contains(captureText, ">") &&
@@ -477,7 +294,6 @@ func (d *HTMLDocument) analyzeCompletionContext(position protocol.Position, hand
 				!strings.Contains(captureText, "=") {
 				analysis.Type = types.CompletionAttributeName
 				analysis.AttributeName = captureText
-				// Find the closest preceding tag name
 				for _, tagCapture := range allTagNames {
 					if tagCapture.EndByte <= byteOffset {
 						analysis.TagName = tagCapture.Text
@@ -488,18 +304,15 @@ func (d *HTMLDocument) analyzeCompletionContext(position protocol.Position, hand
 		}
 	}
 
-	// Special case: check if cursor is positioned just after a custom element tag name or attribute (attribute name completion)
 	if analysis.Type == types.CompletionUnknown && captureCount > 0 {
 		for captureMap := range completionMatcher.ParentCaptures(tree.RootNode(), []byte(content), "context") {
 			for captureName, captures := range captureMap {
 				if captureName == "tag.name" {
 					for _, capture := range captures {
-						// Check if cursor is positioned 1-3 characters after the tag name (whitespace)
-						if strings.Contains(capture.Text, "-") && // Custom element
+						if strings.Contains(capture.Text, "-") &&
 							capture.EndByte < byteOffset &&
-							byteOffset <= capture.EndByte+3 { // Within 3 chars after tag name
+							byteOffset <= capture.EndByte+3 {
 
-							// Check if the content after tag name is just whitespace
 							afterTag := content[capture.EndByte:byteOffset]
 							if strings.TrimSpace(afterTag) == "" {
 								analysis.Type = types.CompletionAttributeName
@@ -512,13 +325,10 @@ func (d *HTMLDocument) analyzeCompletionContext(position protocol.Position, hand
 			}
 		}
 
-		// Additional special case: check if cursor is positioned after a complete attribute
-		// This handles cases like <test-component color="red" |> where cursor is after the space
 		for captureMap := range completionMatcher.ParentCaptures(tree.RootNode(), []byte(content), "context") {
 			var associatedTagName string
 			var latestAttrEnd uint
 
-			// Find the associated tag name and latest attribute end position
 			if tagNames, exists := captureMap["tag.name"]; exists && len(tagNames) > 0 {
 				for _, tagCapture := range tagNames {
 					if strings.Contains(tagCapture.Text, "-") && tagCapture.StartByte < byteOffset {
@@ -527,7 +337,6 @@ func (d *HTMLDocument) analyzeCompletionContext(position protocol.Position, hand
 				}
 			}
 
-			// Find the latest attribute value that ends before our cursor
 			if attrValues, exists := captureMap["attr.value"]; exists {
 				for _, attrValue := range attrValues {
 					if attrValue.EndByte < byteOffset && attrValue.EndByte > latestAttrEnd {
@@ -536,7 +345,6 @@ func (d *HTMLDocument) analyzeCompletionContext(position protocol.Position, hand
 				}
 			}
 
-			// Check unquoted attribute values too
 			if unquotedValues, exists := captureMap["attr.unquoted.value"]; exists {
 				for _, unquotedValue := range unquotedValues {
 					if unquotedValue.EndByte < byteOffset && unquotedValue.EndByte > latestAttrEnd {
@@ -545,16 +353,13 @@ func (d *HTMLDocument) analyzeCompletionContext(position protocol.Position, hand
 				}
 			}
 
-			// If we found a tag name and an attribute ending before our cursor, check the gap
 			if associatedTagName != "" && latestAttrEnd > 0 {
-				// Check if the content between the attribute end and cursor is just whitespace
 				gapContent := content[latestAttrEnd:byteOffset]
-				// For quoted attributes, skip the closing quote
 				if len(gapContent) > 0 && (gapContent[0] == '"' || gapContent[0] == '\'') {
 					gapContent = gapContent[1:]
 				}
 
-				if strings.TrimSpace(gapContent) == "" && len(gapContent) <= 5 { // Allow reasonable whitespace
+				if strings.TrimSpace(gapContent) == "" && len(gapContent) <= 5 {
 					analysis.Type = types.CompletionAttributeName
 					analysis.TagName = associatedTagName
 					return analysis
@@ -563,10 +368,6 @@ func (d *HTMLDocument) analyzeCompletionContext(position protocol.Position, hand
 		}
 	}
 
-	// Tree-sitter fallback: check if cursor is at a bare "<" inside an ERROR
-	// node. The tree has an anonymous "<" child but no tag_name yet, so no
-	// query capture matches. Use DescendantForByteRange to verify the cursor
-	// is inside an ERROR or start_tag context.
 	if analysis.Type == types.CompletionUnknown && byteOffset > 0 {
 		node := tree.RootNode().DescendantForByteRange(byteOffset-1, byteOffset)
 		if node != nil {
@@ -587,31 +388,8 @@ func (d *HTMLDocument) analyzeCompletionContext(position protocol.Position, hand
 	return analysis
 }
 
-// positionToByteOffset converts LSP position to byte offset
-func (d *HTMLDocument) positionToByteOffset(pos protocol.Position, content string) uint {
-	var offset uint = 0
-	lines := strings.Split(content, "\n")
-
-	// Add bytes for complete lines before the target line
-	for i := uint32(0); i < pos.Line && i < uint32(len(lines)); i++ {
-		offset += uint(len(lines[i])) + 1 // +1 for newline
-	}
-
-	// Add bytes for characters in the target line
-	if pos.Line < uint32(len(lines)) {
-		line := lines[pos.Line]
-		if pos.Character < uint32(len(line)) {
-			offset += uint(pos.Character)
-		} else {
-			offset += uint(len(line))
-		}
-	}
-
-	return offset
-}
-
 // CompletionPrefix extracts the prefix being typed for filtering completions.
-// Uses analysis struct fields and LineContent only — never searches full
+// Uses analysis struct fields and LineContent only -- never searches full
 // document content, which may contain template tokens after injection parsing.
 func (d *HTMLDocument) CompletionPrefix(analysis *types.CompletionAnalysis) string {
 	if analysis == nil {
@@ -669,138 +447,23 @@ func (d *HTMLDocument) CompletionPrefix(analysis *types.CompletionAnalysis) stri
 	}
 }
 
-// AnalyzeCompletionContextTS analyzes completion context using tree-sitter queries (interface method)
-func (d *HTMLDocument) AnalyzeCompletionContextTS(position protocol.Position, dm any) *types.CompletionAnalysis {
-	helpers.SafeDebugLog("[HTML] AnalyzeCompletionContextTS called with position %+v", position)
-	// Use reflection to call GetLanguageHandler to avoid circular imports
-	dmValue := reflect.ValueOf(dm)
-	if dmValue.Kind() == reflect.Pointer && !dmValue.IsNil() {
-		method := dmValue.MethodByName("GetLanguageHandler")
-		if method.IsValid() {
-			results := method.Call([]reflect.Value{reflect.ValueOf(d.language)})
-			if len(results) > 0 && !results[0].IsNil() {
-				handler := results[0].Interface()
-				if h, ok := handler.(interface {
-					AnalyzeCompletionContext(types.Document, protocol.Position) *types.CompletionAnalysis
-				}); ok {
-					result := h.AnalyzeCompletionContext(d, position)
-					helpers.SafeDebugLog("[HTML] AnalyzeCompletionContext returned: Type=%d, TagName=%s, AttributeName=%s",
-						result.Type, result.TagName, result.AttributeName)
-					return result
-				} else {
-					helpers.SafeDebugLog("[HTML] Handler type assertion failed for AnalyzeCompletionContext")
-				}
-			} else {
-				helpers.SafeDebugLog("[HTML] GetLanguageHandler returned nil for html")
-			}
-		} else {
-			helpers.SafeDebugLog("[HTML] GetLanguageHandler method not found")
-		}
-	} else {
-		helpers.SafeDebugLog("[HTML] Invalid dm value")
-	}
-	// Fallback: return safe default
-	helpers.SafeDebugLog("[HTML] Returning fallback CompletionUnknown")
-	return &types.CompletionAnalysis{
-		Type: types.CompletionUnknown,
-	}
-}
-
-// FindElementAtPosition finds a custom element at the given position (interface method)
-func (d *HTMLDocument) FindElementAtPosition(position protocol.Position, dm any) *types.CustomElementMatch {
-	// Use reflection to call GetLanguageHandler to avoid circular imports
-	dmValue := reflect.ValueOf(dm)
-	if dmValue.Kind() == reflect.Pointer && !dmValue.IsNil() {
-		method := dmValue.MethodByName("GetLanguageHandler")
-		if method.IsValid() {
-			results := method.Call([]reflect.Value{reflect.ValueOf(d.language)})
-			if len(results) > 0 && !results[0].IsNil() {
-				handler := results[0].Interface()
-				if h, ok := handler.(interface {
-					FindElementAtPosition(types.Document, protocol.Position) *types.CustomElementMatch
-				}); ok {
-					return h.FindElementAtPosition(d, position)
-				}
-			}
-		}
-	}
-	// Fallback: return nil if handler not available
-	return nil
-}
-
-// FindAttributeAtPosition finds an attribute at the given position (interface method)
-func (d *HTMLDocument) FindAttributeAtPosition(position protocol.Position, dm any) (*types.AttributeMatch, string) {
-	// Use reflection to call GetLanguageHandler to avoid circular imports
-	dmValue := reflect.ValueOf(dm)
-	if dmValue.Kind() == reflect.Pointer && !dmValue.IsNil() {
-		method := dmValue.MethodByName("GetLanguageHandler")
-		if method.IsValid() {
-			results := method.Call([]reflect.Value{reflect.ValueOf(d.language)})
-			if len(results) > 0 && !results[0].IsNil() {
-				handler := results[0].Interface()
-				if h, ok := handler.(interface {
-					FindAttributeAtPosition(types.Document, protocol.Position) (*types.AttributeMatch, string)
-				}); ok {
-					return h.FindAttributeAtPosition(d, position)
-				}
-			}
-		}
-	}
-	// Fallback: return nil if handler not available
-	return nil, ""
-}
-
-// FindCustomElements finds custom elements in the document (interface method)
-func (d *HTMLDocument) FindCustomElements(dm any) ([]types.CustomElementMatch, error) {
-	// Use reflection to call GetLanguageHandler to avoid circular imports
-	dmValue := reflect.ValueOf(dm)
-	if dmValue.Kind() == reflect.Pointer && !dmValue.IsNil() {
-		method := dmValue.MethodByName("GetLanguageHandler")
-		if method.IsValid() {
-			results := method.Call([]reflect.Value{reflect.ValueOf(d.language)})
-			if len(results) > 0 && !results[0].IsNil() {
-				handler := results[0].Interface()
-				if h, ok := handler.(interface {
-					FindCustomElements(types.Document) ([]types.CustomElementMatch, error)
-				}); ok {
-					return h.FindCustomElements(d)
-				}
-			}
-		}
-	}
-	// Fallback: return empty slice if handler not available
-	return []types.CustomElementMatch{}, nil
-}
-
 // FindModuleScript finds insertion point in module script
 func (d *HTMLDocument) FindModuleScript() (protocol.Position, bool) {
-	// For HTML documents, find the first module script tag
 	scriptTags := d.ScriptTags()
 	for _, script := range scriptTags {
 		if script.IsModule && script.Src == "" {
-			// Found inline module script, return end of content
 			return script.ContentRange.End, true
 		}
 	}
 	return protocol.Position{}, false
 }
 
-// FindInlineModuleScript finds insertion point in inline module script
-func (d *HTMLDocument) FindInlineModuleScript() (protocol.Position, bool) {
-	return d.FindModuleScript()
-}
-
 // findHeadInsertionPoint finds insertion point just before </head> using tree-sitter.
 func (d *HTMLDocument) findHeadInsertionPoint(handler *Handler) (protocol.Position, bool) {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
-	tree := d.tree
+	tree, content := d.TreeAndContent()
 	if tree == nil {
 		return protocol.Position{}, false
 	}
-
-	content := d.content
 
 	matcher, err := Q.GetCachedQueryMatcher(handler.queryManager, handler.language, "headElements")
 	if err != nil {
@@ -812,30 +475,10 @@ func (d *HTMLDocument) findHeadInsertionPoint(handler *Handler) (protocol.Positi
 	root := tree.RootNode()
 	for captureMap := range matcher.ParentCaptures(root, []byte(content), "head.element") {
 		if endTags, exists := captureMap["end.tag"]; exists && len(endTags) > 0 {
-			pos := d.byteOffsetToPosition(endTags[0].StartByte)
+			pos := d.ByteOffsetToPosition(endTags[0].StartByte)
 			return pos, true
 		}
 	}
 
-	return protocol.Position{}, false
-}
-
-// FindHeadInsertionPoint finds insertion point in <head> section (interface method).
-func (d *HTMLDocument) FindHeadInsertionPoint(dm any) (protocol.Position, bool) {
-	dmValue := reflect.ValueOf(dm)
-	if dmValue.Kind() == reflect.Pointer && !dmValue.IsNil() {
-		method := dmValue.MethodByName("GetLanguageHandler")
-		if method.IsValid() {
-			results := method.Call([]reflect.Value{reflect.ValueOf(d.language)})
-			if len(results) > 0 && !results[0].IsNil() {
-				handler := results[0].Interface()
-				if h, ok := handler.(interface {
-					FindHeadInsertionPoint(types.Document) (protocol.Position, bool)
-				}); ok {
-					return h.FindHeadInsertionPoint(d)
-				}
-			}
-		}
-	}
 	return protocol.Position{}, false
 }

--- a/lsp/document/html/handler.go
+++ b/lsp/document/html/handler.go
@@ -61,12 +61,7 @@ func (h *Handler) Language() string {
 
 // CreateDocument creates a new HTML document
 func (h *Handler) CreateDocument(uri, content string, version int32) types.Document {
-	doc := &HTMLDocument{
-		uri:      uri,
-		content:  content,
-		version:  version,
-		language: h.language,
-	}
+	doc := NewHTMLDocument(uri, content, version, h.language)
 
 	if err := doc.Parse(content); err != nil {
 		helpers.SafeDebugLog("[HTML] Failed to parse document %s: %v", uri, err)
@@ -81,12 +76,7 @@ func (h *Handler) CreateDocument(uri, content string, version int32) types.Docum
 // those regions are parsed as HTML while byte positions map to the original
 // source. Used by template and PHP handlers instead of whitespace-fill.
 func (h *Handler) CreateDocumentWithRanges(uri, content string, version int32, ranges []ts.Range) types.Document {
-	doc := &HTMLDocument{
-		uri:      uri,
-		content:  content,
-		version:  version,
-		language: h.language,
-	}
+	doc := NewHTMLDocument(uri, content, version, h.language)
 
 	if err := doc.ParseWithRanges(content, ranges); err != nil {
 		helpers.SafeDebugLog("[HTML] Failed to parse document with ranges %s: %v", uri, err)
@@ -100,12 +90,7 @@ func (h *Handler) CreateDocumentWithRanges(uri, content string, version int32, r
 // Used by Blade handler where the grammar produces HTML-compatible nodes
 // directly, so the same queries work without re-parsing.
 func (h *Handler) CreateDocumentWithTree(uri, content string, version int32, tree *ts.Tree) types.Document {
-	doc := &HTMLDocument{
-		uri:      uri,
-		content:  content,
-		version:  version,
-		language: h.language,
-	}
+	doc := NewHTMLDocument(uri, content, version, h.language)
 
 	doc.UpdateContent(content, version)
 	doc.SetTree(tree)

--- a/lsp/document/tsx/document.go
+++ b/lsp/document/tsx/document.go
@@ -18,186 +18,41 @@ package tsx
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
-	"sync"
 
 	tsxlang "bennypowers.dev/cem/internal/languages/tsx"
-	"bennypowers.dev/cem/lsp/types"
 	Q "bennypowers.dev/cem/internal/treesitter"
+	"bennypowers.dev/cem/lsp/document/base"
+	"bennypowers.dev/cem/lsp/types"
 	protocol "github.com/tliron/glsp/protocol_3_16"
-	ts "github.com/tree-sitter/go-tree-sitter"
 )
 
-// Completion scoring constants for prioritizing tree-sitter captures
 const (
-	// Base scores for different completion types (lower scores are more specific)
-	SCORE_TAG_NAME_BASE   = 10 // Most specific: tag name completion
-	SCORE_ATTR_NAME_BASE  = 20 // Medium specificity: attribute name completion
-	SCORE_ATTR_VALUE_BASE = 30 // Least specific: attribute value completion
+	SCORE_TAG_NAME_BASE   = 10
+	SCORE_ATTR_NAME_BASE  = 20
+	SCORE_ATTR_VALUE_BASE = 30
 
-	// Bonus/penalty scoring factors
-	SCORE_CURSOR_BONUS          = 50 // Large bonus for captures containing cursor
-	SCORE_BROAD_CAPTURE_PENALTY = 5  // Penalty multiplier for broad captures (ERROR nodes)
+	SCORE_CURSOR_BONUS          = 50
+	SCORE_BROAD_CAPTURE_PENALTY = 5
 
-	// Thresholds for completion analysis
-	MAX_REASONABLE_TAG_LENGTH = 10 // Threshold for reasonable tag name length
+	MAX_REASONABLE_TAG_LENGTH = 10
 )
 
 // TSXDocument represents a TSX document with tree-sitter parsing
 type TSXDocument struct {
-	uri        string
-	content    string
-	version    int32
-	language   string
-	tree       *ts.Tree
-	parser     *ts.Parser
-	scriptTags []types.ScriptTag
-	mu         sync.RWMutex
+	*base.BaseDocument
 }
 
-// Base document interface methods
-
-// URI returns the document URI
-func (d *TSXDocument) URI() string {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.uri
-}
-
-// Content returns the document content
-func (d *TSXDocument) Content() (string, error) {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.content, nil
-}
-
-// Version returns the document version
-func (d *TSXDocument) Version() int32 {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.version
-}
-
-// Language returns the document language
-func (d *TSXDocument) Language() string {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.language
-}
-
-// Tree returns the document's syntax tree
-func (d *TSXDocument) Tree() *ts.Tree {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.tree
-}
-
-// ScriptTags returns the parsed script tags
-func (d *TSXDocument) ScriptTags() []types.ScriptTag {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.scriptTags
-}
-
-// ImportMap returns nil for TSX documents (no importmaps in TSX files)
-func (d *TSXDocument) ImportMap() map[string]string {
-	return nil
-}
-
-// UpdateContent updates the document content
-func (d *TSXDocument) UpdateContent(content string, version int32) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	d.content = content
-	d.version = version
-}
-
-// SetTree sets the document's syntax tree
-func (d *TSXDocument) SetTree(tree *ts.Tree) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	if d.tree != nil {
-		d.tree.Close()
-	}
-	d.tree = tree
-}
-
-// Parser returns the document's parser
-func (d *TSXDocument) Parser() *ts.Parser {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.parser
-}
-
-// SetParser sets the document's parser, returning any previous parser to the pool.
-func (d *TSXDocument) SetParser(parser *ts.Parser) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	if d.parser != nil && d.parser != parser {
-		tsxlang.ReturnParser(d.parser)
-	}
-	d.parser = parser
-}
-
-// SetScriptTags sets the script tags
-func (d *TSXDocument) SetScriptTags(scriptTags []types.ScriptTag) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	d.scriptTags = scriptTags
-}
-
-// Close cleans up document resources
-func (d *TSXDocument) Close() {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	if d.tree != nil {
-		d.tree.Close()
-		d.tree = nil
-	}
-
-	if d.parser != nil {
-		tsxlang.ReturnParser(d.parser)
-		d.parser = nil
-	}
-}
-
-// ByteRangeToProtocolRange converts byte range to protocol range
-func (d *TSXDocument) ByteRangeToProtocolRange(content string, startByte, endByte uint) protocol.Range {
-	return protocol.Range{
-		Start: d.byteOffsetToPosition(startByte),
-		End:   d.byteOffsetToPosition(endByte),
-	}
-}
-
-// Helper method for byte offset to position conversion
-func (d *TSXDocument) byteOffsetToPosition(offset uint) protocol.Position {
-	line := uint32(0)
-	char := uint32(0)
-
-	for i, r := range d.content {
-		if uint(i) >= offset {
-			break
-		}
-
-		if r == '\n' {
-			line++
-			char = 0
-		} else {
-			char++
-		}
-	}
-
-	return protocol.Position{
-		Line:      line,
-		Character: char,
-	}
+// NewTSXDocument creates a new TSX document
+func NewTSXDocument(uri, content string, version int32) *TSXDocument {
+	doc := &TSXDocument{}
+	doc.BaseDocument = base.NewBaseDocument(uri, content, version, "tsx", tsxlang.ReturnParser, doc)
+	return doc
 }
 
 // Parse parses the TSX content using tree-sitter
 func (d *TSXDocument) Parse(content string) error {
-	d.UpdateContent(content, d.version)
+	d.UpdateContent(content, d.Version())
 
 	parser := tsxlang.BorrowParser()
 	if parser == nil {
@@ -209,6 +64,35 @@ func (d *TSXDocument) Parse(content string) error {
 	d.SetTree(tree)
 
 	return nil
+}
+
+// FindModuleScript returns EOF position for TSX files.
+func (d *TSXDocument) FindModuleScript() (protocol.Position, bool) {
+	content, err := d.Content()
+	if err != nil {
+		return protocol.Position{}, false
+	}
+
+	lines := strings.Split(content, "\n")
+	return protocol.Position{Line: uint32(len(lines)), Character: 0}, true
+}
+
+// CompletionPrefix extracts the prefix being typed for filtering completions
+func (d *TSXDocument) CompletionPrefix(analysis *types.CompletionAnalysis) string {
+	if analysis == nil {
+		return ""
+	}
+
+	switch analysis.Type {
+	case types.CompletionTagName:
+		return analysis.TagName
+	case types.CompletionAttributeName:
+		return analysis.AttributeName
+	case types.CompletionAttributeValue:
+		return analysis.AttributeName
+	default:
+		return ""
+	}
 }
 
 // findCustomElements finds custom elements in TSX documents
@@ -224,17 +108,14 @@ func (d *TSXDocument) findCustomElements(handler *Handler) ([]types.CustomElemen
 	}
 
 	var elements []types.CustomElementMatch
-	// Use a map to deduplicate elements based on position
 	elementMap := make(map[string]types.CustomElementMatch)
 
-	// Create a fresh query matcher for thread safety
 	customElementsMatcher, err := Q.GetCachedQueryMatcher(handler.queryManager, "tsx", "customElements")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create custom elements matcher: %w", err)
 	}
 	defer customElementsMatcher.Close()
 
-	// Handle multiple parent capture types: element, self.closing.tag, start.tag, incomplete.element
 	parentCaptureNames := []string{"element", "self.closing.tag", "start.tag", "incomplete.element"}
 
 	for _, parentName := range parentCaptureNames {
@@ -242,10 +123,8 @@ func (d *TSXDocument) findCustomElements(handler *Handler) ([]types.CustomElemen
 			if tagNames, exists := captureMap["tag.name"]; exists {
 				for _, tagCapture := range tagNames {
 					if strings.Contains(tagCapture.Text, "-") {
-						// Create a unique key based on tag name and position
 						elementKey := fmt.Sprintf("%s:%d:%d", tagCapture.Text, tagCapture.StartByte, tagCapture.EndByte)
 
-						// Skip if we've already processed this element
 						if _, exists := elementMap[elementKey]; exists {
 							continue
 						}
@@ -256,7 +135,6 @@ func (d *TSXDocument) findCustomElements(handler *Handler) ([]types.CustomElemen
 							Attributes: make(map[string]types.AttributeMatch),
 						}
 
-						// Look for attributes in the same capture map
 						if attrNames, hasAttrs := captureMap["attr.name"]; hasAttrs {
 							for _, attrCapture := range attrNames {
 								attr := types.AttributeMatch{
@@ -264,12 +142,10 @@ func (d *TSXDocument) findCustomElements(handler *Handler) ([]types.CustomElemen
 									Range: d.ByteRangeToProtocolRange(content, attrCapture.StartByte, attrCapture.EndByte),
 								}
 
-								// Look for attribute value
 								if attrValues, hasValues := captureMap["attr.value"]; hasValues {
 									for _, valueCapture := range attrValues {
-										// Simple heuristic: if value is near the attribute name, associate it
 										if valueCapture.StartByte > attrCapture.EndByte &&
-											valueCapture.StartByte < attrCapture.EndByte+100 { // Within 100 chars
+											valueCapture.StartByte < attrCapture.EndByte+100 {
 											attr.Value = valueCapture.Text
 											break
 										}
@@ -287,7 +163,6 @@ func (d *TSXDocument) findCustomElements(handler *Handler) ([]types.CustomElemen
 		}
 	}
 
-	// Convert map back to slice
 	for _, element := range elementMap {
 		elements = append(elements, element)
 	}
@@ -311,18 +186,14 @@ func (d *TSXDocument) analyzeCompletionContext(position protocol.Position, handl
 		return analysis
 	}
 
-	// Convert position to byte offset
-	byteOffset := d.positionToByteOffset(position, content)
+	byteOffset := d.PositionToByteOffset(position, content)
 
-	// Create a fresh completion context query matcher for thread safety
 	completionMatcher, err := Q.GetCachedQueryMatcher(handler.queryManager, "tsx", "completionContext")
 	if err != nil {
 		return analysis
 	}
 	defer completionMatcher.Close()
 
-	// Use tree-sitter to analyze context
-	// Collect all matching captures first, then prioritize
 	var possibleMatches []struct {
 		captureType string
 		capture     Q.CaptureInfo
@@ -330,14 +201,11 @@ func (d *TSXDocument) analyzeCompletionContext(position protocol.Position, handl
 	}
 
 	for captureMap := range completionMatcher.ParentCaptures(tree.RootNode(), []byte(content), "context") {
-		// Find which contexts the cursor is in by checking byte offsets
 		for captureName, captures := range captureMap {
-			// Skip generic "context" captures, only score specific completion types
 			if captureName == "context" {
 				continue
 			}
 			for _, capture := range captures {
-				// Include captures that contain the cursor
 				if capture.StartByte <= byteOffset && byteOffset <= capture.EndByte {
 					possibleMatches = append(possibleMatches, struct {
 						captureType string
@@ -345,7 +213,6 @@ func (d *TSXDocument) analyzeCompletionContext(position protocol.Position, handl
 						captureMap  Q.CaptureMap
 					}{captureName, capture, captureMap})
 				} else if captureName == "attr.name.completion" && capture.EndByte <= byteOffset && byteOffset-capture.EndByte <= 10 {
-					// Include attribute name captures that end just before the cursor (for attribute value completion)
 					possibleMatches = append(possibleMatches, struct {
 						captureType string
 						capture     Q.CaptureInfo
@@ -357,18 +224,13 @@ func (d *TSXDocument) analyzeCompletionContext(position protocol.Position, handl
 	}
 
 	if len(possibleMatches) == 0 {
-		// Check for the special case where cursor is right after a custom element tag
-		// Look for captures that end just before the cursor position
 		for captureMap := range completionMatcher.ParentCaptures(tree.RootNode(), []byte(content), "context") {
 			for captureName, captures := range captureMap {
 				for _, capture := range captures {
-					// If cursor is 1-2 positions after a tag name completion capture
 					if captureName == "tag.name.completion" &&
 						capture.EndByte < byteOffset &&
 						byteOffset-capture.EndByte <= 2 {
-						// Check if the capture text contains a custom element
 						if strings.Contains(capture.Text, "-") {
-							// This is likely attribute name completion context
 							analysis.Type = types.CompletionAttributeName
 							analysis.TagName = extractCustomElementFromText(capture.Text)
 							return analysis
@@ -380,9 +242,6 @@ func (d *TSXDocument) analyzeCompletionContext(position protocol.Position, handl
 		return analysis
 	}
 
-	// Prioritize the most specific match that has enough context
-	// Priority order: attr.value.completion > attr.name.completion > tag.name.completion
-	// But also prefer matches that include tag/attribute context
 	var bestMatch *struct {
 		captureType string
 		capture     Q.CaptureInfo
@@ -395,11 +254,10 @@ func (d *TSXDocument) analyzeCompletionContext(position protocol.Position, handl
 			continue
 		}
 
-		// Calculate a score for this match based on specificity and context
 		currentScore := scoreMatch(match.captureType, match.captureMap, match.capture, byteOffset)
 		bestScore := scoreMatch(bestMatch.captureType, bestMatch.captureMap, bestMatch.capture, byteOffset)
 
-		if currentScore < bestScore { // Lower scores are better (more specific)
+		if currentScore < bestScore {
 			bestMatch = &possibleMatches[i]
 		}
 	}
@@ -412,17 +270,14 @@ func (d *TSXDocument) analyzeCompletionContext(position protocol.Position, handl
 		case "attr.name.completion":
 			analysis.Type = types.CompletionAttributeName
 			analysis.AttributeName = bestMatch.capture.Text
-			// Try to find the tag name for this attribute
 			analysis.TagName = d.findTagNameForAttribute(byteOffset, bestMatch.captureMap)
 		case "attr.value.completion":
 			analysis.Type = types.CompletionAttributeValue
-			// Look across all captures to find the best tag and attribute names
 			tagName := d.findBestTagName(byteOffset, possibleMatches)
 			attrName := d.findBestAttributeName(byteOffset, possibleMatches)
 			analysis.TagName = tagName
 			analysis.AttributeName = attrName
 		case "interpolation":
-			// Inside TypeScript interpolation - no JSX completions
 			analysis.Type = types.CompletionUnknown
 			return analysis
 		}
@@ -431,21 +286,17 @@ func (d *TSXDocument) analyzeCompletionContext(position protocol.Position, handl
 	return analysis
 }
 
-// findTagNameForAttribute finds the tag name associated with an attribute at the given position
 func (d *TSXDocument) findTagNameForAttribute(byteOffset uint, captureMap Q.CaptureMap) string {
-	// Look for tag name captures that are before the current position
 	if tagNames, exists := captureMap["tag.name.completion"]; exists {
 		var closestTag *Q.CaptureInfo
-		var closestDistance = ^uint(0) // Max uint value
+		var closestDistance = ^uint(0)
 
 		for _, tagCapture := range tagNames {
-			// For attribute completions, we want tag captures that contain the cursor OR end just before it
 			if (tagCapture.StartByte <= byteOffset && byteOffset <= tagCapture.EndByte) ||
 				(tagCapture.EndByte <= byteOffset) {
 
 				var distance uint
 				if byteOffset <= tagCapture.EndByte {
-					// Cursor is inside the tag capture - prioritize this
 					distance = 0
 				} else {
 					distance = byteOffset - tagCapture.EndByte
@@ -459,10 +310,8 @@ func (d *TSXDocument) findTagNameForAttribute(byteOffset uint, captureMap Q.Capt
 		}
 
 		if closestTag != nil {
-			// Extract the actual tag name from the capture text
 			tagName := extractCustomElementFromText(closestTag.Text)
 			if tagName == "" {
-				// Fallback: if extraction fails, try to use the text directly if it looks like a tag name
 				if strings.Contains(closestTag.Text, "-") && !strings.Contains(closestTag.Text, " ") {
 					tagName = closestTag.Text
 				}
@@ -474,27 +323,24 @@ func (d *TSXDocument) findTagNameForAttribute(byteOffset uint, captureMap Q.Capt
 	return ""
 }
 
-// findBestTagName finds the best tag name from all possible matches
 func (d *TSXDocument) findBestTagName(byteOffset uint, possibleMatches []struct {
 	captureType string
 	capture     Q.CaptureInfo
 	captureMap  Q.CaptureMap
 }) string {
 	var bestTagName string
-	var bestDistance = ^uint(0) // Max uint value
+	var bestDistance = ^uint(0)
 
-	// Look through all captures for tag names
 	for _, match := range possibleMatches {
 		if tagNames, exists := match.captureMap["tag.name.completion"]; exists {
 			for _, tagCapture := range tagNames {
-				// Prefer captures that contain or are close to the cursor
 				var distance uint
 				if tagCapture.StartByte <= byteOffset && byteOffset <= tagCapture.EndByte {
-					distance = 0 // Inside the capture - perfect
+					distance = 0
 				} else if tagCapture.EndByte <= byteOffset {
 					distance = byteOffset - tagCapture.EndByte
 				} else {
-					continue // Skip captures that start after the cursor
+					continue
 				}
 
 				if distance < bestDistance {
@@ -511,21 +357,17 @@ func (d *TSXDocument) findBestTagName(byteOffset uint, possibleMatches []struct 
 	return bestTagName
 }
 
-// findBestAttributeName finds the best attribute name from all possible matches
 func (d *TSXDocument) findBestAttributeName(byteOffset uint, possibleMatches []struct {
 	captureType string
 	capture     Q.CaptureInfo
 	captureMap  Q.CaptureMap
 }) string {
 	var bestAttrName string
-	var bestDistance = ^uint(0) // Max uint value
+	var bestDistance = ^uint(0)
 
-	// Look through all captures for attribute names across ALL capture maps
 	for _, match := range possibleMatches {
-		// Check for attr.name.completion captures
 		if attrNames, exists := match.captureMap["attr.name.completion"]; exists {
 			for _, attrCapture := range attrNames {
-				// Prefer captures that are close to but before the cursor
 				if attrCapture.EndByte <= byteOffset {
 					distance := byteOffset - attrCapture.EndByte
 					if distance < bestDistance {
@@ -539,7 +381,6 @@ func (d *TSXDocument) findBestAttributeName(byteOffset uint, possibleMatches []s
 			}
 		}
 
-		// Also check for any capture that might be an attribute name completion context
 		if match.captureType == "attr.name.completion" {
 			if match.capture.EndByte <= byteOffset {
 				distance := byteOffset - match.capture.EndByte
@@ -557,41 +398,14 @@ func (d *TSXDocument) findBestAttributeName(byteOffset uint, possibleMatches []s
 	return bestAttrName
 }
 
-// positionToByteOffset converts LSP position to byte offset
-func (d *TSXDocument) positionToByteOffset(pos protocol.Position, content string) uint {
-	var offset uint = 0
-	lines := strings.Split(content, "\n")
-
-	// Add bytes for complete lines before the target line
-	for i := uint32(0); i < pos.Line && i < uint32(len(lines)); i++ {
-		offset += uint(len(lines[i])) + 1 // +1 for newline
-	}
-
-	// Add bytes for characters in the target line
-	if pos.Line < uint32(len(lines)) {
-		line := lines[pos.Line]
-		if pos.Character < uint32(len(line)) {
-			offset += uint(pos.Character)
-		} else {
-			offset += uint(len(line))
-		}
-	}
-
-	return offset
-}
-
-// extractCustomElementFromText extracts the custom element name from capture text
 func extractCustomElementFromText(text string) string {
-	// Look for the last occurrence of a custom element pattern
 	parts := strings.Split(text, "<")
 	if len(parts) < 2 {
 		return ""
 	}
 
-	// Get the part after the last "<"
 	lastPart := parts[len(parts)-1]
 
-	// Extract the tag name (up to first space or >)
 	tagName := lastPart
 	if spaceIdx := strings.Index(tagName, " "); spaceIdx != -1 {
 		tagName = tagName[:spaceIdx]
@@ -600,7 +414,6 @@ func extractCustomElementFromText(text string) string {
 		tagName = tagName[:gtIdx]
 	}
 
-	// Only return if it contains a hyphen (custom element)
 	if strings.Contains(tagName, "-") {
 		return tagName
 	}
@@ -608,20 +421,15 @@ func extractCustomElementFromText(text string) string {
 	return ""
 }
 
-// extractAttributeNameFromText extracts the attribute name from capture text
 func extractAttributeNameFromText(text string) string {
-	// If it's already a simple attribute name, return it
 	if !strings.Contains(text, " ") && !strings.Contains(text, "<") && !strings.Contains(text, "=") {
 		return text
 	}
 
-	// Look for the last word that looks like an attribute name
 	words := strings.Fields(text)
 	for i := len(words) - 1; i >= 0; i-- {
 		word := words[i]
-		// Remove trailing = if present
 		word = strings.TrimSuffix(word, "=")
-		// Attribute names should be simple identifiers
 		if len(word) > 0 && !strings.Contains(word, "<") && !strings.Contains(word, ">") {
 			return word
 		}
@@ -630,162 +438,30 @@ func extractAttributeNameFromText(text string) string {
 	return ""
 }
 
-// scoreMatch scores a completion match based on type specificity and capture precision.
-//
-// Scoring Strategy:
-// - Lower scores are better (more specific matches win)
-// - Tag name completion gets the lowest base score (most specific)
-// - Attribute value completion gets the highest base score (least specific)
-// - Large bonus for captures that contain the cursor position
-// - Penalties for overly broad captures (ERROR nodes) and long captures
 func scoreMatch(captureType string, captureMap Q.CaptureMap, capture Q.CaptureInfo, byteOffset uint) int {
 	score := 0
 
-	// Base score for match type (lower scores win for more specific captures)
 	switch captureType {
 	case "tag.name.completion":
-		score += SCORE_TAG_NAME_BASE // Most specific completion type
+		score += SCORE_TAG_NAME_BASE
 	case "attr.name.completion":
-		score += SCORE_ATTR_NAME_BASE // Medium specificity
+		score += SCORE_ATTR_NAME_BASE
 	case "attr.value.completion":
-		score += SCORE_ATTR_VALUE_BASE // Least specific (most complex context)
+		score += SCORE_ATTR_VALUE_BASE
 	}
 
-	// Large bonus for captures that contain the cursor (lower score = better)
-	// This ensures that captures containing the cursor are strongly preferred
 	if capture.StartByte <= byteOffset && byteOffset <= capture.EndByte {
-		score -= SCORE_CURSOR_BONUS // Significant bonus for containing cursor
+		score -= SCORE_CURSOR_BONUS
 	}
 
-	// Penalty for overly broad capture maps (ERROR nodes often have many captures)
-	// More captures usually means less precision in tree-sitter parsing
 	if len(captureMap) > 2 {
-		score += len(captureMap) * SCORE_BROAD_CAPTURE_PENALTY // Penalize broad captures
+		score += len(captureMap) * SCORE_BROAD_CAPTURE_PENALTY
 	}
 
-	// Major penalty for overly long captures (likely ERROR node captures)
-	// Reasonable tag/attribute names are usually short
 	captureLength := capture.EndByte - capture.StartByte
 	if captureLength > MAX_REASONABLE_TAG_LENGTH {
-		score += int(captureLength) // Penalize based on length
+		score += int(captureLength)
 	}
 
 	return score
-}
-
-// AnalyzeCompletionContextTS analyzes completion context using tree-sitter queries (interface method)
-func (d *TSXDocument) AnalyzeCompletionContextTS(position protocol.Position, dm any) *types.CompletionAnalysis {
-	// Use reflection to call GetLanguageHandler to avoid circular imports
-	dmValue := reflect.ValueOf(dm)
-	if dmValue.Kind() == reflect.Pointer && !dmValue.IsNil() {
-		method := dmValue.MethodByName("GetLanguageHandler")
-		if method.IsValid() {
-			results := method.Call([]reflect.Value{reflect.ValueOf("tsx")})
-			if len(results) > 0 && !results[0].IsNil() {
-				handler := results[0].Interface()
-				if h, ok := handler.(interface {
-					AnalyzeCompletionContext(types.Document, protocol.Position) *types.CompletionAnalysis
-				}); ok {
-					result := h.AnalyzeCompletionContext(d, position)
-					return result
-				}
-			}
-		}
-	}
-	// Fallback: return safe default
-	return &types.CompletionAnalysis{
-		Type: types.CompletionUnknown,
-	}
-}
-
-// CompletionPrefix extracts the prefix being typed for filtering completions
-func (d *TSXDocument) CompletionPrefix(analysis *types.CompletionAnalysis) string {
-	if analysis == nil {
-		return ""
-	}
-
-	switch analysis.Type {
-	case types.CompletionTagName:
-		return analysis.TagName
-	case types.CompletionAttributeName:
-		return analysis.AttributeName
-	case types.CompletionAttributeValue:
-		return analysis.AttributeName // For attribute values, we filter on the attribute name
-	default:
-		return ""
-	}
-}
-
-// FindElementAtPosition finds a custom element at the given position (interface method)
-func (d *TSXDocument) FindElementAtPosition(position protocol.Position, dm any) *types.CustomElementMatch {
-	// Use reflection to call GetLanguageHandler to avoid circular imports
-	dmValue := reflect.ValueOf(dm)
-	if dmValue.Kind() == reflect.Pointer && !dmValue.IsNil() {
-		method := dmValue.MethodByName("GetLanguageHandler")
-		if method.IsValid() {
-			results := method.Call([]reflect.Value{reflect.ValueOf("tsx")})
-			if len(results) > 0 && !results[0].IsNil() {
-				handler := results[0].Interface()
-				if h, ok := handler.(interface {
-					FindElementAtPosition(types.Document, protocol.Position) *types.CustomElementMatch
-				}); ok {
-					return h.FindElementAtPosition(d, position)
-				}
-			}
-		}
-	}
-	// Fallback: return nil if handler not available
-	return nil
-}
-
-// FindAttributeAtPosition finds an attribute at the given position (interface method)
-func (d *TSXDocument) FindAttributeAtPosition(position protocol.Position, dm any) (*types.AttributeMatch, string) {
-	// This method needs to be implemented for the types.Document interface
-	// For now, return nil as this functionality is handled by the handler
-	return nil, ""
-}
-
-// FindCustomElements finds custom elements in the document (interface method)
-func (d *TSXDocument) FindCustomElements(dm any) ([]types.CustomElementMatch, error) {
-	// Use reflection to call GetLanguageHandler to avoid circular imports
-	dmValue := reflect.ValueOf(dm)
-	if dmValue.Kind() == reflect.Pointer && !dmValue.IsNil() {
-		method := dmValue.MethodByName("GetLanguageHandler")
-		if method.IsValid() {
-			results := method.Call([]reflect.Value{reflect.ValueOf("tsx")})
-			if len(results) > 0 && !results[0].IsNil() {
-				handler := results[0].Interface()
-				if h, ok := handler.(interface {
-					FindCustomElements(types.Document) ([]types.CustomElementMatch, error)
-				}); ok {
-					return h.FindCustomElements(d)
-				}
-			}
-		}
-	}
-	// Fallback: return empty slice if handler not available
-	return []types.CustomElementMatch{}, nil
-}
-
-// FindModuleScript finds insertion point in module script
-func (d *TSXDocument) FindModuleScript() (protocol.Position, bool) {
-	// For TSX files, find the end of the file content
-	content, err := d.Content()
-	if err != nil {
-		return protocol.Position{}, false
-	}
-
-	lines := strings.Split(content, "\n")
-	return protocol.Position{Line: uint32(len(lines)), Character: 0}, true
-}
-
-// FindInlineModuleScript finds insertion point in inline module script
-func (d *TSXDocument) FindInlineModuleScript() (protocol.Position, bool) {
-	return d.FindModuleScript()
-}
-
-// FindHeadInsertionPoint finds insertion point in <head> section
-func (d *TSXDocument) FindHeadInsertionPoint(dm any) (protocol.Position, bool) {
-	// TSX files don't have <head> sections
-	return protocol.Position{}, false
 }

--- a/lsp/document/tsx/document.go
+++ b/lsp/document/tsx/document.go
@@ -97,14 +97,9 @@ func (d *TSXDocument) CompletionPrefix(analysis *types.CompletionAnalysis) strin
 
 // findCustomElements finds custom elements in TSX documents
 func (d *TSXDocument) findCustomElements(handler *Handler) ([]types.CustomElementMatch, error) {
-	tree := d.Tree()
+	tree, content := d.TreeAndContent()
 	if tree == nil {
 		return nil, fmt.Errorf("no tree available for document")
-	}
-
-	content, err := d.Content()
-	if err != nil {
-		return nil, err
 	}
 
 	var elements []types.CustomElementMatch
@@ -176,13 +171,8 @@ func (d *TSXDocument) analyzeCompletionContext(position protocol.Position, handl
 		Type: types.CompletionUnknown,
 	}
 
-	tree := d.Tree()
+	tree, content := d.TreeAndContent()
 	if tree == nil {
-		return analysis
-	}
-
-	content, err := d.Content()
-	if err != nil {
 		return analysis
 	}
 

--- a/lsp/document/tsx/document.go
+++ b/lsp/document/tsx/document.go
@@ -38,7 +38,8 @@ const (
 	MAX_REASONABLE_TAG_LENGTH = 10
 )
 
-// TSXDocument represents a TSX document with tree-sitter parsing
+// TSXDocument represents a TSX document with tree-sitter parsing.
+// Always use NewTSXDocument to construct; a zero-value TSXDocument will panic.
 type TSXDocument struct {
 	*base.BaseDocument
 }

--- a/lsp/document/tsx/document.go
+++ b/lsp/document/tsx/document.go
@@ -73,9 +73,16 @@ func (d *TSXDocument) FindModuleScript() (protocol.Position, bool) {
 	if err != nil {
 		return protocol.Position{}, false
 	}
+	if content == "" {
+		return protocol.Position{}, true
+	}
 
 	lines := strings.Split(content, "\n")
-	return protocol.Position{Line: uint32(len(lines)), Character: 0}, true
+	lastLine := len(lines) - 1
+	return protocol.Position{
+		Line:      uint32(lastLine),
+		Character: uint32(len(lines[lastLine])),
+	}, true
 }
 
 // CompletionPrefix extracts the prefix being typed for filtering completions

--- a/lsp/document/tsx/handler.go
+++ b/lsp/document/tsx/handler.go
@@ -48,14 +48,8 @@ func (h *Handler) Language() string {
 
 // CreateDocument creates a new TSX document
 func (h *Handler) CreateDocument(uri, content string, version int32) types.Document {
-	doc := &TSXDocument{
-		uri:      uri,
-		content:  content,
-		version:  version,
-		language: "tsx",
-	}
+	doc := NewTSXDocument(uri, content, version)
 
-	// Parse the document
 	if err := doc.Parse(content); err != nil {
 		helpers.SafeDebugLog("[TSX] Failed to parse document %s: %v", uri, err)
 	}

--- a/lsp/document/typescript/document.go
+++ b/lsp/document/typescript/document.go
@@ -264,7 +264,7 @@ func (d *TypeScriptDocument) findCustomElements(handler *Handler) ([]types.Custo
 		return nil, fmt.Errorf("no tree available for document")
 	}
 
-	_, err := d.Content()
+	docContent, err := d.Content()
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +277,7 @@ func (d *TypeScriptDocument) findCustomElements(handler *Handler) ([]types.Custo
 	}
 
 	for _, template := range templates {
-		templateElements, err := d.parseHTMLInTemplate(template, handler)
+		templateElements, err := d.parseHTMLInTemplate(template, handler, docContent)
 		if err != nil {
 			helpers.SafeDebugLog("[TypeScript] Failed to parse template: %v", err)
 			continue
@@ -366,7 +366,7 @@ func (d *TypeScriptDocument) findHTMLTemplates(handler *Handler) ([]TemplateCont
 	return templates, nil
 }
 
-func (d *TypeScriptDocument) parseHTMLInTemplate(template TemplateContext, handler *Handler) ([]types.CustomElementMatch, error) {
+func (d *TypeScriptDocument) parseHTMLInTemplate(template TemplateContext, handler *Handler, docContent string) ([]types.CustomElementMatch, error) {
 	templateContent, err := template.Content()
 	if err != nil {
 		return nil, err
@@ -403,8 +403,8 @@ func (d *TypeScriptDocument) parseHTMLInTemplate(template TemplateContext, handl
 					seen[key] = true
 					element := types.CustomElementMatch{
 						TagName:    capture.Text,
-						Range:      d.adjustRangeToTemplate(capture, template),
-						Attributes: d.collectTemplateAttributes(captureMap, contentBytes, template),
+						Range:      d.adjustRangeToTemplate(capture, template, docContent),
+						Attributes: d.collectTemplateAttributes(captureMap, contentBytes, template, docContent),
 					}
 					elements = append(elements, element)
 				}
@@ -418,10 +418,11 @@ func (d *TypeScriptDocument) parseHTMLInTemplate(template TemplateContext, handl
 func (d *TypeScriptDocument) adjustRangeToTemplate(
 	capture Q.CaptureInfo,
 	template TemplateContext,
+	docContent string,
 ) protocol.Range {
 	return protocol.Range{
-		Start: d.ByteOffsetToPosition(template.startByte + capture.StartByte),
-		End:   d.ByteOffsetToPosition(template.startByte + capture.EndByte),
+		Start: d.ByteOffsetToPosition(template.startByte+capture.StartByte, docContent),
+		End:   d.ByteOffsetToPosition(template.startByte+capture.EndByte, docContent),
 	}
 }
 
@@ -429,6 +430,7 @@ func (d *TypeScriptDocument) collectTemplateAttributes(
 	captureMap Q.CaptureMap,
 	contentBytes []byte,
 	template TemplateContext,
+	docContent string,
 ) map[string]types.AttributeMatch {
 	attributes := make(map[string]types.AttributeMatch)
 	attrNames, ok := captureMap["attr.name"]
@@ -455,7 +457,7 @@ func (d *TypeScriptDocument) collectTemplateAttributes(
 	for _, attrName := range attrNames {
 		attrMatch := types.AttributeMatch{
 			Name:  attrName.Text,
-			Range: d.adjustRangeToTemplate(attrName, template),
+			Range: d.adjustRangeToTemplate(attrName, template, docContent),
 		}
 
 		var closestValue string
@@ -604,6 +606,7 @@ func (d *TypeScriptDocument) analyzeTemplateContentAsHTML(
 	if err != nil {
 		return analysis
 	}
+	defer htmlCompletionContext.Close()
 
 	var allTagNames []Q.CaptureInfo
 	for captureMap := range htmlCompletionContext.ParentCaptures(htmlTree.RootNode(), []byte(templateContent), "context") {

--- a/lsp/document/typescript/document.go
+++ b/lsp/document/typescript/document.go
@@ -19,20 +19,19 @@ package typescript
 import (
 	"crypto/sha256"
 	"fmt"
-	"reflect"
 	"strings"
 	"sync"
 
 	htmllang "bennypowers.dev/cem/internal/languages/html"
 	"bennypowers.dev/cem/internal/languages/typescript"
+	Q "bennypowers.dev/cem/internal/treesitter"
+	"bennypowers.dev/cem/lsp/document/base"
 	"bennypowers.dev/cem/lsp/helpers"
 	"bennypowers.dev/cem/lsp/types"
-	Q "bennypowers.dev/cem/internal/treesitter"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 	ts "github.com/tree-sitter/go-tree-sitter"
 )
 
-// cachedTree wraps a tree-sitter tree with reference counting for safe concurrent access
 type cachedTree struct {
 	tree *ts.Tree
 	refs int
@@ -40,168 +39,75 @@ type cachedTree struct {
 
 // TypeScriptDocument represents a TypeScript document with tree-sitter parsing
 type TypeScriptDocument struct {
-	uri        string
-	content    string
-	version    int32
-	language   string
-	tree       *ts.Tree
-	parser     *ts.Parser
-	scriptTags []types.ScriptTag
-	mu         sync.RWMutex
+	*base.BaseDocument
 
-	// Performance cache: parsed templates and custom elements
 	cachedTemplates      []TemplateContext
 	cachedCustomElements []types.CustomElementMatch
-	cachedHTMLTrees      map[[32]byte]*cachedTree // HTML parse trees indexed by SHA-256 hash of template content
-	cacheVersion         int32                    // Version when cache was populated
+	cachedHTMLTrees      map[[32]byte]*cachedTree
+	cacheVersion         int32
+	cacheMu              sync.RWMutex
 }
 
-// Base document interface methods
-
-// URI returns the document URI
-func (d *TypeScriptDocument) URI() string {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.uri
+// NewTypeScriptDocument creates a new TypeScript document
+func NewTypeScriptDocument(uri, content string, version int32) *TypeScriptDocument {
+	doc := &TypeScriptDocument{}
+	doc.BaseDocument = base.NewBaseDocument(uri, content, version, "typescript", typescript.ReturnParser, doc)
+	return doc
 }
 
-// Content returns the document content
-func (d *TypeScriptDocument) Content() (string, error) {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.content, nil
-}
-
-// Version returns the document version
-func (d *TypeScriptDocument) Version() int32 {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.version
-}
-
-// Language returns the document language
-func (d *TypeScriptDocument) Language() string {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.language
-}
-
-// Tree returns the document's syntax tree
-func (d *TypeScriptDocument) Tree() *ts.Tree {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.tree
-}
-
-// ScriptTags returns the parsed script tags
-func (d *TypeScriptDocument) ScriptTags() []types.ScriptTag {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.scriptTags
-}
-
-// ImportMap returns nil for TypeScript documents (no importmaps in TS files)
-func (d *TypeScriptDocument) ImportMap() map[string]string {
-	return nil
-}
-
-// UpdateContent updates the document content
+// UpdateContent updates the document content and invalidates caches.
 func (d *TypeScriptDocument) UpdateContent(content string, version int32) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	oldVersion := d.version
-	d.content = content
-	d.version = version
-	// Invalidate cache when content changes
-	d.cachedTemplates = nil
-	d.cachedCustomElements = nil
-	d.invalidateHTMLTreeCache()
-	d.cacheVersion = 0
+	oldVersion := d.Version()
+	d.BaseDocument.UpdateContent(content, version)
+	d.invalidateCache()
 	helpers.SafeDebugLog("[CACHE] UpdateContent: cache INVALIDATED (old version %d -> new version %d)", oldVersion, version)
 }
 
-// SetTree sets the document's syntax tree
-// Note: Defensively invalidates cache to ensure correctness even if called without UpdateContent
+// SetTree sets the document's syntax tree and invalidates caches.
 func (d *TypeScriptDocument) SetTree(tree *ts.Tree) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	if d.tree != nil {
-		d.tree.Close()
-	}
-	d.tree = tree
-	// Invalidate cache when tree is replaced
+	d.BaseDocument.SetTree(tree)
+	d.invalidateCache()
+	helpers.SafeDebugLog("[CACHE] SetTree: cache INVALIDATED (version %d)", d.Version())
+}
+
+// Close cleans up document resources including cached HTML trees.
+func (d *TypeScriptDocument) Close() {
+	d.invalidateHTMLTreeCache()
+	d.BaseDocument.Close()
+}
+
+func (d *TypeScriptDocument) invalidateCache() {
+	d.cacheMu.Lock()
+	defer d.cacheMu.Unlock()
 	d.cachedTemplates = nil
 	d.cachedCustomElements = nil
-	d.invalidateHTMLTreeCache()
+	d.invalidateHTMLTreeCacheLocked()
 	d.cacheVersion = 0
-	helpers.SafeDebugLog("[CACHE] SetTree: cache INVALIDATED (version %d)", d.version)
 }
 
-// Parser returns the document's parser
-func (d *TypeScriptDocument) Parser() *ts.Parser {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.parser
-}
-
-// SetParser sets the document's parser, returning any previous parser to the pool.
-func (d *TypeScriptDocument) SetParser(parser *ts.Parser) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	if d.parser != nil && d.parser != parser {
-		typescript.ReturnParser(d.parser)
-	}
-	d.parser = parser
-}
-
-// SetScriptTags sets the script tags
-func (d *TypeScriptDocument) SetScriptTags(scriptTags []types.ScriptTag) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	d.scriptTags = scriptTags
-}
-
-// Close cleans up document resources
-func (d *TypeScriptDocument) Close() {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	if d.tree != nil {
-		d.tree.Close()
-		d.tree = nil
-	}
-
-	if d.parser != nil {
-		typescript.ReturnParser(d.parser)
-		d.parser = nil
-	}
-
-	// Clean up cached HTML trees
-	d.invalidateHTMLTreeCache()
-}
-
-// invalidateHTMLTreeCache closes and clears all cached HTML parse trees
-// Must be called with d.mu lock held
 func (d *TypeScriptDocument) invalidateHTMLTreeCache() {
+	d.cacheMu.Lock()
+	defer d.cacheMu.Unlock()
+	d.invalidateHTMLTreeCacheLocked()
+}
+
+func (d *TypeScriptDocument) invalidateHTMLTreeCacheLocked() {
 	if d.cachedHTMLTrees != nil {
 		treesRemaining := 0
 		for hash, cached := range d.cachedHTMLTrees {
 			if cached != nil {
-				// Only close and delete trees with no active references
 				if cached.refs == 0 {
 					if cached.tree != nil {
 						cached.tree.Close()
 					}
 					delete(d.cachedHTMLTrees, hash)
 				} else {
-					// Keep trees with active references in the map so ReleaseCachedHTMLTree can find them
 					treesRemaining++
 					helpers.SafeDebugLog("[CACHE] Keeping tree with %d active references (hash=%x)", cached.refs, hash[:8])
 				}
 			}
 		}
 
-		// Only nil the map if all trees were closed
 		if treesRemaining == 0 {
 			d.cachedHTMLTrees = nil
 			helpers.SafeDebugLog("[CACHE] HTML tree cache cleared completely")
@@ -212,22 +118,19 @@ func (d *TypeScriptDocument) invalidateHTMLTreeCache() {
 }
 
 // ReleaseCachedHTMLTree decrements the reference count for a cached HTML tree
-// and closes it if the count reaches zero
 func (d *TypeScriptDocument) ReleaseCachedHTMLTree(tree *ts.Tree) {
 	if tree == nil {
 		return
 	}
 
-	d.mu.Lock()
-	defer d.mu.Unlock()
+	d.cacheMu.Lock()
+	defer d.cacheMu.Unlock()
 
-	// Find the cached entry for this tree by comparing tree pointers
 	for hash, cached := range d.cachedHTMLTrees {
 		if cached != nil && cached.tree == tree {
 			cached.refs--
 			helpers.SafeDebugLog("[CACHE] HTML tree ref count decremented (hash=%x, refs=%d)", hash[:8], cached.refs)
 
-			// When refs reach 0, close the tree and remove from cache
 			if cached.refs == 0 {
 				tree.Close()
 				delete(d.cachedHTMLTrees, hash)
@@ -237,42 +140,32 @@ func (d *TypeScriptDocument) ReleaseCachedHTMLTree(tree *ts.Tree) {
 		}
 	}
 
-	// Tree not found in cache - this can happen if the tree was already closed
-	// or if it was created outside the cache. This is not an error.
 	helpers.SafeDebugLog("[CACHE] ReleaseCachedHTMLTree called but tree not found in cache")
 }
 
-// getCachedHTMLTree gets or creates a cached HTML parse tree for template content
-// Callers MUST call ReleaseCachedHTMLTree when done using the tree
 func (d *TypeScriptDocument) getCachedHTMLTree(templateContent string) *ts.Tree {
-	// Compute SHA-256 hash of template content for cache key
 	contentHash := sha256.Sum256([]byte(templateContent))
 
-	// Fast path: check cache under read lock for better concurrency
-	d.mu.RLock()
+	d.cacheMu.RLock()
 	if d.cachedHTMLTrees != nil {
 		if cached, exists := d.cachedHTMLTrees[contentHash]; exists && cached != nil && cached.tree != nil {
-			d.mu.RUnlock()
+			d.cacheMu.RUnlock()
 
-			// Upgrade to write lock to safely increment refs
-			// Note: We must re-check after acquiring write lock in case cache was invalidated
-			d.mu.Lock()
+			d.cacheMu.Lock()
 			if cached, exists := d.cachedHTMLTrees[contentHash]; exists && cached != nil && cached.tree != nil {
 				cached.refs++
 				tree := cached.tree
-				d.mu.Unlock()
+				d.cacheMu.Unlock()
 				helpers.SafeDebugLog("[CACHE] HTML tree cache HIT (hash=%x, refs=%d)", contentHash[:8], cached.refs)
 				return tree
 			}
-			d.mu.Unlock()
-			// Fall through to parse - cache was invalidated between locks
+			d.cacheMu.Unlock()
 		}
 	}
-	d.mu.RUnlock()
+	d.cacheMu.RUnlock()
 
 	helpers.SafeDebugLog("[CACHE] HTML tree cache MISS (hash=%x, content length=%d)", contentHash[:8], len(templateContent))
 
-	// Parse outside lock to allow concurrent document operations
 	htmlParser := htmllang.BorrowParser()
 	if htmlParser == nil {
 		return nil
@@ -284,25 +177,20 @@ func (d *TypeScriptDocument) getCachedHTMLTree(templateContent string) *ts.Tree 
 		return nil
 	}
 
-	// Re-check and populate under write lock
-	d.mu.Lock()
-	defer d.mu.Unlock()
+	d.cacheMu.Lock()
+	defer d.cacheMu.Unlock()
 
-	// Initialize cache map if needed
 	if d.cachedHTMLTrees == nil {
 		d.cachedHTMLTrees = make(map[[32]byte]*cachedTree)
 	}
 
-	// Another goroutine may have populated the cache while we were parsing
 	if cached, exists := d.cachedHTMLTrees[contentHash]; exists && cached != nil && cached.tree != nil {
-		// Discard our parsed tree since another goroutine already cached one
 		htmlTree.Close()
 		cached.refs++
 		helpers.SafeDebugLog("[CACHE] HTML tree cache HIT after concurrent parse (hash=%x, refs=%d)", contentHash[:8], cached.refs)
 		return cached.tree
 	}
 
-	// Cache the tree for future use with initial ref count of 1
 	d.cachedHTMLTrees[contentHash] = &cachedTree{
 		tree: htmlTree,
 		refs: 1,
@@ -313,42 +201,10 @@ func (d *TypeScriptDocument) getCachedHTMLTree(templateContent string) *ts.Tree 
 	return htmlTree
 }
 
-// ByteRangeToProtocolRange converts byte range to protocol range
-func (d *TypeScriptDocument) ByteRangeToProtocolRange(content string, startByte, endByte uint) protocol.Range {
-	return protocol.Range{
-		Start: d.byteOffsetToPosition(startByte),
-		End:   d.byteOffsetToPosition(endByte),
-	}
-}
-
-// Helper method for byte offset to position conversion
-func (d *TypeScriptDocument) byteOffsetToPosition(offset uint) protocol.Position {
-	line := uint32(0)
-	char := uint32(0)
-
-	for i, r := range d.content {
-		if uint(i) >= offset {
-			break
-		}
-
-		if r == '\n' {
-			line++
-			char = 0
-		} else {
-			char++
-		}
-	}
-
-	return protocol.Position{
-		Line:      line,
-		Character: char,
-	}
-}
-
 // Parse parses the TypeScript content using tree-sitter
 func (d *TypeScriptDocument) Parse(content string) error {
-	helpers.SafeDebugLog("[CACHE] Parse() called for document version %d - THIS INVALIDATES CACHE", d.version)
-	d.UpdateContent(content, d.version)
+	helpers.SafeDebugLog("[CACHE] Parse() called for document version %d - THIS INVALIDATES CACHE", d.Version())
+	d.UpdateContent(content, d.Version())
 
 	parser := typescript.BorrowParser()
 	if parser == nil {
@@ -362,20 +218,46 @@ func (d *TypeScriptDocument) Parse(content string) error {
 	return nil
 }
 
-// findCustomElements finds custom elements in TypeScript template literals
+// FindModuleScript returns EOF position for TypeScript files.
+func (d *TypeScriptDocument) FindModuleScript() (protocol.Position, bool) {
+	content, err := d.Content()
+	if err != nil {
+		return protocol.Position{}, false
+	}
+	lines := strings.Split(content, "\n")
+	return protocol.Position{Line: uint32(len(lines)), Character: 0}, true
+}
+
+// CompletionPrefix extracts the prefix being typed for filtering completions
+func (d *TypeScriptDocument) CompletionPrefix(analysis *types.CompletionAnalysis) string {
+	if analysis == nil {
+		return ""
+	}
+
+	switch analysis.Type {
+	case types.CompletionTagName:
+		return analysis.TagName
+	case types.CompletionAttributeName:
+		return analysis.AttributeName
+	case types.CompletionAttributeValue:
+		return analysis.AttributeName
+	default:
+		return ""
+	}
+}
+
 func (d *TypeScriptDocument) findCustomElements(handler *Handler) ([]types.CustomElementMatch, error) {
-	// Check cache first
-	d.mu.RLock()
-	currentVersion := d.version
+	d.cacheMu.RLock()
+	currentVersion := d.Version()
 	if d.cachedCustomElements != nil && d.cacheVersion == currentVersion {
 		cachedElements := d.cachedCustomElements
-		d.mu.RUnlock()
+		d.cacheMu.RUnlock()
 		helpers.SafeDebugLog("[CACHE] findCustomElements: cache HIT (version %d, %d elements)", currentVersion, len(cachedElements))
 		return cachedElements, nil
 	}
 	helpers.SafeDebugLog("[CACHE] findCustomElements: cache MISS (version %d, cached version %d, cached nil: %v)",
 		currentVersion, d.cacheVersion, d.cachedCustomElements == nil)
-	d.mu.RUnlock()
+	d.cacheMu.RUnlock()
 
 	tree := d.Tree()
 	if tree == nil {
@@ -389,13 +271,11 @@ func (d *TypeScriptDocument) findCustomElements(handler *Handler) ([]types.Custo
 
 	var elements []types.CustomElementMatch
 
-	// First, find HTML template literals
 	templates, err := d.findHTMLTemplates(handler)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find HTML templates: %w", err)
 	}
 
-	// Parse each template as HTML to find custom elements
 	for _, template := range templates {
 		templateElements, err := d.parseHTMLInTemplate(template, handler)
 		if err != nil {
@@ -405,36 +285,32 @@ func (d *TypeScriptDocument) findCustomElements(handler *Handler) ([]types.Custo
 		elements = append(elements, templateElements...)
 	}
 
-	// Populate cache before returning
-	d.mu.Lock()
-	if d.version != currentVersion {
-		// Document was updated during computation, discard stale result
-		d.mu.Unlock()
-		helpers.SafeDebugLog("[CACHE] findCustomElements: version changed during computation (was %d, now %d), discarding stale results", currentVersion, d.version)
+	d.cacheMu.Lock()
+	if d.Version() != currentVersion {
+		d.cacheMu.Unlock()
+		helpers.SafeDebugLog("[CACHE] findCustomElements: version changed during computation (was %d, now %d), discarding stale results", currentVersion, d.Version())
 		return elements, nil
 	}
 	d.cachedCustomElements = elements
 	d.cacheVersion = currentVersion
-	d.mu.Unlock()
+	d.cacheMu.Unlock()
 	helpers.SafeDebugLog("[CACHE] findCustomElements: cache POPULATED (version %d, %d elements)", currentVersion, len(elements))
 
 	return elements, nil
 }
 
-// findHTMLTemplates finds HTML template literals in the TypeScript document
 func (d *TypeScriptDocument) findHTMLTemplates(handler *Handler) ([]TemplateContext, error) {
-	// Check cache first
-	d.mu.RLock()
-	currentVersion := d.version
+	d.cacheMu.RLock()
+	currentVersion := d.Version()
 	if d.cachedTemplates != nil && d.cacheVersion == currentVersion {
 		cachedTemplates := d.cachedTemplates
-		d.mu.RUnlock()
+		d.cacheMu.RUnlock()
 		helpers.SafeDebugLog("[CACHE] findHTMLTemplates: cache HIT (version %d, %d templates)", currentVersion, len(cachedTemplates))
 		return cachedTemplates, nil
 	}
 	helpers.SafeDebugLog("[CACHE] findHTMLTemplates: cache MISS (version %d, cached version %d, cached nil: %v)",
 		currentVersion, d.cacheVersion, d.cachedTemplates == nil)
-	d.mu.RUnlock()
+	d.cacheMu.RUnlock()
 
 	tree := d.Tree()
 	if tree == nil {
@@ -448,19 +324,16 @@ func (d *TypeScriptDocument) findHTMLTemplates(handler *Handler) ([]TemplateCont
 
 	var templates []TemplateContext
 
-	// Create a fresh HTML templates query matcher for thread safety
 	templatesMatcher, err := Q.GetCachedQueryMatcher(handler.queryManager, "typescript", "htmlTemplates")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTML templates matcher: %w", err)
 	}
 	defer templatesMatcher.Close()
 
-	// Find HTML templates with different parent capture names
 	parentCaptureNames := []string{"html.template", "html.generic.template", "html.options.template", "innerHTML.assignment"}
 
 	for _, parentName := range parentCaptureNames {
 		for captureMap := range templatesMatcher.ParentCaptures(tree.RootNode(), []byte(content), parentName) {
-			// Process different template literal capture names
 			templateCaptureNames := []string{"template.literal", "generic.template.literal", "options.template.literal", "innerHTML.template"}
 
 			for _, captureName := range templateCaptureNames {
@@ -479,40 +352,34 @@ func (d *TypeScriptDocument) findHTMLTemplates(handler *Handler) ([]TemplateCont
 		}
 	}
 
-	// Populate cache before returning
-	d.mu.Lock()
-	if d.version != currentVersion {
-		// Document was updated during computation, discard stale result
-		d.mu.Unlock()
-		helpers.SafeDebugLog("[CACHE] findHTMLTemplates: version changed during computation (was %d, now %d), discarding stale results", currentVersion, d.version)
+	d.cacheMu.Lock()
+	if d.Version() != currentVersion {
+		d.cacheMu.Unlock()
+		helpers.SafeDebugLog("[CACHE] findHTMLTemplates: version changed during computation (was %d, now %d), discarding stale results", currentVersion, d.Version())
 		return templates, nil
 	}
 	d.cachedTemplates = templates
 	d.cacheVersion = currentVersion
-	d.mu.Unlock()
+	d.cacheMu.Unlock()
 	helpers.SafeDebugLog("[CACHE] findHTMLTemplates: cache POPULATED (version %d, %d templates)", currentVersion, len(templates))
 
 	return templates, nil
 }
 
-// parseHTMLInTemplate parses HTML content within a template literal
 func (d *TypeScriptDocument) parseHTMLInTemplate(template TemplateContext, handler *Handler) ([]types.CustomElementMatch, error) {
 	templateContent, err := template.Content()
 	if err != nil {
 		return nil, err
 	}
 
-	// Get or create cached HTML parse tree for this template content
 	htmlTree := d.getCachedHTMLTree(templateContent)
 	if htmlTree == nil {
 		return nil, fmt.Errorf("failed to parse HTML template")
 	}
-	// Release the tree when done to decrement reference count
 	defer d.ReleaseCachedHTMLTree(htmlTree)
 
 	var elements []types.CustomElementMatch
 
-	// Get HTML custom elements query from the query manager
 	htmlCustomElements, err := Q.GetCachedQueryMatcher(handler.queryManager, "html", "customElements")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get HTML custom elements query: %w", err)
@@ -522,7 +389,6 @@ func (d *TypeScriptDocument) parseHTMLInTemplate(template TemplateContext, handl
 	contentBytes := []byte(templateContent)
 	seen := make(map[string]bool)
 
-	// Find custom elements in the HTML template (both regular and self-closing)
 	for _, parentName := range []string{"element", "self.closing.tag"} {
 		for captureMap := range htmlCustomElements.ParentCaptures(htmlTree.RootNode(), contentBytes, parentName) {
 			if tagNames, exists := captureMap["tag.name"]; exists {
@@ -549,19 +415,16 @@ func (d *TypeScriptDocument) parseHTMLInTemplate(template TemplateContext, handl
 	return elements, nil
 }
 
-// adjustRangeToTemplate adjusts a range from template content to document coordinates
 func (d *TypeScriptDocument) adjustRangeToTemplate(
 	capture Q.CaptureInfo,
 	template TemplateContext,
 ) protocol.Range {
 	return protocol.Range{
-		Start: d.byteOffsetToPosition(template.startByte + capture.StartByte),
-		End:   d.byteOffsetToPosition(template.startByte + capture.EndByte),
+		Start: d.ByteOffsetToPosition(template.startByte + capture.StartByte),
+		End:   d.ByteOffsetToPosition(template.startByte + capture.EndByte),
 	}
 }
 
-// collectTemplateAttributes extracts attributes from a capture map and adjusts
-// their ranges to document coordinates.
 func (d *TypeScriptDocument) collectTemplateAttributes(
 	captureMap Q.CaptureMap,
 	contentBytes []byte,
@@ -573,7 +436,6 @@ func (d *TypeScriptDocument) collectTemplateAttributes(
 		return attributes
 	}
 
-	// Build a map of attribute values by their byte position
 	valuesByPosition := make(map[uint]string)
 	if attrValues, ok := captureMap["attr.value"]; ok {
 		for _, av := range attrValues {
@@ -596,7 +458,6 @@ func (d *TypeScriptDocument) collectTemplateAttributes(
 			Range: d.adjustRangeToTemplate(attrName, template),
 		}
 
-		// Find the closest value after this attribute name with an = sign between them
 		var closestValue string
 		var closestDistance = ^uint(0)
 		for valuePos, value := range valuesByPosition {
@@ -622,7 +483,6 @@ func (d *TypeScriptDocument) collectTemplateAttributes(
 	return attributes
 }
 
-// analyzeCompletionContext analyzes completion context for TypeScript documents
 func (d *TypeScriptDocument) analyzeCompletionContext(
 	position protocol.Position,
 	handler *Handler,
@@ -641,10 +501,8 @@ func (d *TypeScriptDocument) analyzeCompletionContext(
 		return analysis
 	}
 
-	// Convert position to byte offset
-	byteOffset := d.positionToByteOffset(position, content)
+	byteOffset := d.PositionToByteOffset(position, content)
 
-	// Create a fresh completion context query matcher for thread safety
 	completionMatcher, err := Q.GetCachedQueryMatcher(handler.queryManager, "typescript", "completionContext")
 	if err != nil {
 		helpers.SafeDebugLog("[TypeScript] Failed to create completion context matcher: %v", err)
@@ -652,7 +510,6 @@ func (d *TypeScriptDocument) analyzeCompletionContext(
 	}
 	defer completionMatcher.Close()
 
-	// Use tree-sitter to analyze context
 	helpers.SafeDebugLog("[TypeScript] Analyzing completion context at offset %d", byteOffset)
 
 	captureCount := 0
@@ -660,7 +517,6 @@ func (d *TypeScriptDocument) analyzeCompletionContext(
 		captureCount++
 		helpers.SafeDebugLog("[TypeScript] Found capture map %d with keys: %v", captureCount, getCaptureMapKeys(captureMap))
 
-		// Analyze captures to determine completion context
 		for captureName, captures := range captureMap {
 			helpers.SafeDebugLog("[TypeScript] Checking capture %s with %d captures", captureName, len(captures))
 			for _, capture := range captures {
@@ -670,13 +526,10 @@ func (d *TypeScriptDocument) analyzeCompletionContext(
 					helpers.SafeDebugLog("[TypeScript] Match found for %s", captureName)
 					switch captureName {
 					case "template.content":
-						// Inside an HTML template literal
 						helpers.SafeDebugLog("[TypeScript] Setting IsLitTemplate = true")
 						analysis.IsLitTemplate = true
-						// Analyze the HTML content within the template
 						analysis = d.analyzeTemplateCompletionContext(byteOffset, analysis, handler)
 					case "interpolation":
-						// Inside TypeScript interpolation - no HTML completions
 						helpers.SafeDebugLog("[TypeScript] Found interpolation, returning CompletionUnknown")
 						analysis.Type = types.CompletionUnknown
 						return analysis
@@ -693,7 +546,6 @@ func (d *TypeScriptDocument) analyzeCompletionContext(
 	return analysis
 }
 
-// getCaptureMapKeys returns the keys from a capture map for debugging
 func getCaptureMapKeys(captureMap Q.CaptureMap) []string {
 	keys := make([]string, 0, len(captureMap))
 	for k := range captureMap {
@@ -702,14 +554,12 @@ func getCaptureMapKeys(captureMap Q.CaptureMap) []string {
 	return keys
 }
 
-// analyzeTemplateCompletionContext analyzes completion context within template literals
 func (d *TypeScriptDocument) analyzeTemplateCompletionContext(
 	byteOffset uint,
 	analysis *types.CompletionAnalysis,
 	handler *Handler,
 ) *types.CompletionAnalysis {
 	helpers.SafeDebugLog("[TypeScript] analyzeTemplateCompletionContext called with offset %d", byteOffset)
-	// Find which template the cursor is in
 	templates, err := d.findHTMLTemplates(handler)
 	if err != nil {
 		helpers.SafeDebugLog("[TypeScript] Failed to find HTML templates: %v", err)
@@ -723,15 +573,13 @@ func (d *TypeScriptDocument) analyzeTemplateCompletionContext(
 	}
 
 	for _, template := range templates {
-		templateStart := d.positionToByteOffset(template.Range.Start, content)
-		templateEnd := d.positionToByteOffset(template.Range.End, content)
+		templateStart := d.PositionToByteOffset(template.Range.Start, content)
+		templateEnd := d.PositionToByteOffset(template.Range.End, content)
 
 		if templateStart <= byteOffset && byteOffset <= templateEnd {
-			// Cursor is in this template - analyze the HTML content
 			relativeOffset := byteOffset - templateStart
 			templateContent, _ := template.Content()
 
-			// Use HTML completion context analysis on the template content
 			analysis = d.analyzeTemplateContentAsHTML(templateContent, relativeOffset, analysis, handler)
 			break
 		}
@@ -740,28 +588,23 @@ func (d *TypeScriptDocument) analyzeTemplateCompletionContext(
 	return analysis
 }
 
-// analyzeTemplateContentAsHTML analyzes HTML content within a template
 func (d *TypeScriptDocument) analyzeTemplateContentAsHTML(
 	templateContent string,
 	relativeOffset uint,
 	analysis *types.CompletionAnalysis,
 	handler *Handler,
 ) *types.CompletionAnalysis {
-	// Get or create cached HTML parse tree for this template content
 	htmlTree := d.getCachedHTMLTree(templateContent)
 	if htmlTree == nil {
 		return analysis
 	}
-	// Release the tree when done to decrement reference count
 	defer d.ReleaseCachedHTMLTree(htmlTree)
 
-	// Get HTML completion context query
 	htmlCompletionContext, err := Q.GetCachedQueryMatcher(handler.queryManager, "html", "completionContext")
 	if err != nil {
 		return analysis
 	}
 
-	// First pass: collect all tag names from all capture maps
 	var allTagNames []Q.CaptureInfo
 	for captureMap := range htmlCompletionContext.ParentCaptures(htmlTree.RootNode(), []byte(templateContent), "context") {
 		if tagNames, exists := captureMap["tag.name"]; exists {
@@ -769,9 +612,7 @@ func (d *TypeScriptDocument) analyzeTemplateContentAsHTML(
 		}
 	}
 
-	// Second pass: analyze completion context at the relative offset
 	for captureMap := range htmlCompletionContext.ParentCaptures(htmlTree.RootNode(), []byte(templateContent), "context") {
-		// Find completion context at the relative offset
 		for captureName, captures := range captureMap {
 			for _, capture := range captures {
 				if capture.StartByte <= relativeOffset && relativeOffset <= capture.EndByte {
@@ -782,12 +623,10 @@ func (d *TypeScriptDocument) analyzeTemplateContentAsHTML(
 						analysis.IsLitTemplate = true
 					case "attr.name":
 						attrText := capture.Text
-						// Check for Lit syntax patterns in attribute names
 						if strings.HasPrefix(attrText, "@") {
 							analysis.Type = types.CompletionLitEventBinding
 							analysis.LitSyntax = "@"
 							analysis.IsLitTemplate = true
-							// Remove @ prefix for the actual attribute name
 							if len(attrText) > 1 {
 								analysis.AttributeName = attrText[1:]
 							}
@@ -795,7 +634,6 @@ func (d *TypeScriptDocument) analyzeTemplateContentAsHTML(
 							analysis.Type = types.CompletionLitPropertyBinding
 							analysis.LitSyntax = "."
 							analysis.IsLitTemplate = true
-							// Remove . prefix for the actual property name
 							if len(attrText) > 1 {
 								analysis.AttributeName = attrText[1:]
 							}
@@ -803,7 +641,6 @@ func (d *TypeScriptDocument) analyzeTemplateContentAsHTML(
 							analysis.Type = types.CompletionLitBooleanAttribute
 							analysis.LitSyntax = "?"
 							analysis.IsLitTemplate = true
-							// Remove ? prefix for the actual attribute name
 							if len(attrText) > 1 {
 								analysis.AttributeName = attrText[1:]
 							}
@@ -813,7 +650,6 @@ func (d *TypeScriptDocument) analyzeTemplateContentAsHTML(
 							analysis.IsLitTemplate = true
 						}
 
-						// Find the associated tag name for attribute completions from all collected tag names
 						for _, tagCapture := range allTagNames {
 							if tagCapture.EndByte <= relativeOffset {
 								analysis.TagName = tagCapture.Text
@@ -822,7 +658,6 @@ func (d *TypeScriptDocument) analyzeTemplateContentAsHTML(
 					case "attr.value":
 						analysis.Type = types.CompletionAttributeValue
 						analysis.IsLitTemplate = true
-						// For attribute value completion, find the attribute name
 						if attrNames, hasAttr := captureMap["attr.name"]; hasAttr {
 							for _, attrCapture := range attrNames {
 								if attrCapture.EndByte <= relativeOffset {
@@ -830,7 +665,6 @@ func (d *TypeScriptDocument) analyzeTemplateContentAsHTML(
 								}
 							}
 						}
-						// Also find the tag name from all collected tag names
 						for _, tagCapture := range allTagNames {
 							if tagCapture.EndByte <= relativeOffset {
 								analysis.TagName = tagCapture.Text
@@ -843,164 +677,4 @@ func (d *TypeScriptDocument) analyzeTemplateContentAsHTML(
 	}
 
 	return analysis
-}
-
-// positionToByteOffset converts LSP position to byte offset
-func (d *TypeScriptDocument) positionToByteOffset(pos protocol.Position, content string) uint {
-	var offset uint = 0
-	lines := strings.Split(content, "\n")
-
-	// Add bytes for complete lines before the target line
-	for i := uint32(0); i < pos.Line && i < uint32(len(lines)); i++ {
-		offset += uint(len(lines[i])) + 1 // +1 for newline
-	}
-
-	// Add bytes for characters in the target line
-	if pos.Line < uint32(len(lines)) {
-		line := lines[pos.Line]
-		if pos.Character < uint32(len(line)) {
-			offset += uint(pos.Character)
-		} else {
-			offset += uint(len(line))
-		}
-	}
-
-	return offset
-}
-
-// CompletionPrefix extracts the prefix being typed for filtering completions
-func (d *TypeScriptDocument) CompletionPrefix(analysis *types.CompletionAnalysis) string {
-	if analysis == nil {
-		return ""
-	}
-
-	switch analysis.Type {
-	case types.CompletionTagName:
-		return analysis.TagName
-	case types.CompletionAttributeName:
-		return analysis.AttributeName
-	case types.CompletionAttributeValue:
-		return analysis.AttributeName // For attribute values, we filter on the attribute name
-	default:
-		return ""
-	}
-}
-
-// AnalyzeCompletionContextTS analyzes completion context using tree-sitter queries (interface method)
-func (d *TypeScriptDocument) AnalyzeCompletionContextTS(position protocol.Position, dm any) *types.CompletionAnalysis {
-	// Use reflection to call GetLanguageHandler to avoid circular imports
-	dmValue := reflect.ValueOf(dm)
-	if dmValue.Kind() == reflect.Pointer && !dmValue.IsNil() {
-		method := dmValue.MethodByName("GetLanguageHandler")
-		if method.IsValid() {
-			results := method.Call([]reflect.Value{reflect.ValueOf("typescript")})
-			if len(results) > 0 && !results[0].IsNil() {
-				handler := results[0].Interface()
-				if h, ok := handler.(interface {
-					AnalyzeCompletionContext(types.Document, protocol.Position) *types.CompletionAnalysis
-				}); ok {
-					result := h.AnalyzeCompletionContext(d, position)
-					return result
-				}
-			}
-		}
-	}
-	// Fallback: return safe default
-	return &types.CompletionAnalysis{
-		Type: types.CompletionUnknown,
-	}
-}
-
-// FindElementAtPosition finds a custom element at the given position (interface method)
-func (d *TypeScriptDocument) FindElementAtPosition(
-	position protocol.Position,
-	dm any,
-) *types.CustomElementMatch {
-	// Use reflection to call GetLanguageHandler to avoid circular imports
-	dmValue := reflect.ValueOf(dm)
-	if dmValue.Kind() == reflect.Pointer && !dmValue.IsNil() {
-		method := dmValue.MethodByName("GetLanguageHandler")
-		if method.IsValid() {
-			results := method.Call([]reflect.Value{reflect.ValueOf("typescript")})
-			if len(results) > 0 && !results[0].IsNil() {
-				handler := results[0].Interface()
-				if h, ok := handler.(interface {
-					FindElementAtPosition(types.Document, protocol.Position) *types.CustomElementMatch
-				}); ok {
-					return h.FindElementAtPosition(d, position)
-				}
-			}
-		}
-	}
-	// Fallback: return nil if handler not available
-	return nil
-}
-
-// FindAttributeAtPosition finds an attribute at the given position (interface method)
-func (d *TypeScriptDocument) FindAttributeAtPosition(
-	position protocol.Position,
-	dm any,
-) (*types.AttributeMatch, string) {
-	dmValue := reflect.ValueOf(dm)
-	if dmValue.Kind() == reflect.Pointer && !dmValue.IsNil() {
-		method := dmValue.MethodByName("GetLanguageHandler")
-		if method.IsValid() {
-			results := method.Call([]reflect.Value{reflect.ValueOf("typescript")})
-			if len(results) > 0 && !results[0].IsNil() {
-				handler := results[0].Interface()
-				if h, ok := handler.(interface {
-					FindAttributeAtPosition(types.Document, protocol.Position) (*types.AttributeMatch, string)
-				}); ok {
-					return h.FindAttributeAtPosition(d, position)
-				}
-			}
-		}
-	}
-	return nil, ""
-}
-
-// FindCustomElements finds custom elements in the document (interface method)
-func (d *TypeScriptDocument) FindCustomElements(
-	dm any,
-) ([]types.CustomElementMatch, error) {
-	// Use reflection to call GetLanguageHandler to avoid circular imports
-	dmValue := reflect.ValueOf(dm)
-	if dmValue.Kind() == reflect.Pointer && !dmValue.IsNil() {
-		method := dmValue.MethodByName("GetLanguageHandler")
-		if method.IsValid() {
-			results := method.Call([]reflect.Value{reflect.ValueOf("typescript")})
-			if len(results) > 0 && !results[0].IsNil() {
-				handler := results[0].Interface()
-				if h, ok := handler.(interface {
-					FindCustomElements(types.Document) ([]types.CustomElementMatch, error)
-				}); ok {
-					return h.FindCustomElements(d)
-				}
-			}
-		}
-	}
-	// Fallback: return empty slice if handler not available
-	return []types.CustomElementMatch{}, nil
-}
-
-// FindModuleScript finds insertion point in module script
-func (d *TypeScriptDocument) FindModuleScript() (protocol.Position, bool) {
-	// TypeScript files are modules by default, return end of file
-	content, err := d.Content()
-	if err != nil {
-		return protocol.Position{}, false
-	}
-	lines := strings.Split(content, "\n")
-	return protocol.Position{Line: uint32(len(lines)), Character: 0}, true
-}
-
-// FindInlineModuleScript finds insertion point in inline module script
-func (d *TypeScriptDocument) FindInlineModuleScript() (protocol.Position, bool) {
-	return d.FindModuleScript()
-}
-
-// FindHeadInsertionPoint finds insertion point in <head> section
-func (d *TypeScriptDocument) FindHeadInsertionPoint(dm any) (protocol.Position, bool) {
-	// TypeScript files don't have <head> sections
-	return protocol.Position{}, false
 }

--- a/lsp/document/typescript/document.go
+++ b/lsp/document/typescript/document.go
@@ -259,14 +259,9 @@ func (d *TypeScriptDocument) findCustomElements(handler *Handler) ([]types.Custo
 		currentVersion, d.cacheVersion, d.cachedCustomElements == nil)
 	d.cacheMu.RUnlock()
 
-	tree := d.Tree()
+	tree, docContent := d.TreeAndContent()
 	if tree == nil {
 		return nil, fmt.Errorf("no tree available for document")
-	}
-
-	docContent, err := d.Content()
-	if err != nil {
-		return nil, err
 	}
 
 	var elements []types.CustomElementMatch
@@ -312,14 +307,9 @@ func (d *TypeScriptDocument) findHTMLTemplates(handler *Handler) ([]TemplateCont
 		currentVersion, d.cacheVersion, d.cachedTemplates == nil)
 	d.cacheMu.RUnlock()
 
-	tree := d.Tree()
+	tree, content := d.TreeAndContent()
 	if tree == nil {
 		return nil, fmt.Errorf("no tree available")
-	}
-
-	content, err := d.Content()
-	if err != nil {
-		return nil, err
 	}
 
 	var templates []TemplateContext
@@ -493,13 +483,8 @@ func (d *TypeScriptDocument) analyzeCompletionContext(
 		Type: types.CompletionUnknown,
 	}
 
-	tree := d.Tree()
+	tree, content := d.TreeAndContent()
 	if tree == nil {
-		return analysis
-	}
-
-	content, err := d.Content()
-	if err != nil {
 		return analysis
 	}
 

--- a/lsp/document/typescript/document.go
+++ b/lsp/document/typescript/document.go
@@ -38,6 +38,7 @@ type cachedTree struct {
 }
 
 // TypeScriptDocument represents a TypeScript document with tree-sitter parsing.
+// Always use NewTypeScriptDocument to construct; a zero-value TypeScriptDocument will panic.
 //
 // Lock ordering: BaseDocument.mu is never held when cacheMu is acquired.
 // Both SetTree and UpdateContent acquire mu (via BaseDocument) then release it

--- a/lsp/document/typescript/document.go
+++ b/lsp/document/typescript/document.go
@@ -231,8 +231,16 @@ func (d *TypeScriptDocument) FindModuleScript() (protocol.Position, bool) {
 	if err != nil {
 		return protocol.Position{}, false
 	}
+	if content == "" {
+		return protocol.Position{}, true
+	}
+
 	lines := strings.Split(content, "\n")
-	return protocol.Position{Line: uint32(len(lines)), Character: 0}, true
+	lastLine := len(lines) - 1
+	return protocol.Position{
+		Line:      uint32(lastLine),
+		Character: uint32(len(lines[lastLine])),
+	}, true
 }
 
 // CompletionPrefix extracts the prefix being typed for filtering completions

--- a/lsp/document/typescript/document.go
+++ b/lsp/document/typescript/document.go
@@ -37,7 +37,13 @@ type cachedTree struct {
 	refs int
 }
 
-// TypeScriptDocument represents a TypeScript document with tree-sitter parsing
+// TypeScriptDocument represents a TypeScript document with tree-sitter parsing.
+//
+// Lock ordering: BaseDocument.mu is never held when cacheMu is acquired.
+// Both SetTree and UpdateContent acquire mu (via BaseDocument) then release it
+// before acquiring cacheMu (via invalidateCache). Methods that read cache state
+// under cacheMu may call Version() (acquires mu.RLock) safely because the
+// inverse nesting (mu.Lock -> cacheMu) never occurs.
 type TypeScriptDocument struct {
 	*base.BaseDocument
 

--- a/lsp/document/typescript/handler.go
+++ b/lsp/document/typescript/handler.go
@@ -48,14 +48,8 @@ func (h *Handler) Language() string {
 
 // CreateDocument creates a new TypeScript document
 func (h *Handler) CreateDocument(uri, content string, version int32) types.Document {
-	doc := &TypeScriptDocument{
-		uri:      uri,
-		content:  content,
-		version:  version,
-		language: "typescript",
-	}
+	doc := NewTypeScriptDocument(uri, content, version)
 
-	// Parse the document
 	if err := doc.Parse(content); err != nil {
 		helpers.SafeDebugLog("[TypeScript] Failed to parse document %s: %v", uri, err)
 	}

--- a/lsp/methods/textDocument/context.go
+++ b/lsp/methods/textDocument/context.go
@@ -30,7 +30,7 @@ func AnalyzeCompletionContext(doc types.Document, position protocol.Position, tr
 }
 
 // AnalyzeCompletionContextWithDM determines what completion should be provided using tree-sitter with DocumentManager
-func AnalyzeCompletionContextWithDM(doc types.Document, position protocol.Position, triggerChar string, dm any) (*types.CompletionAnalysis, error) {
+func AnalyzeCompletionContextWithDM(doc types.Document, position protocol.Position, triggerChar string, dm types.HandlerProvider) (*types.CompletionAnalysis, error) {
 	if doc == nil {
 		return nil, fmt.Errorf("document is nil")
 	}
@@ -51,16 +51,7 @@ func AnalyzeCompletionContextWithDM(doc types.Document, position protocol.Positi
 		return nil, fmt.Errorf("position character %d is out of bounds for line %d (line has %d characters)", position.Character, position.Line, len(lineContent))
 	}
 
-	// Check if document supports tree-sitter analysis
-	docWithTreeSitter, ok := doc.(interface {
-		AnalyzeCompletionContextTS(position protocol.Position, dm any) *types.CompletionAnalysis
-	})
-	if !ok {
-		return nil, fmt.Errorf("document does not support tree-sitter completion context analysis")
-	}
-
-	// Use tree-sitter analysis - this is the only supported method
-	tsAnalysis := docWithTreeSitter.AnalyzeCompletionContextTS(position, dm)
+	tsAnalysis := doc.AnalyzeCompletionContextTS(position, dm)
 	if tsAnalysis == nil {
 		return nil, fmt.Errorf("tree-sitter completion context analysis returned nil")
 	}

--- a/lsp/methods/textDocument/definition/definition.go
+++ b/lsp/methods/textDocument/definition/definition.go
@@ -115,7 +115,7 @@ func Definition(ctx types.ServerContext, context *glsp.Context, params *protocol
 }
 
 // analyzeDefinitionTarget analyzes the cursor position to determine what definition is being requested
-func analyzeDefinitionTarget(doc types.Document, position protocol.Position, dm any) *DefinitionRequest {
+func analyzeDefinitionTarget(doc types.Document, position protocol.Position, dm types.HandlerProvider) *DefinitionRequest {
 	// Find if we're on an element
 	element := doc.FindElementAtPosition(position, dm)
 	if element != nil {

--- a/lsp/types/context.go
+++ b/lsp/types/context.go
@@ -26,6 +26,8 @@ import (
 
 // DocumentManager interface for document operations
 type DocumentManager interface {
+	HandlerProvider
+
 	OpenDocument(uri, content string, version int32) Document
 	UpdateDocument(uri, content string, version int32) Document
 	UpdateDocumentWithChanges(uri, content string, version int32, changes []protocol.TextDocumentContentChangeEvent) Document

--- a/lsp/types/document.go
+++ b/lsp/types/document.go
@@ -25,20 +25,35 @@ import (
 
 // Document interface for LSP document operations
 type Document interface {
-	FindElementAtPosition(position protocol.Position, dm any) *CustomElementMatch
-	FindAttributeAtPosition(position protocol.Position, dm any) (*AttributeMatch, string)
-	Content() (string, error) // Returns content with proper error handling
+	// Content returns the document content with error handling
+	Content() (string, error)
+	// Version returns the document version
 	Version() int32
+	// URI returns the document URI
 	URI() string
-	Language() string // Returns the document language
-	FindCustomElements(dm any) ([]CustomElementMatch, error)
-	AnalyzeCompletionContextTS(position protocol.Position, dm any) *CompletionAnalysis
-	CompletionPrefix(analysis *CompletionAnalysis) string                            // Get completion prefix using tree-sitter
-	ScriptTags() []ScriptTag                                                         // Get parsed script tags
-	ImportMap() map[string]string                                                    // Get import map (if any) from <script type="importmap">
-	FindModuleScript() (protocol.Position, bool)                                     // Find insertion point in module script
-	FindInlineModuleScript() (protocol.Position, bool)                               // Find insertion point in inline module script (no src)
-	FindHeadInsertionPoint(dm any) (protocol.Position, bool)                         // Find insertion point in <head> section
+	// Language returns the document language identifier
+	Language() string
+	// ScriptTags returns parsed script tags for HTML documents
+	ScriptTags() []ScriptTag
+	// ImportMap returns import map entries from <script type="importmap">, if any
+	ImportMap() map[string]string
+
+	// FindElementAtPosition finds a custom element at the given position
+	FindElementAtPosition(position protocol.Position, hp HandlerProvider) *CustomElementMatch
+	// FindAttributeAtPosition finds an attribute at the given position
+	FindAttributeAtPosition(position protocol.Position, hp HandlerProvider) (*AttributeMatch, string)
+	// FindCustomElements finds all custom elements in the document
+	FindCustomElements(hp HandlerProvider) ([]CustomElementMatch, error)
+	// AnalyzeCompletionContextTS analyzes completion context using tree-sitter
+	AnalyzeCompletionContextTS(position protocol.Position, hp HandlerProvider) *CompletionAnalysis
+	// CompletionPrefix extracts the prefix being typed for filtering completions
+	CompletionPrefix(analysis *CompletionAnalysis) string
+	// FindModuleScript finds insertion point in a module script
+	FindModuleScript() (protocol.Position, bool)
+	// FindInlineModuleScript finds insertion point in an inline module script (no src)
+	FindInlineModuleScript() (protocol.Position, bool)
+	// FindHeadInsertionPoint finds insertion point in the <head> section
+	FindHeadInsertionPoint(hp HandlerProvider) (protocol.Position, bool)
 	ByteRangeToProtocolRange(content string, startByte, endByte uint) protocol.Range // Convert byte range to protocol range
 	Close()                                                                          // Clean up document resources
 
@@ -48,6 +63,12 @@ type Document interface {
 	Parser() *ts.Parser                          // Get the tree-sitter parser
 	SetParser(parser *ts.Parser)                 // Set the tree-sitter parser
 	UpdateContent(content string, version int32) // Update document content
+}
+
+// HandlerProvider looks up language handlers by name.
+// DocumentManager implements this; documents use it for handler delegation.
+type HandlerProvider interface {
+	GetLanguageHandler(language string) LanguageHandler
 }
 
 // LanguageHandler defines the interface for language-specific operations
@@ -70,18 +91,15 @@ type RangeParser interface {
 
 // Manager interface for document lifecycle management
 type Manager interface {
-	// Document lifecycle
+	HandlerProvider
+
 	OpenDocument(uri, content string, version int32) Document
 	UpdateDocument(uri, content string, version int32) Document
 	UpdateDocumentWithChanges(uri, content string, version int32, changes []protocol.TextDocumentContentChangeEvent) Document
 	CloseDocument(uri string)
 	Document(uri string) Document
 	AllDocuments() []Document
-
-	// Core query management (language-agnostic)
 	QueryManager() *Q.QueryManager
-
-	// Cleanup
 	Close()
 }
 


### PR DESCRIPTION
## Summary

- Embed `BaseDocument` in HTMLDocument, TypeScriptDocument, and TSXDocument, eliminating ~800 lines of duplicated boilerplate
- Add `returnParser` callback for correct parser pool routing via `SetParser`/`Close`
- Add `HandlerProvider` interface, replacing runtime reflection with compile-time typed handler delegation
- Add `TreeAndContent()` composite getter for atomic tree+content reads
- Add targeted unit tests for parser pool lifecycle

## Changes

**New package `lsp/document/base/`**: `BaseDocument` moved here to avoid import cycle between `lsp/document/` (which imports sub-packages) and the sub-packages (which now import the base).

**`HandlerProvider` interface** in `lsp/types/`: typed replacement for the `reflect.ValueOf(dm).MethodByName("GetLanguageHandler")` pattern that all three document types duplicated. `Manager` and `DocumentManager` interfaces embed it. Compile-time safety for handler lookup.

**Per-type changes**:
- **TSXDocument**: embed only, keeps `Parse`, `FindModuleScript`, `CompletionPrefix`, analysis methods
- **HTMLDocument**: embed + `importMap` field, keeps `ImportMap` (defensive copy), `Parse`, `ParseWithRanges`, `FindModuleScript`, `CompletionPrefix`, analysis methods
- **TypeScriptDocument**: embed + cache fields with separate `cacheMu`, keeps `UpdateContent`/`SetTree`/`Close` overrides for cache invalidation, `Parse`, `CompletionPrefix`, all template analysis methods

**Bugs fixed during review**:
- Data race: `ByteOffsetToPosition` was reading `d.content` without lock after `TreeAndContent()` released it. Now accepts explicit content parameter.
- TOCTOU: several methods called `Tree()` and `Content()` as separate locked reads. Replaced with `TreeAndContent()` for atomic snapshot.
- `FindInlineModuleScript` regression: Go embedding dispatch resolved `d.FindModuleScript()` to BaseDocument's version (no `Src` filter) instead of HTMLDocument's override. Restored independent implementation.
- Pre-existing leak: missing `defer htmlCompletionContext.Close()` in `analyzeTemplateContentAsHTML`

Closes #307

## Test plan

- [x] All 2451 existing tests pass (8 pre-existing skips unchanged)
- [x] New parser pool lifecycle tests: callback invocation, cross-pool routing, double-close safety
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean (3 pre-existing issues in `serve/`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized document state management architecture for improved maintainability and code reuse across language-specific document types.
  * Enhanced type safety by strengthening internal handler provider typing.

* **Tests**
  * Added comprehensive test coverage for document lifecycle and parser management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->