### PR TITLE
fix(lsp): use UTF-16 code units for position character offsets

### DIFF
--- a/internal/textutil/utf16.go
+++ b/internal/textutil/utf16.go
@@ -1,0 +1,102 @@
+/*
+Copyright © 2025 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package textutil
+
+import (
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+// UTF16ToByteOffset converts a UTF-16 code unit offset to a UTF-8 byte offset.
+func UTF16ToByteOffset(text string, utf16Offset uint32) uint {
+	var byteOffset uint
+	var utf16Count uint32
+
+	for byteOffset < uint(len(text)) && utf16Count < utf16Offset {
+		r, size := utf8.DecodeRuneInString(text[byteOffset:])
+		if r == utf8.RuneError && size == 1 {
+			byteOffset++
+			utf16Count++
+			continue
+		}
+
+		byteOffset += uint(size)
+		utf16Count += uint32(utf16.RuneLen(r))
+	}
+
+	return byteOffset
+}
+
+// ByteOffsetToUTF16 converts a UTF-8 byte offset to a UTF-16 code unit offset.
+func ByteOffsetToUTF16(text string, byteOffset uint) uint32 {
+	var currentByte uint
+	var utf16Count uint32
+
+	for currentByte < byteOffset && currentByte < uint(len(text)) {
+		r, size := utf8.DecodeRuneInString(text[currentByte:])
+		if r == utf8.RuneError && size == 1 {
+			currentByte++
+			utf16Count++
+			continue
+		}
+
+		currentByte += uint(size)
+		utf16Count += uint32(utf16.RuneLen(r))
+	}
+
+	return utf16Count
+}
+
+// UTF16ToByteOffsetBytes is like UTF16ToByteOffset but operates on []byte.
+func UTF16ToByteOffsetBytes(text []byte, utf16Offset uint32) uint {
+	var byteOffset uint
+	var utf16Count uint32
+
+	for byteOffset < uint(len(text)) && utf16Count < utf16Offset {
+		r, size := utf8.DecodeRune(text[byteOffset:])
+		if r == utf8.RuneError && size == 1 {
+			byteOffset++
+			utf16Count++
+			continue
+		}
+
+		byteOffset += uint(size)
+		utf16Count += uint32(utf16.RuneLen(r))
+	}
+
+	return byteOffset
+}
+
+// ByteOffsetToUTF16Bytes is like ByteOffsetToUTF16 but operates on []byte.
+func ByteOffsetToUTF16Bytes(text []byte, byteOffset uint) uint32 {
+	var currentByte uint
+	var utf16Count uint32
+
+	for currentByte < byteOffset && currentByte < uint(len(text)) {
+		r, size := utf8.DecodeRune(text[currentByte:])
+		if r == utf8.RuneError && size == 1 {
+			currentByte++
+			utf16Count++
+			continue
+		}
+
+		currentByte += uint(size)
+		utf16Count += uint32(utf16.RuneLen(r))
+	}
+
+	return utf16Count
+}

--- a/internal/textutil/utf16_test.go
+++ b/internal/textutil/utf16_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright © 2025 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package textutil_test
+
+import (
+	"testing"
+	"unicode/utf8"
+
+	"bennypowers.dev/cem/internal/textutil"
+)
+
+func TestUTF16ToByteOffset(t *testing.T) {
+	tests := []struct {
+		name         string
+		text         string
+		utf16Offset  uint32
+		expectedByte uint
+	}{
+		{"ASCII only", "hello world", 6, 6},
+		{"Emoji at start", "😀 hello", 3, 5},
+		{"Emoji in middle", "hello 😀 world", 8, 10},
+		{"Multiple emoji", "🔥🎉😀", 4, 8},
+		{"Chinese characters", "你好世界", 2, 6},
+		{"Mixed ASCII and emoji", "Hello 🌍 World", 8, 10},
+		{"Spanish ñ", "Mañana", 3, 4},
+		{"Zero offset", "😀 test", 0, 0},
+		{"Offset beyond text", "test", 100, 4},
+		{"Valid U+FFFD", "�x", 1, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := textutil.UTF16ToByteOffset(tt.text, tt.utf16Offset)
+			if result != tt.expectedByte {
+				t.Errorf("UTF16ToByteOffset(%q, %d) = %d, want %d",
+					tt.text, tt.utf16Offset, result, tt.expectedByte)
+			}
+		})
+	}
+}
+
+func TestByteOffsetToUTF16(t *testing.T) {
+	tests := []struct {
+		name          string
+		text          string
+		byteOffset    uint
+		expectedUTF16 uint32
+	}{
+		{"ASCII only", "hello world", 6, 6},
+		{"Emoji at start", "😀 hello", 5, 3},
+		{"Chinese characters", "你好世界", 6, 2},
+		{"Valid U+FFFD", "�x", 3, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := textutil.ByteOffsetToUTF16(tt.text, tt.byteOffset)
+			if result != tt.expectedUTF16 {
+				t.Errorf("ByteOffsetToUTF16(%q, %d) = %d, want %d",
+					tt.text, tt.byteOffset, result, tt.expectedUTF16)
+			}
+		})
+	}
+}
+
+func TestUTF16ToByteOffsetBytes(t *testing.T) {
+	tests := []struct {
+		name         string
+		text         string
+		utf16Offset  uint32
+		expectedByte uint
+	}{
+		{"ASCII only", "hello world", 6, 6},
+		{"Emoji at start", "😀 hello", 3, 5},
+		{"Chinese characters", "你好世界", 2, 6},
+		{"Zero offset", "😀 test", 0, 0},
+		{"Offset beyond text", "test", 100, 4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := textutil.UTF16ToByteOffsetBytes([]byte(tt.text), tt.utf16Offset)
+			if result != tt.expectedByte {
+				t.Errorf("UTF16ToByteOffsetBytes(%q, %d) = %d, want %d",
+					tt.text, tt.utf16Offset, result, tt.expectedByte)
+			}
+		})
+	}
+}
+
+func TestByteOffsetToUTF16Bytes(t *testing.T) {
+	tests := []struct {
+		name          string
+		text          string
+		byteOffset    uint
+		expectedUTF16 uint32
+	}{
+		{"ASCII only", "hello world", 6, 6},
+		{"Emoji at start", "😀 hello", 5, 3},
+		{"Chinese characters", "你好世界", 6, 2},
+		{"Valid U+FFFD", "�x", 3, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := textutil.ByteOffsetToUTF16Bytes([]byte(tt.text), tt.byteOffset)
+			if result != tt.expectedUTF16 {
+				t.Errorf("ByteOffsetToUTF16Bytes(%q, %d) = %d, want %d",
+					tt.text, tt.byteOffset, result, tt.expectedUTF16)
+			}
+		})
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	texts := []string{
+		"hello world",
+		"😀 hello 🌍 world",
+		"你好世界 hello",
+		"Mañana 🔥🎉",
+	}
+
+	for _, text := range texts {
+		t.Run(text, func(t *testing.T) {
+			// Only test at rune-aligned byte offsets; mid-rune offsets
+			// snap forward and can't round-trip.
+			for byteOff := 0; byteOff < len(text); {
+				utf16 := textutil.ByteOffsetToUTF16(text, uint(byteOff))
+				back := textutil.UTF16ToByteOffset(text, utf16)
+				if back != uint(byteOff) {
+					t.Errorf("round-trip failed: byte %d -> utf16 %d -> byte %d",
+						byteOff, utf16, back)
+				}
+				_, size := utf8.DecodeRuneInString(text[byteOff:])
+				byteOff += size
+			}
+		})
+	}
+}

--- a/internal/treesitter/queries.go
+++ b/internal/treesitter/queries.go
@@ -19,6 +19,7 @@ package treesitter
 import (
 	"fmt"
 
+	"bennypowers.dev/cem/internal/textutil"
 	ts "github.com/tree-sitter/go-tree-sitter"
 )
 
@@ -90,26 +91,21 @@ func NodeToRange(node *ts.Node, content []byte) Range {
 	}
 }
 
-// ByteOffsetToPosition converts a byte offset to line/character position
+// ByteOffsetToPosition converts a byte offset to line/character position.
+// Character is in UTF-16 code units per the LSP specification.
 func ByteOffsetToPosition(content []byte, offset uint) Position {
 	line := uint32(0)
-	char := uint32(0)
+	lineStart := uint(0)
 
-	for i, b := range content {
-		if uint(i) >= offset {
-			break
-		}
-
-		if b == '\n' {
+	for i := uint(0); i < offset && i < uint(len(content)); i++ {
+		if content[i] == '\n' {
 			line++
-			char = 0
-		} else {
-			char++
+			lineStart = i + 1
 		}
 	}
 
 	return Position{
 		Line:      line,
-		Character: char,
+		Character: textutil.ByteOffsetToUTF16Bytes(content[lineStart:], offset-lineStart),
 	}
 }

--- a/internal/treesitter/queries_test.go
+++ b/internal/treesitter/queries_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright © 2025 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package treesitter_test
+
+import (
+	"testing"
+
+	"bennypowers.dev/cem/internal/treesitter"
+)
+
+func TestByteOffsetToPosition_UTF16(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		offset    uint
+		wantLine  uint32
+		wantChar  uint32
+	}{
+		{"ASCII", "hello world", 6, 0, 6},
+		{"emoji (4 bytes = 2 UTF-16 units)", "😀 hello", 4, 0, 2},
+		{"after emoji and space", "😀 hello", 5, 0, 3},
+		{"Chinese (3 bytes = 1 UTF-16 unit)", "你好world", 6, 0, 2},
+		{"multiline ASCII", "line1\nline2\nline3", 14, 2, 2},
+		{"multiline with emoji", "line1\n😀 hello", 10, 1, 2},
+		{"offset at start", "hello", 0, 0, 0},
+		{"offset at newline", "hello\nworld", 5, 0, 5},
+		{"offset after newline", "hello\nworld", 6, 1, 0},
+		{"empty content", "", 0, 0, 0},
+		{"content ending with newline", "hello\n", 6, 1, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pos := treesitter.ByteOffsetToPosition([]byte(tt.content), tt.offset)
+			if pos.Line != tt.wantLine || pos.Character != tt.wantChar {
+				t.Errorf("ByteOffsetToPosition(%q, %d) = {%d, %d}, want {%d, %d}",
+					tt.content, tt.offset, pos.Line, pos.Character, tt.wantLine, tt.wantChar)
+			}
+		})
+	}
+}

--- a/lsp/document/base/base_document.go
+++ b/lsp/document/base/base_document.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"sync"
 
+	"bennypowers.dev/cem/internal/textutil"
 	"bennypowers.dev/cem/lsp/types"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 	ts "github.com/tree-sitter/go-tree-sitter"
@@ -225,30 +226,26 @@ func (d *BaseDocument) ByteRangeToProtocolRange(content string, startByte, endBy
 }
 
 // ByteOffsetToPosition converts a byte offset to a protocol position within the given content.
+// Character is in UTF-16 code units per the LSP specification.
 func (d *BaseDocument) ByteOffsetToPosition(offset uint, content string) protocol.Position {
 	line := uint32(0)
-	char := uint32(0)
+	lineStart := uint(0)
 
-	for i, r := range content {
-		if uint(i) >= offset {
-			break
-		}
-
-		if r == '\n' {
+	for i := uint(0); i < offset && i < uint(len(content)); i++ {
+		if content[i] == '\n' {
 			line++
-			char = 0
-		} else {
-			char++
+			lineStart = i + 1
 		}
 	}
 
 	return protocol.Position{
 		Line:      line,
-		Character: char,
+		Character: textutil.ByteOffsetToUTF16(content[lineStart:], offset-lineStart),
 	}
 }
 
 // PositionToByteOffset converts a protocol position to a byte offset within the given content.
+// Character is interpreted as UTF-16 code units per the LSP specification.
 func (d *BaseDocument) PositionToByteOffset(pos protocol.Position, content string) uint {
 	var offset uint
 	lines := strings.Split(content, "\n")
@@ -259,11 +256,7 @@ func (d *BaseDocument) PositionToByteOffset(pos protocol.Position, content strin
 
 	if pos.Line < uint32(len(lines)) {
 		line := lines[pos.Line]
-		if pos.Character < uint32(len(line)) {
-			offset += uint(pos.Character)
-		} else {
-			offset += uint(len(line))
-		}
+		offset += textutil.UTF16ToByteOffset(line, pos.Character)
 	}
 
 	return offset

--- a/lsp/document/base/base_document_test.go
+++ b/lsp/document/base/base_document_test.go
@@ -2,8 +2,10 @@ package base
 
 import (
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
+	protocol "github.com/tliron/glsp/protocol_3_16"
 	ts "github.com/tree-sitter/go-tree-sitter"
 )
 
@@ -100,4 +102,144 @@ func TestTreeAndContent_ReturnsAtomicSnapshot(t *testing.T) {
 
 	assert.Nil(t, tree, "tree should be nil when not set")
 	assert.Equal(t, "<div>hello</div>", content)
+}
+
+func TestByteOffsetToPosition_UTF16(t *testing.T) {
+	doc := NewBaseDocument("test.html", "", 1, "html", nil, nil)
+	tests := []struct {
+		name     string
+		content  string
+		offset   uint
+		expected protocol.Position
+	}{
+		{
+			name:     "ASCII",
+			content:  "hello world",
+			offset:   6,
+			expected: protocol.Position{Line: 0, Character: 6},
+		},
+		{
+			name:     "emoji counts as 2 UTF-16 code units",
+			content:  "😀 hello",
+			offset:   4, // byte offset after emoji
+			expected: protocol.Position{Line: 0, Character: 2},
+		},
+		{
+			name:     "after emoji and space",
+			content:  "😀 hello",
+			offset:   5, // byte offset after emoji + space
+			expected: protocol.Position{Line: 0, Character: 3},
+		},
+		{
+			name:     "Chinese characters (3 bytes, 1 UTF-16 unit each)",
+			content:  "你好world",
+			offset:   6, // after 2 Chinese chars
+			expected: protocol.Position{Line: 0, Character: 2},
+		},
+		{
+			name:     "multiline with emoji",
+			content:  "line1\n😀 hello",
+			offset:   10, // "line1\n" (6) + emoji (4)
+			expected: protocol.Position{Line: 1, Character: 2},
+		},
+		{
+			name:     "multiline ASCII",
+			content:  "line1\nline2\nline3",
+			offset:   14, // "line1\nline2\nli"
+			expected: protocol.Position{Line: 2, Character: 2},
+		},
+		{
+			name:    "offset at start",
+			content: "hello",
+			offset:  0,
+			expected: protocol.Position{Line: 0, Character: 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pos := doc.ByteOffsetToPosition(tt.offset, tt.content)
+			assert.Equal(t, tt.expected, pos)
+		})
+	}
+}
+
+func TestPositionToByteOffset_UTF16(t *testing.T) {
+	doc := NewBaseDocument("test.html", "", 1, "html", nil, nil)
+	tests := []struct {
+		name     string
+		content  string
+		pos      protocol.Position
+		expected uint
+	}{
+		{
+			name:     "ASCII",
+			content:  "hello world",
+			pos:      protocol.Position{Line: 0, Character: 6},
+			expected: 6,
+		},
+		{
+			name:     "emoji (2 UTF-16 units = 4 bytes)",
+			content:  "😀 hello",
+			pos:      protocol.Position{Line: 0, Character: 2}, // after emoji
+			expected: 4,
+		},
+		{
+			name:     "after emoji and space",
+			content:  "😀 hello",
+			pos:      protocol.Position{Line: 0, Character: 3}, // after emoji + space
+			expected: 5,
+		},
+		{
+			name:     "Chinese characters",
+			content:  "你好world",
+			pos:      protocol.Position{Line: 0, Character: 2}, // after 2 Chinese chars
+			expected: 6,
+		},
+		{
+			name:     "multiline with emoji",
+			content:  "line1\n😀 hello",
+			pos:      protocol.Position{Line: 1, Character: 2}, // after emoji on line 2
+			expected: 10,
+		},
+		{
+			name:     "position at start",
+			content:  "hello",
+			pos:      protocol.Position{Line: 0, Character: 0},
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			off := doc.PositionToByteOffset(tt.pos, tt.content)
+			assert.Equal(t, tt.expected, off)
+		})
+	}
+}
+
+func TestPositionRoundTrip(t *testing.T) {
+	doc := NewBaseDocument("test.html", "", 1, "html", nil, nil)
+	contents := []string{
+		"hello world",
+		"😀 hello 🌍 world",
+		"你好世界",
+		"line1\n😀 hello\n你好",
+	}
+
+	for _, content := range contents {
+		t.Run(content, func(t *testing.T) {
+			// Only test rune-aligned byte offsets; mid-rune offsets snap forward.
+			for offset := 0; offset < len(content); {
+				pos := doc.ByteOffsetToPosition(uint(offset), content)
+				back := doc.PositionToByteOffset(pos, content)
+				if back != uint(offset) {
+					t.Errorf("round-trip failed: byte %d -> pos{%d,%d} -> byte %d",
+						offset, pos.Line, pos.Character, back)
+				}
+				_, size := utf8.DecodeRuneInString(content[offset:])
+				offset += size
+			}
+		})
+	}
 }

--- a/lsp/incremental.go
+++ b/lsp/incremental.go
@@ -17,9 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package lsp
 
 import (
-	"unicode/utf16"
-	"unicode/utf8"
-
+	"bennypowers.dev/cem/internal/textutil"
 	"bennypowers.dev/cem/lsp/helpers"
 	"bennypowers.dev/cem/lsp/types"
 	protocol "github.com/tliron/glsp/protocol_3_16"
@@ -39,52 +37,14 @@ const (
 // LSP uses UTF-16 code units for character positions, while tree-sitter uses UTF-8 byte offsets.
 // We need to convert between these two encodings using stdlib unicode/utf16 package.
 
-// UTF16ToByteOffset converts a UTF-16 code unit offset to a UTF-8 byte offset
+// UTF16ToByteOffset converts a UTF-16 code unit offset to a UTF-8 byte offset.
 func UTF16ToByteOffset(text string, utf16Offset uint32) uint {
-	var byteOffset uint = 0
-	var utf16Count uint32 = 0
-
-	for byteOffset < uint(len(text)) && utf16Count < utf16Offset {
-		r, size := utf8.DecodeRuneInString(text[byteOffset:])
-		// Check for invalid UTF-8: RuneError with size == 1
-		// Note: Valid U+FFFD has size == 3, so we need to check both
-		if r == utf8.RuneError && size == 1 {
-			// Invalid UTF-8, treat as single byte
-			byteOffset++
-			utf16Count++
-			continue
-		}
-
-		byteOffset += uint(size)
-		// Use stdlib to count UTF-16 code units for this rune
-		utf16Count += uint32(utf16.RuneLen(r))
-	}
-
-	return byteOffset
+	return textutil.UTF16ToByteOffset(text, utf16Offset)
 }
 
-// ByteOffsetToUTF16 converts a UTF-8 byte offset to a UTF-16 code unit offset
+// ByteOffsetToUTF16 converts a UTF-8 byte offset to a UTF-16 code unit offset.
 func ByteOffsetToUTF16(text string, byteOffset uint) uint32 {
-	var currentByte uint = 0
-	var utf16Count uint32 = 0
-
-	for currentByte < byteOffset && currentByte < uint(len(text)) {
-		r, size := utf8.DecodeRuneInString(text[currentByte:])
-		// Check for invalid UTF-8: RuneError with size == 1
-		// Note: Valid U+FFFD has size == 3, so we need to check both
-		if r == utf8.RuneError && size == 1 {
-			// Invalid UTF-8, treat as single byte
-			currentByte++
-			utf16Count++
-			continue
-		}
-
-		currentByte += uint(size)
-		// Use stdlib to count UTF-16 code units
-		utf16Count += uint32(utf16.RuneLen(r))
-	}
-
-	return utf16Count
+	return textutil.ByteOffsetToUTF16(text, byteOffset)
 }
 
 // DocumentEdit represents a change to a document


### PR DESCRIPTION
## Summary

- Extract shared UTF-16 conversion helpers to `internal/textutil` with both `string` and `[]byte` variants
- Fix `BaseDocument.ByteOffsetToPosition` (was counting runes/UTF-32, now counts UTF-16 code units)
- Fix `BaseDocument.PositionToByteOffset` (was treating Character as byte offset, now converts UTF-16 to bytes)
- Fix `treesitter.ByteOffsetToPosition` (was counting raw bytes, now counts UTF-16 code units)
- `lsp/incremental.go` wrappers now delegate to `textutil`

Closes #311

## Test plan

- [x] New unit tests for all `textutil` functions (ASCII, emoji, CJK, round-trip)
- [x] New unit tests for `BaseDocument.ByteOffsetToPosition` and `PositionToByteOffset` with UTF-16 content
- [x] New unit tests for `treesitter.ByteOffsetToPosition` with emoji, CJK, multiline, edge cases
- [x] Round-trip tests verify byte -> position -> byte at rune-aligned offsets
- [x] Full test suite passes (`go test ./... -count=1`)
- [x] Lint clean (`golangci-lint run ./...`)

<!-- @coderabbitai ignore -->