### PR TITLE
fix(lsp): ref-count tree-sitter trees to prevent use-after-free

### DIFF
--- a/lsp/document/base/base_document.go
+++ b/lsp/document/base/base_document.go
@@ -19,12 +19,40 @@ package base
 import (
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"bennypowers.dev/cem/internal/textutil"
 	"bennypowers.dev/cem/lsp/types"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 	ts "github.com/tree-sitter/go-tree-sitter"
 )
+
+// refCountedTree wraps a tree-sitter tree with atomic reference counting.
+// The tree is only closed when the last reference is released.
+type refCountedTree struct {
+	tree *ts.Tree
+	refs atomic.Int32
+}
+
+func newRefCountedTree(tree *ts.Tree) *refCountedTree {
+	rc := &refCountedTree{tree: tree}
+	rc.refs.Store(1)
+	return rc
+}
+
+func (rc *refCountedTree) acquire() {
+	rc.refs.Add(1)
+}
+
+func (rc *refCountedTree) release() {
+	if n := rc.refs.Add(-1); n == 0 {
+		if rc.tree != nil {
+			rc.tree.Close()
+		}
+	} else if n < 0 {
+		panic("refCountedTree: negative ref count")
+	}
+}
 
 // BaseDocument provides common document functionality that language-specific documents can embed.
 // Always use NewBaseDocument to construct; a zero-value BaseDocument will panic.
@@ -33,7 +61,7 @@ type BaseDocument struct {
 	content      string
 	version      int32
 	language     string
-	tree         *ts.Tree
+	rcTree       *refCountedTree
 	parser       *ts.Parser
 	scriptTags   []types.ScriptTag
 	returnParser func(*ts.Parser)
@@ -83,21 +111,45 @@ func (d *BaseDocument) Language() string {
 	return d.language
 }
 
-// Tree returns the document's syntax tree
+// Tree returns the document's syntax tree for nil checks and use under URI lock.
+// Callers that dereference the tree (call RootNode, iterate matches, etc.)
+// outside of a URI lock MUST use AcquireTree or TreeAndContent instead.
 func (d *BaseDocument) Tree() *ts.Tree {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
-	return d.tree
+	if d.rcTree == nil {
+		return nil
+	}
+	return d.rcTree.tree
 }
 
-// SetTree sets the document's syntax tree (protected method for subclasses)
+// AcquireTree returns the tree and a release function that must be called
+// when the caller is done using the tree. The tree will not be freed until
+// all acquired references are released.
+func (d *BaseDocument) AcquireTree() (*ts.Tree, func()) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	if d.rcTree == nil {
+		return nil, func() {}
+	}
+	d.rcTree.acquire()
+	rc := d.rcTree
+	return rc.tree, rc.release
+}
+
+// SetTree sets the document's syntax tree (protected method for subclasses).
+// The old tree is released; it will be freed when all acquired references are gone.
 func (d *BaseDocument) SetTree(tree *ts.Tree) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	if d.tree != nil {
-		d.tree.Close()
+	if d.rcTree != nil {
+		d.rcTree.release()
 	}
-	d.tree = tree
+	if tree != nil {
+		d.rcTree = newRefCountedTree(tree)
+	} else {
+		d.rcTree = nil
+	}
 }
 
 // SetParser sets the document's parser, returning any previous parser to the pool.
@@ -147,13 +199,14 @@ func (d *BaseDocument) SetScriptTags(scriptTags []types.ScriptTag) {
 }
 
 // Close cleans up document resources, returning the parser to its pool.
+// The tree is released; it will be freed when all acquired references are gone.
 func (d *BaseDocument) Close() {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	if d.tree != nil {
-		d.tree.Close()
-		d.tree = nil
+	if d.rcTree != nil {
+		d.rcTree.release()
+		d.rcTree = nil
 	}
 
 	if d.parser != nil {
@@ -205,16 +258,18 @@ func (d *BaseDocument) FindInlineModuleScript() (protocol.Position, bool) {
 	return protocol.Position{}, false
 }
 
-// TreeAndContent returns the tree and content atomically under one lock.
-// Use this from sub-package methods that need both values consistently.
-//
-// The returned tree is safe to use after the lock releases because
-// DocumentManager serializes all operations on the same URI via per-URI
-// locks, preventing concurrent Close() from freeing the tree mid-use.
-func (d *BaseDocument) TreeAndContent() (*ts.Tree, string) {
+// TreeAndContent returns the tree, content, and a release function atomically.
+// The release function must be called when the caller is done using the tree.
+// The tree will not be freed until all acquired references are released.
+func (d *BaseDocument) TreeAndContent() (*ts.Tree, string, func()) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
-	return d.tree, d.content
+	if d.rcTree == nil {
+		return nil, d.content, func() {}
+	}
+	d.rcTree.acquire()
+	rc := d.rcTree
+	return rc.tree, d.content, rc.release
 }
 
 // ByteRangeToProtocolRange converts byte range to protocol range.

--- a/lsp/document/base/base_document_test.go
+++ b/lsp/document/base/base_document_test.go
@@ -11,22 +11,25 @@ import (
 	tsHtml "github.com/tree-sitter/tree-sitter-html/bindings/go"
 )
 
-func parseHTML(content string) *ts.Tree {
+func parseHTML(t *testing.T, content string) *ts.Tree {
+	t.Helper()
 	parser := ts.NewParser()
 	defer parser.Close()
-	parser.SetLanguage(ts.NewLanguage(tsHtml.Language()))
+	if err := parser.SetLanguage(ts.NewLanguage(tsHtml.Language())); err != nil {
+		t.Fatalf("failed to set language: %v", err)
+	}
 	return parser.Parse([]byte(content), nil)
 }
 
 func TestRefCountedTree_ReleaseFreesTree(t *testing.T) {
-	tree := parseHTML("<div>hello</div>")
+	tree := parseHTML(t,"<div>hello</div>")
 	rc := newRefCountedTree(tree)
 	rc.release()
 	// tree.Close() was called internally; no double-free means success
 }
 
 func TestRefCountedTree_AcquireKeepsTreeAlive(t *testing.T) {
-	tree := parseHTML("<div>hello</div>")
+	tree := parseHTML(t,"<div>hello</div>")
 	rc := newRefCountedTree(tree)
 
 	rc.acquire()
@@ -38,7 +41,7 @@ func TestRefCountedTree_AcquireKeepsTreeAlive(t *testing.T) {
 }
 
 func TestRefCountedTree_UnderflowPanics(t *testing.T) {
-	tree := parseHTML("<div>hello</div>")
+	tree := parseHTML(t,"<div>hello</div>")
 	rc := newRefCountedTree(tree)
 	rc.release() // legitimate release, refs=0, tree closed
 
@@ -48,7 +51,7 @@ func TestRefCountedTree_UnderflowPanics(t *testing.T) {
 }
 
 func TestRefCountedTree_ConcurrentAcquireRelease(t *testing.T) {
-	tree := parseHTML("<p>concurrent</p>")
+	tree := parseHTML(t,"<p>concurrent</p>")
 	rc := newRefCountedTree(tree)
 
 	var wg sync.WaitGroup
@@ -74,13 +77,13 @@ func TestAcquireTree_NilTreeReturnsNoopRelease(t *testing.T) {
 
 func TestAcquireTree_PreventsUseAfterSetTree(t *testing.T) {
 	doc := NewBaseDocument("test.html", "<div>v1</div>", 1, "html", nil, nil)
-	tree1 := parseHTML("<div>v1</div>")
+	tree1 := parseHTML(t,"<div>v1</div>")
 	doc.SetTree(tree1)
 
 	acquired, release := doc.AcquireTree()
 	assert.NotNil(t, acquired)
 
-	tree2 := parseHTML("<div>v2</div>")
+	tree2 := parseHTML(t,"<div>v2</div>")
 	doc.SetTree(tree2) // replaces tree1, but reader still holds ref
 
 	// tree1 should still be usable via the acquired reference

--- a/lsp/document/base/base_document_test.go
+++ b/lsp/document/base/base_document_test.go
@@ -1,13 +1,94 @@
 package base
 
 import (
+	"sync"
 	"testing"
 	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 	ts "github.com/tree-sitter/go-tree-sitter"
+	tsHtml "github.com/tree-sitter/tree-sitter-html/bindings/go"
 )
+
+func parseHTML(content string) *ts.Tree {
+	parser := ts.NewParser()
+	defer parser.Close()
+	parser.SetLanguage(ts.NewLanguage(tsHtml.Language()))
+	return parser.Parse([]byte(content), nil)
+}
+
+func TestRefCountedTree_ReleaseFreesTree(t *testing.T) {
+	tree := parseHTML("<div>hello</div>")
+	rc := newRefCountedTree(tree)
+	rc.release()
+	// tree.Close() was called internally; no double-free means success
+}
+
+func TestRefCountedTree_AcquireKeepsTreeAlive(t *testing.T) {
+	tree := parseHTML("<div>hello</div>")
+	rc := newRefCountedTree(tree)
+
+	rc.acquire()
+	rc.release() // owner releases, but reader still holds
+	// tree should still be usable
+	assert.NotNil(t, tree.RootNode())
+
+	rc.release() // reader releases, tree is now freed
+}
+
+func TestRefCountedTree_UnderflowPanics(t *testing.T) {
+	tree := parseHTML("<div>hello</div>")
+	rc := newRefCountedTree(tree)
+	rc.release() // legitimate release, refs=0, tree closed
+
+	assert.Panics(t, func() {
+		rc.release() // underflow
+	}, "double release should panic")
+}
+
+func TestRefCountedTree_ConcurrentAcquireRelease(t *testing.T) {
+	tree := parseHTML("<p>concurrent</p>")
+	rc := newRefCountedTree(tree)
+
+	var wg sync.WaitGroup
+	for range 50 {
+		rc.acquire()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = tree.RootNode().Kind()
+			rc.release()
+		}()
+	}
+	wg.Wait()
+	rc.release() // owner release, all readers done, tree freed
+}
+
+func TestAcquireTree_NilTreeReturnsNoopRelease(t *testing.T) {
+	doc := NewBaseDocument("test.html", "", 1, "html", nil, nil)
+	tree, release := doc.AcquireTree()
+	assert.Nil(t, tree)
+	assert.NotPanics(t, release)
+}
+
+func TestAcquireTree_PreventsUseAfterSetTree(t *testing.T) {
+	doc := NewBaseDocument("test.html", "<div>v1</div>", 1, "html", nil, nil)
+	tree1 := parseHTML("<div>v1</div>")
+	doc.SetTree(tree1)
+
+	acquired, release := doc.AcquireTree()
+	assert.NotNil(t, acquired)
+
+	tree2 := parseHTML("<div>v2</div>")
+	doc.SetTree(tree2) // replaces tree1, but reader still holds ref
+
+	// tree1 should still be usable via the acquired reference
+	assert.Equal(t, "document", acquired.RootNode().Kind())
+
+	release() // now tree1 can be freed
+	doc.Close()
+}
 
 func TestSetParser_CallbackFiresWithOldParser(t *testing.T) {
 	var returned *ts.Parser
@@ -98,7 +179,8 @@ func TestClose_NilCallbackDoesNotPanic(t *testing.T) {
 func TestTreeAndContent_ReturnsAtomicSnapshot(t *testing.T) {
 	doc := NewBaseDocument("test.html", "<div>hello</div>", 1, "html", nil, nil)
 
-	tree, content := doc.TreeAndContent()
+	tree, content, release := doc.TreeAndContent()
+	defer release()
 
 	assert.Nil(t, tree, "tree should be nil when not set")
 	assert.Equal(t, "<div>hello</div>", content)

--- a/lsp/document/html/document.go
+++ b/lsp/document/html/document.go
@@ -126,10 +126,11 @@ func (d *HTMLDocument) findCustomElements(handler *Handler) ([]types.CustomEleme
 		return elements, nil
 	}
 
-	tree, content := d.TreeAndContent()
+	tree, content, releaseTree := d.TreeAndContent()
 	if tree == nil {
 		return elements, nil
 	}
+	defer releaseTree()
 
 	matcher, err := Q.GetCachedQueryMatcher(handler.queryManager, handler.language, "customElements")
 	if err != nil {
@@ -216,10 +217,11 @@ func (d *HTMLDocument) analyzeCompletionContext(position protocol.Position, hand
 		Type: types.CompletionUnknown,
 	}
 
-	tree, content := d.TreeAndContent()
+	tree, content, releaseTree := d.TreeAndContent()
 	if tree == nil {
 		return analysis
 	}
+	defer releaseTree()
 
 	byteOffset := d.PositionToByteOffset(position, content)
 
@@ -462,10 +464,11 @@ func (d *HTMLDocument) FindModuleScript() (protocol.Position, bool) {
 
 // findHeadInsertionPoint finds insertion point just before </head> using tree-sitter.
 func (d *HTMLDocument) findHeadInsertionPoint(handler *Handler) (protocol.Position, bool) {
-	tree, content := d.TreeAndContent()
+	tree, content, releaseTree := d.TreeAndContent()
 	if tree == nil {
 		return protocol.Position{}, false
 	}
+	defer releaseTree()
 
 	matcher, err := Q.GetCachedQueryMatcher(handler.queryManager, handler.language, "headElements")
 	if err != nil {

--- a/lsp/document/tsx/document.go
+++ b/lsp/document/tsx/document.go
@@ -105,10 +105,11 @@ func (d *TSXDocument) CompletionPrefix(analysis *types.CompletionAnalysis) strin
 
 // findCustomElements finds custom elements in TSX documents
 func (d *TSXDocument) findCustomElements(handler *Handler) ([]types.CustomElementMatch, error) {
-	tree, content := d.TreeAndContent()
+	tree, content, releaseTree := d.TreeAndContent()
 	if tree == nil {
 		return nil, fmt.Errorf("no tree available for document")
 	}
+	defer releaseTree()
 
 	var elements []types.CustomElementMatch
 	elementMap := make(map[string]types.CustomElementMatch)
@@ -179,10 +180,11 @@ func (d *TSXDocument) analyzeCompletionContext(position protocol.Position, handl
 		Type: types.CompletionUnknown,
 	}
 
-	tree, content := d.TreeAndContent()
+	tree, content, releaseTree := d.TreeAndContent()
 	if tree == nil {
 		return analysis
 	}
+	defer releaseTree()
 
 	byteOffset := d.PositionToByteOffset(position, content)
 

--- a/lsp/document/typescript/document.go
+++ b/lsp/document/typescript/document.go
@@ -161,9 +161,10 @@ func (d *TypeScriptDocument) getCachedHTMLTree(templateContent string) *ts.Tree 
 			d.cacheMu.Lock()
 			if cached, exists := d.cachedHTMLTrees[contentHash]; exists && cached != nil && cached.tree != nil {
 				cached.refs++
+				refs := cached.refs
 				tree := cached.tree
 				d.cacheMu.Unlock()
-				helpers.SafeDebugLog("[CACHE] HTML tree cache HIT (hash=%x, refs=%d)", contentHash[:8], cached.refs)
+				helpers.SafeDebugLog("[CACHE] HTML tree cache HIT (hash=%x, refs=%d)", contentHash[:8], refs)
 				return tree
 			}
 			d.cacheMu.Unlock()
@@ -274,10 +275,11 @@ func (d *TypeScriptDocument) findCustomElements(handler *Handler) ([]types.Custo
 		currentVersion, d.cacheVersion, d.cachedCustomElements == nil)
 	d.cacheMu.RUnlock()
 
-	tree, docContent := d.TreeAndContent()
+	tree, docContent, releaseTree := d.TreeAndContent()
 	if tree == nil {
 		return nil, fmt.Errorf("no tree available for document")
 	}
+	defer releaseTree()
 
 	var elements []types.CustomElementMatch
 
@@ -322,10 +324,11 @@ func (d *TypeScriptDocument) findHTMLTemplates(handler *Handler) ([]TemplateCont
 		currentVersion, d.cacheVersion, d.cachedTemplates == nil)
 	d.cacheMu.RUnlock()
 
-	tree, content := d.TreeAndContent()
+	tree, content, releaseTree := d.TreeAndContent()
 	if tree == nil {
 		return nil, fmt.Errorf("no tree available")
 	}
+	defer releaseTree()
 
 	var templates []TemplateContext
 
@@ -498,10 +501,11 @@ func (d *TypeScriptDocument) analyzeCompletionContext(
 		Type: types.CompletionUnknown,
 	}
 
-	tree, content := d.TreeAndContent()
+	tree, content, releaseTree := d.TreeAndContent()
 	if tree == nil {
 		return analysis
 	}
+	defer releaseTree()
 
 	byteOffset := d.PositionToByteOffset(position, content)
 

--- a/lsp/document/typescript/document.go
+++ b/lsp/document/typescript/document.go
@@ -153,24 +153,18 @@ func (d *TypeScriptDocument) ReleaseCachedHTMLTree(tree *ts.Tree) {
 func (d *TypeScriptDocument) getCachedHTMLTree(templateContent string) *ts.Tree {
 	contentHash := sha256.Sum256([]byte(templateContent))
 
-	d.cacheMu.RLock()
+	d.cacheMu.Lock()
 	if d.cachedHTMLTrees != nil {
 		if cached, exists := d.cachedHTMLTrees[contentHash]; exists && cached != nil && cached.tree != nil {
-			d.cacheMu.RUnlock()
-
-			d.cacheMu.Lock()
-			if cached, exists := d.cachedHTMLTrees[contentHash]; exists && cached != nil && cached.tree != nil {
-				cached.refs++
-				refs := cached.refs
-				tree := cached.tree
-				d.cacheMu.Unlock()
-				helpers.SafeDebugLog("[CACHE] HTML tree cache HIT (hash=%x, refs=%d)", contentHash[:8], refs)
-				return tree
-			}
+			cached.refs++
+			refs := cached.refs
+			tree := cached.tree
 			d.cacheMu.Unlock()
+			helpers.SafeDebugLog("[CACHE] HTML tree cache HIT (hash=%x, refs=%d)", contentHash[:8], refs)
+			return tree
 		}
 	}
-	d.cacheMu.RUnlock()
+	d.cacheMu.Unlock()
 
 	helpers.SafeDebugLog("[CACHE] HTML tree cache MISS (hash=%x, content length=%d)", contentHash[:8], len(templateContent))
 

--- a/lsp/document_test.go
+++ b/lsp/document_test.go
@@ -456,7 +456,6 @@ const template = html` + "`" + `
 }
 
 func TestDocument_CachedHTMLTreeRefCounting_Concurrent(t *testing.T) {
-	t.Skip("Skipping flaky test - tree-sitter query cursors are not thread-safe, causing segfaults in concurrent access")
 	// This test verifies that reference counting prevents use-after-free bugs
 	// when multiple goroutines access cached HTML trees while cache is being invalidated
 	dm, err := document.NewDocumentManager()

--- a/lsp/methods/textDocument/completion/completion.go
+++ b/lsp/methods/textDocument/completion/completion.go
@@ -695,7 +695,8 @@ func getSlotAttributeCompletions(ctx types.ServerContext, doc types.Document, po
 // findParentElementTag attempts to find the parent element tag name containing the current position
 func findParentElementTag(doc types.Document, position protocol.Position) string {
 	// Try tree-sitter approach first (fast O(log n))
-	if tree := doc.Tree(); tree != nil {
+	if tree, releaseTree := doc.AcquireTree(); tree != nil {
+		defer releaseTree()
 		content, err := doc.Content()
 		if err == nil {
 			// Convert position to byte offset

--- a/lsp/methods/textDocument/publishDiagnostics/attributeDiagnostics.go
+++ b/lsp/methods/textDocument/publishDiagnostics/attributeDiagnostics.go
@@ -128,11 +128,11 @@ func AnalyzeAttributeDiagnosticsForTest(ctx types.ServerContext, doc types.Docum
 func findAttributes(ctx types.ServerContext, doc types.Document, content string) ([]AttributeMatch, error) {
 	var matches []AttributeMatch
 
-	// Get the tree-sitter tree
-	tree := doc.Tree()
+	tree, releaseTree := doc.AcquireTree()
 	if tree == nil {
 		return nil, fmt.Errorf("no tree-sitter tree available")
 	}
+	defer releaseTree()
 
 	// Get query manager from context
 	qm, err := ctx.QueryManager()

--- a/lsp/methods/textDocument/publishDiagnostics/slotDiagnostics.go
+++ b/lsp/methods/textDocument/publishDiagnostics/slotDiagnostics.go
@@ -187,7 +187,8 @@ func findSlotAttributes(content string) []SlotMatch {
 // findParentElement finds the parent custom element for a slotted element
 // using tree-sitter AST traversal, with a string-scanning fallback.
 func findParentElement(doc types.Document, position protocol.Position) string {
-	if tree := doc.Tree(); tree != nil {
+	if tree, releaseTree := doc.AcquireTree(); tree != nil {
+		defer releaseTree()
 		if tag := findParentElementTreeSitter(doc, tree, position); tag != "" {
 			return tag
 		}

--- a/lsp/types/document.go
+++ b/lsp/types/document.go
@@ -58,8 +58,9 @@ type Document interface {
 	Close()                                                                          // Clean up document resources
 
 	// Tree-sitter methods for incremental parsing support
-	Tree() *ts.Tree                              // Get the current syntax tree
-	SetTree(tree *ts.Tree)                       // Set the syntax tree
+	Tree() *ts.Tree              // Get the current syntax tree (for nil checks and use under URI lock only)
+	AcquireTree() (*ts.Tree, func()) // Get tree with ref counting; caller must call the release func when done
+	SetTree(tree *ts.Tree)       // Set the syntax tree
 	Parser() *ts.Parser                          // Get the tree-sitter parser
 	SetParser(parser *ts.Parser)                 // Set the tree-sitter parser
 	UpdateContent(content string, version int32) // Update document content


### PR DESCRIPTION
## Summary

- Add `refCountedTree` with atomic ref counting to `BaseDocument` so tree-sitter `*ts.Tree` objects (C-allocated memory) stay alive until all readers release
- `TreeAndContent()` now returns a release func; add `AcquireTree()` to `Document` interface
- Convert 3 unsafe `Tree()` callers in completion/diagnostics to `AcquireTree()`
- Fix pre-existing data race in `getCachedHTMLTree` (`cached.refs` read outside lock)
- Unskip `TestDocument_CachedHTMLTreeRefCounting_Concurrent`

Closes #313

## Test plan

- [x] All 2515 Go tests pass with `-race -count=1`
- [x] `TestDefinitionConcurrentAccess` passes under `-race -count=5`
- [x] `TestDocument_CachedHTMLTreeRefCounting_Concurrent` passes under `-race -count=3`
- [x] New unit tests for `refCountedTree` (lifecycle, underflow panic, concurrent access, SetTree-while-reader-holds-ref)
- [x] `golangci-lint` and `go vet` clean on changed packages

<!-- @coderabbitai ignore -->