### PR TITLE
test: harden frontend test infrastructure and parallelize CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,25 @@ jobs:
         run: make test-unit
       - name: Run E2E tests
         run: make test-e2e
+
+  test-frontend:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+        env:
+          GOTOOLCHAIN: auto
+          GOEXPERIMENT: jsonv2
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+      - name: Install Go dependencies
+        run: go get .
+      - name: Build cem binary
+        run: make build
       - name: Install frontend dependencies
         run: cd serve && npm ci
       - name: Cache Playwright browsers
@@ -47,5 +66,7 @@ jobs:
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: cd serve && npx playwright install --with-deps
+      - name: Install Playwright system dependencies
+        run: cd serve && npx playwright install-deps
       - name: Run frontend tests
         run: make test-frontend

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,6 @@ install-frontend:
 
 test-frontend: install-frontend build
 	@set -e; \
-	WORKDIR=$$(pwd); \
 	PIDFILE=$$(mktemp); \
 	LOGFILE=$$(mktemp); \
 	cleanup() { \
@@ -158,16 +157,20 @@ test-frontend: install-frontend build
 		rm -f "$$PIDFILE" "$$LOGFILE"; \
 	}; \
 	trap cleanup EXIT INT TERM; \
-	echo "Starting cem serve on port 9876 for tests..."; \
-	(cd serve/testdata/demo-routing && exec ../../../dist/cem serve --port 9876) > "$$LOGFILE" 2>&1 & \
+	echo "Starting cem serve on dynamic port for tests..."; \
+	(cd serve/testdata/demo-routing && exec ../../../dist/cem serve --port 0) > "$$LOGFILE" 2>&1 & \
 	echo $$! > "$$PIDFILE"; \
 	echo "Waiting for server to be ready..."; \
 	TIMEOUT=30; \
 	ELAPSED=0; \
+	PORT=""; \
 	while [ $$ELAPSED -lt $$TIMEOUT ]; do \
-		if nc -z localhost 9876 2>/dev/null || \
-		   (command -v curl >/dev/null 2>&1 && curl -s http://localhost:9876 >/dev/null 2>&1); then \
-			echo "Server is ready."; \
+		if [ -z "$$PORT" ]; then \
+			PORT=$$(grep -oP 'localhost:\K[0-9]+' "$$LOGFILE" 2>/dev/null | head -1); \
+		fi; \
+		if [ -n "$$PORT" ] && \
+		   curl -sf "http://localhost:$$PORT/__cem/api/health" >/dev/null 2>&1; then \
+			echo "Server is ready on port $$PORT."; \
 			break; \
 		fi; \
 		sleep 0.5; \
@@ -180,7 +183,7 @@ test-frontend: install-frontend build
 		exit 1; \
 	fi; \
 	echo "Running frontend tests..."; \
-	cd serve && npm test; \
+	cd serve && CEM_TEST_PORT=$$PORT npm test; \
 	TEST_EXIT=$$?; \
 	exit $$TEST_EXIT
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -307,7 +307,9 @@ var serveCmd = &cobra.Command{
 		if reload {
 			reloadStatus = " (live reload enabled)"
 		}
-		log.Info("Server started on http://localhost:%d%s", port, reloadStatus)
+		// Use actual port (may differ from requested when --port 0)
+		actualPort := server.Port()
+		log.Info("Server started on http://localhost:%d%s", actualPort, reloadStatus)
 
 		// Update status with running info (with colors)
 		reloadColor := pterm.FgRed.Sprint("false")
@@ -315,7 +317,7 @@ var serveCmd = &cobra.Command{
 			reloadColor = pterm.FgGreen.Sprint("true")
 		}
 		statusMsg := fmt.Sprintf("Running on %s%s Live reload: %s %s Press %s for help, %s to quit",
-			pterm.FgCyan.Sprintf("http://localhost:%d", port),
+			pterm.FgCyan.Sprintf("http://localhost:%d", actualPort),
 			pterm.FgGray.Sprint(" |"),
 			reloadColor,
 			pterm.FgGray.Sprint("|"),
@@ -331,7 +333,7 @@ var serveCmd = &cobra.Command{
 		quitChan := make(chan struct{})
 		go func() {
 			time.Sleep(100 * time.Millisecond)
-			handleKeyboardInput(server, log, port, quitChan)
+			handleKeyboardInput(server, log, actualPort, quitChan)
 		}()
 
 		// Wait for quit signal (keyboard or interrupt)

--- a/serve/server.go
+++ b/serve/server.go
@@ -154,6 +154,8 @@ func NewServerWithConfig(config Config) (*Server, error) {
 
 // Port returns the server's port
 func (s *Server) Port() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.port
 }
 
@@ -253,6 +255,11 @@ func (s *Server) Start() error {
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", s.port))
 	if err != nil {
 		return fmt.Errorf("failed to bind port %d: %w", s.port, err)
+	}
+
+	// When port 0 is requested, update to the actual port assigned by the OS
+	if s.port == 0 {
+		s.port = listener.Addr().(*net.TCPAddr).Port
 	}
 
 	// Limit total concurrent connections to prevent resource exhaustion

--- a/serve/server_test.go
+++ b/serve/server_test.go
@@ -150,6 +150,29 @@ func TestServerConfig(t *testing.T) {
 	}
 }
 
+// TestServerDynamicPort verifies port 0 assigns an ephemeral port
+func TestServerDynamicPort(t *testing.T) {
+	server, err := serve.NewServer(0)
+	if err != nil {
+		t.Fatalf("Failed to create server: %v", err)
+	}
+	defer func() { _ = server.Close() }()
+
+	if server.Port() != 0 {
+		t.Errorf("Expected port 0 before Start(), got %d", server.Port())
+	}
+
+	err = server.Start()
+	if err != nil {
+		t.Fatalf("Failed to start server: %v", err)
+	}
+
+	if server.Port() == 0 {
+		t.Error("Expected non-zero port after Start()")
+	}
+	t.Logf("Dynamic port assigned: %d", server.Port())
+}
+
 // TestServerLifecycle verifies start/stop behavior
 func TestServerLifecycle(t *testing.T) {
 	server, err := serve.NewServer(8003)

--- a/serve/web-test-runner.config.js
+++ b/serve/web-test-runner.config.js
@@ -3,6 +3,8 @@ import { visualRegressionPlugin } from '@web/test-runner-visual-regression/plugi
 
 const updateGoldens = process.argv.includes('--update-goldens');
 
+const cemPort = process.env.CEM_TEST_PORT || '9876';
+
 export default {
   files: [
     'middleware/routes/templates/**/*.test.js',
@@ -49,12 +51,15 @@ export default {
       baseDir: 'middleware/routes/testdata/frontend/visual-goldens',
     }),
   ],
+  browserStartTimeout: 30000,
+  testsStartTimeout: 20000,
+  testsFinishTimeout: 60000,
   // Proxy /__cem/ routes to real cem serve instance
   middleware: [
     async (ctx, next) => {
       if (ctx.url.startsWith('/__cem/')) {
-        // Proxy to real cem serve running on port 9876
-        const proxyUrl = `http://localhost:9876${ctx.url}`;
+        // Proxy to real cem serve instance
+        const proxyUrl = `http://localhost:${cemPort}${ctx.url}`;
         try {
           const response = await fetch(proxyUrl);
           ctx.status = response.status;


### PR DESCRIPTION
## Summary

- Add dynamic port allocation (`--port 0`) to `cem serve`, preventing port collisions in test runs
- Replace bare TCP connect (`nc -z`) with `/__cem/api/health` endpoint for server readiness checking
- Pass dynamic port to web-test-runner via `CEM_TEST_PORT` env var
- Add WTR timeout configuration (`browserStartTimeout`, `testsStartTimeout`, `testsFinishTimeout`) for transient browser failures
- Split frontend tests into parallel CI job, bump `actions/setup-node` to v6, add `playwright install-deps` step
- Add `Port()` RLock for thread safety consistent with other getters

## Test plan

- [x] `TestServerDynamicPort` verifies port 0 assigns ephemeral port and `Port()` returns it
- [x] All concurrency tests pass under `-race` (3x each)
- [x] `golangci-lint run ./...` clean (no new issues)
- [x] `go vet ./...` clean
- [x] `actionlint` passes on updated workflow

Closes #314

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced CI/CD pipeline with frontend test automation and Playwright configuration.
  * Added test coverage for dynamic port assignment.

* **Chores**
  * Improved server port handling to support dynamic port selection from the operating system.
  * Updated test runner configuration to use dynamically assigned ports and added explicit timeout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->