### PR TITLE
fix(generate): auto-derive tag aliases from common prefix

### DIFF
--- a/generate/demodiscovery/discovery_test.go
+++ b/generate/demodiscovery/discovery_test.go
@@ -255,6 +255,40 @@ func TestGenerateFallbackURL(t *testing.T) {
 			tagAliases: map[string]string{},
 			expected:   "https://site.com/elements/button/demo/primary/",
 		},
+		{
+			name: "auto-derived alias strips prefix in URL template",
+			config: &C.CemConfig{
+				Generate: C.GenerateConfig{
+					DemoDiscovery: C.DemoDiscoveryConfig{
+						URLPattern:  "/elements/:tag/demo/:demo.html",
+						URLTemplate: "https://site.com/elements/{{.tag | alias | slug}}/demo/{{.demo}}/",
+					},
+				},
+			},
+			demoPath: "/elements/ex-textarea/demo/index.html",
+			tagAliases: AutoDeriveAliases(
+				[]string{"ex-button", "ex-accordion", "ex-textarea"},
+				map[string]string{},
+			),
+			expected: "https://site.com/elements/textarea/demo/",
+		},
+		{
+			name: "auto-derived alias respects explicit override",
+			config: &C.CemConfig{
+				Generate: C.GenerateConfig{
+					DemoDiscovery: C.DemoDiscoveryConfig{
+						URLPattern:  "/elements/:tag/demo/:demo.html",
+						URLTemplate: "https://site.com/elements/{{.tag | alias | slug}}/demo/{{.demo}}/",
+					},
+				},
+			},
+			demoPath: "/elements/ex-cta/demo/index.html",
+			tagAliases: AutoDeriveAliases(
+				[]string{"ex-cta", "ex-button", "ex-textarea"},
+				map[string]string{"ex-cta": "call-to-action"},
+			),
+			expected: "https://site.com/elements/call-to-action/demo/",
+		},
 	}
 
 	for _, tt := range tests {

--- a/generate/demodiscovery/prefix.go
+++ b/generate/demodiscovery/prefix.go
@@ -1,0 +1,62 @@
+/*
+Copyright © 2025 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package demodiscovery
+
+import (
+	"maps"
+	"strings"
+)
+
+// DetectTagPrefix finds the common first-segment prefix shared by all tag names.
+// Returns "prefix-" if all tags start with the same segment before the first hyphen,
+// or "" if fewer than 2 tags or no common prefix.
+func DetectTagPrefix(tagNames []string) string {
+	if len(tagNames) < 2 {
+		return ""
+	}
+	first := tagNames[0]
+	idx := strings.Index(first, "-")
+	if idx < 0 {
+		return ""
+	}
+	prefix := first[:idx+1]
+	for _, tag := range tagNames[1:] {
+		if !strings.HasPrefix(tag, prefix) {
+			return ""
+		}
+	}
+	return prefix
+}
+
+// AutoDeriveAliases returns a merged alias map: explicit aliases from existingAliases
+// plus auto-derived aliases for any tag name that lacks one.
+// Auto-derivation strips the common tag prefix detected from tagNames.
+func AutoDeriveAliases(tagNames []string, existingAliases map[string]string) map[string]string {
+	result := make(map[string]string, len(existingAliases))
+	maps.Copy(result, existingAliases)
+	prefix := DetectTagPrefix(tagNames)
+	if prefix == "" {
+		return result
+	}
+	for _, tag := range tagNames {
+		if _, ok := result[tag]; ok {
+			continue
+		}
+		result[tag] = strings.TrimPrefix(tag, prefix)
+	}
+	return result
+}

--- a/generate/demodiscovery/prefix_test.go
+++ b/generate/demodiscovery/prefix_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright © 2025 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package demodiscovery
+
+import (
+	"testing"
+)
+
+func TestDetectTagPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		tagNames []string
+		expected string
+	}{
+		{
+			name:     "common two-char prefix",
+			tagNames: []string{"ex-button", "ex-accordion", "ex-textarea", "ex-card"},
+			expected: "ex-",
+		},
+		{
+			name:     "common single-char prefix",
+			tagNames: []string{"x-foo", "x-bar"},
+			expected: "x-",
+		},
+		{
+			name:     "multi-segment tags still detect first-segment prefix",
+			tagNames: []string{"ns-accordion", "ns-accordion-header", "ns-navigation-primary"},
+			expected: "ns-",
+		},
+		{
+			name:     "no common prefix",
+			tagNames: []string{"my-button", "your-panel", "their-card"},
+			expected: "",
+		},
+		{
+			name:     "single element cannot determine prefix",
+			tagNames: []string{"ex-button"},
+			expected: "",
+		},
+		{
+			name:     "empty list",
+			tagNames: []string{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetectTagPrefix(tt.tagNames)
+			if got != tt.expected {
+				t.Errorf("DetectTagPrefix(%v) = %q, want %q", tt.tagNames, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAutoDeriveAliases(t *testing.T) {
+	tests := []struct {
+		name     string
+		tagNames []string
+		existing map[string]string
+		expected map[string]string
+	}{
+		{
+			name:     "strips detected prefix",
+			tagNames: []string{"ex-button", "ex-accordion", "ex-textarea"},
+			existing: map[string]string{},
+			expected: map[string]string{
+				"ex-button":    "button",
+				"ex-accordion": "accordion",
+				"ex-textarea":  "textarea",
+			},
+		},
+		{
+			name:     "explicit alias takes precedence",
+			tagNames: []string{"ex-cta", "ex-button", "ex-textarea"},
+			existing: map[string]string{"ex-cta": "call-to-action"},
+			expected: map[string]string{
+				"ex-cta":      "call-to-action",
+				"ex-button":   "button",
+				"ex-textarea": "textarea",
+			},
+		},
+		{
+			name:     "multi-segment remainder preserved",
+			tagNames: []string{"ns-accordion", "ns-accordion-header", "ns-navigation-primary"},
+			existing: map[string]string{},
+			expected: map[string]string{
+				"ns-accordion":          "accordion",
+				"ns-accordion-header":   "accordion-header",
+				"ns-navigation-primary": "navigation-primary",
+			},
+		},
+		{
+			name:     "no common prefix returns only existing aliases",
+			tagNames: []string{"my-button", "your-panel"},
+			existing: map[string]string{"my-button": "btn"},
+			expected: map[string]string{"my-button": "btn"},
+		},
+		{
+			name:     "empty tag names returns existing aliases",
+			tagNames: []string{},
+			existing: map[string]string{"ex-button": "button"},
+			expected: map[string]string{"ex-button": "button"},
+		},
+		{
+			name:     "single element no derivation",
+			tagNames: []string{"ex-button"},
+			existing: map[string]string{},
+			expected: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AutoDeriveAliases(tt.tagNames, tt.existing)
+			if len(got) != len(tt.expected) {
+				t.Errorf("len = %d, want %d\ngot:  %v\nwant: %v", len(got), len(tt.expected), got, tt.expected)
+				return
+			}
+			for k, want := range tt.expected {
+				if gotVal, ok := got[k]; !ok {
+					t.Errorf("missing key %q", k)
+				} else if gotVal != want {
+					t.Errorf("[%q] = %q, want %q", k, gotVal, want)
+				}
+			}
+		})
+	}
+}

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -166,6 +166,17 @@ func postprocess(
 	var errsMu sync.Mutex
 	errsList := make([]error, 0)
 
+	// Auto-derive aliases for elements without explicit @alias
+	var allTagNames []string
+	for i := range modules {
+		for _, decl := range modules[i].Declarations {
+			if ced, ok := decl.(*M.CustomElementDeclaration); ok && ced.TagName != "" {
+				allTagNames = append(allTagNames, ced.TagName)
+			}
+		}
+	}
+	allTagAliases = DD.AutoDeriveAliases(allTagNames, allTagAliases)
+
 	// Build the demo map once
 	cfg, cfgErr := ctx.Config()
 	if cfgErr != nil {

--- a/generate/session_incremental.go
+++ b/generate/session_incremental.go
@@ -132,8 +132,11 @@ func (gs *GenerateSession) ProcessModulesIncrementalWithSkip(ctx context.Context
 		return nil, NewError("updated manifest is nil after incremental processing")
 	}
 
+	// Auto-derive aliases using all tag names from the full manifest
+	allTagAliases := DD.AutoDeriveAliases(updatedManifest.GetAllTagNames(), aliases)
+
 	// Apply demo discovery and design tokens to affected modules only
-	if err := gs.applyPostProcessingToModules(ctx, result, aliases, updatedModules, skipDemoDiscovery); err != nil {
+	if err := gs.applyPostProcessingToModules(ctx, result, allTagAliases, updatedModules, skipDemoDiscovery); err != nil {
 		pterm.Warning.Printf("Incremental post-processing failed: %v\n", err)
 		// Don't fail the entire build for post-processing issues
 	}

--- a/generate/session_test.go
+++ b/generate/session_test.go
@@ -22,6 +22,8 @@ import (
 	"testing/synctest"
 	"time"
 
+	"strings"
+
 	"bennypowers.dev/cem/internal/logging"
 	M "bennypowers.dev/cem/manifest"
 	"bennypowers.dev/cem/types"
@@ -598,5 +600,51 @@ func BenchmarkGenerateSession_ReusedSession(b *testing.B) {
 	for b.Loop() {
 		_, err = session.GenerateFullManifest(context.Background())
 		require.NoError(b, err)
+	}
+}
+
+func TestGenerateSession_IncrementalAutoDeriveAliases(t *testing.T) {
+	ctx := setupTestContext(t, "../examples/intermediate")
+
+	cfg, err := ctx.Config()
+	require.NoError(t, err)
+	cfg.Generate.Files = []string{"elements/**/*.ts"}
+	cfg.Generate.DemoDiscovery.URLTemplate = "https://example.com/elements/{{.tag | alias}}/demo/{{.demo}}/"
+
+	session, err := NewGenerateSession(ctx)
+	require.NoError(t, err)
+	defer session.Close()
+
+	// Full generate first to populate the manifest with all modules
+	fullPkg, err := session.GenerateFullManifest(context.Background())
+	require.NoError(t, err)
+
+	// Verify full generate auto-derived aliases (ui- prefix stripped)
+	for _, tag := range fullPkg.GetAllTagNames() {
+		decl := fullPkg.FindCustomElementDeclaration(tag)
+		require.NotNil(t, decl, "should find declaration for %s", tag)
+		for _, demo := range decl.Demos {
+			assert.False(t, strings.Contains(demo.URL, "/ui-"),
+				"full generate: demo URL %q for %s should not contain /ui-", demo.URL, tag)
+		}
+	}
+
+	// Incremental rebuild of just one module
+	pkg, err := session.ProcessModulesIncrementalWithSkip(
+		context.Background(),
+		[]string{"elements/ui-button/ui-button.ts"},
+		false,
+	)
+	require.NoError(t, err)
+
+	// Verify incremental rebuild also auto-derived aliases
+	buttonDecl := pkg.FindCustomElementDeclaration("ui-button")
+	require.NotNil(t, buttonDecl)
+	require.NotEmpty(t, buttonDecl.Demos, "ui-button should have demos after incremental rebuild")
+	for _, demo := range buttonDecl.Demos {
+		assert.False(t, strings.Contains(demo.URL, "/ui-"),
+			"incremental: demo URL %q should not contain /ui-", demo.URL)
+		assert.True(t, strings.Contains(demo.URL, "/button/"),
+			"incremental: demo URL %q should contain /button/ (alias-stripped)", demo.URL)
 	}
 }


### PR DESCRIPTION
## Summary

- Auto-derive tag aliases by detecting the common first-segment prefix across all custom element tag names in a project
- When no explicit `@alias` is set, strips the detected prefix (e.g., `ex-button` -> `button`) so URL templates like `{{.tag | alias | slug}}` produce correct demo URLs
- Explicit `@alias` tags always take precedence
- Works in both full and incremental (watch-mode) rebuild paths

## Context

Closes #321. In projects like RHDS where most elements share a prefix (`rh-`), new elements without `@alias` would get incorrect demo URLs retaining the prefix. Previously every element needed an explicit `@alias` annotation even for the obvious case of just stripping the prefix.

## Test plan

- [x] Unit tests for `DetectTagPrefix` (6 cases: common prefix, single-char, multi-segment, no common, single element, empty)
- [x] Unit tests for `AutoDeriveAliases` (6 cases: strips prefix, explicit precedence, multi-segment remainder, no prefix, empty tags, single element)
- [x] Integration tests in `TestGenerateFallbackURL` (auto-derived alias in URL template, explicit override preserved)
- [x] Integration test for incremental rebuild path (`TestGenerateSession_IncrementalAutoDeriveAliases`)
- [x] Validated against RHDS: demo URLs identical between published cem (with all explicit aliases) and dev cem (with aliases removed, auto-derived)
- [x] `make lint` clean, 3834 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tag aliases are now automatically derived from tag names, eliminating the need for manual alias configuration in most cases. The system intelligently detects common prefixes and generates clean aliases by stripping detected prefixes.

* **Tests**
  * Added comprehensive test coverage for alias auto-derivation in both full manifest generation and incremental module processing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->