### PR TITLE
fix(serve): strip YAML frontmatter before rendering demo pages

### DIFF
--- a/internal/textutil/frontmatter.go
+++ b/internal/textutil/frontmatter.go
@@ -1,0 +1,50 @@
+/*
+Copyright © 2025 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package textutil
+
+import "bytes"
+
+// StripFrontmatter removes YAML frontmatter (delimited by "---") from content,
+// returning only the content after the closing delimiter.
+// If no frontmatter is present, returns the original content unchanged.
+func StripFrontmatter(content []byte) []byte {
+	trimmed := bytes.TrimLeft(content, " \t\r\n")
+
+	var openLen int
+	switch {
+	case bytes.HasPrefix(trimmed, []byte("---\n")):
+		openLen = 4
+	case bytes.HasPrefix(trimmed, []byte("---\r\n")):
+		openLen = 5
+	default:
+		return content
+	}
+
+	rest := trimmed[openLen:]
+	_, after, found := bytes.Cut(rest, []byte("\n---"))
+	if !found {
+		return content
+	}
+
+	if len(after) > 0 && after[0] == '\n' {
+		after = after[1:]
+	} else if len(after) > 1 && after[0] == '\r' && after[1] == '\n' {
+		after = after[2:]
+	}
+
+	return after
+}

--- a/internal/textutil/frontmatter.go
+++ b/internal/textutil/frontmatter.go
@@ -35,16 +35,27 @@ func StripFrontmatter(content []byte) []byte {
 	}
 
 	rest := trimmed[openLen:]
-	_, after, found := bytes.Cut(rest, []byte("\n---"))
-	if !found {
-		return content
+
+	for i := range len(rest) {
+		if rest[i] != '\n' {
+			continue
+		}
+		line := rest[i+1:]
+		if !bytes.HasPrefix(line, []byte("---")) {
+			continue
+		}
+		after := line[3:]
+		switch {
+		case len(after) == 0:
+			return after
+		case after[0] == '\n':
+			return after[1:]
+		case after[0] == '\r' && len(after) > 1 && after[1] == '\n':
+			return after[2:]
+		default:
+			continue
+		}
 	}
 
-	if len(after) > 0 && after[0] == '\n' {
-		after = after[1:]
-	} else if len(after) > 1 && after[0] == '\r' && after[1] == '\n' {
-		after = after[2:]
-	}
-
-	return after
+	return content
 }

--- a/internal/textutil/frontmatter_test.go
+++ b/internal/textutil/frontmatter_test.go
@@ -67,9 +67,9 @@ func TestStripFrontmatter(t *testing.T) {
 			want:  "",
 		},
 		{
-			name:  "closing delimiter followed by lone CR",
+			name:  "closing delimiter followed by lone CR not treated as delimiter",
 			input: "---\nfield: value\n---\r<content>",
-			want:  "\r<content>",
+			want:  "---\nfield: value\n---\r<content>",
 		},
 		{
 			name:  "triple dash in HTML content not stripped",
@@ -80,6 +80,31 @@ func TestStripFrontmatter(t *testing.T) {
 			name:  "frontmatter then body with triple dash",
 			input: "---\ndescription: A demo\n---\n<div>---</div>\n<my-element>content</my-element>\n",
 			want:  "<div>---</div>\n<my-element>content</my-element>\n",
+		},
+		{
+			name:  "dashes inside YAML value not treated as delimiter",
+			input: "---\ndescription: foo---bar\n---\n<my-element>content</my-element>\n",
+			want:  "<my-element>content</my-element>\n",
+		},
+		{
+			name:  "line starting with dashes but not exactly three",
+			input: "---\ndescription: |\n  ----\n---\n<my-element>content</my-element>\n",
+			want:  "<my-element>content</my-element>\n",
+		},
+		{
+			name:  "line with dashes followed by text not treated as delimiter",
+			input: "---\ndescription: A demo\n---not-a-delimiter\nmore: data\n---\n<my-element>content</my-element>\n",
+			want:  "<my-element>content</my-element>\n",
+		},
+		{
+			name:  "closing delimiter at EOF without trailing newline",
+			input: "---\ndescription: A demo\n---",
+			want:  "",
+		},
+		{
+			name:  "closing delimiter with CRLF at EOF",
+			input: "---\ndescription: A demo\r\n---\r\n",
+			want:  "",
 		},
 	}
 

--- a/internal/textutil/frontmatter_test.go
+++ b/internal/textutil/frontmatter_test.go
@@ -67,8 +67,18 @@ func TestStripFrontmatter(t *testing.T) {
 			want:  "",
 		},
 		{
+			name:  "closing delimiter followed by lone CR",
+			input: "---\nfield: value\n---\r<content>",
+			want:  "\r<content>",
+		},
+		{
 			name:  "triple dash in HTML content not stripped",
 			input: "<div>---</div>\n<my-element>content</my-element>\n",
+			want:  "<div>---</div>\n<my-element>content</my-element>\n",
+		},
+		{
+			name:  "frontmatter then body with triple dash",
+			input: "---\ndescription: A demo\n---\n<div>---</div>\n<my-element>content</my-element>\n",
 			want:  "<div>---</div>\n<my-element>content</my-element>\n",
 		},
 	}

--- a/internal/textutil/frontmatter_test.go
+++ b/internal/textutil/frontmatter_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright © 2025 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package textutil
+
+import (
+	"testing"
+)
+
+func TestStripFrontmatter(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "no frontmatter",
+			input: "<my-element>content</my-element>",
+			want:  "<my-element>content</my-element>",
+		},
+		{
+			name:  "simple frontmatter",
+			input: "---\ndescription: A demo\n---\n<my-element>content</my-element>\n",
+			want:  "<my-element>content</my-element>\n",
+		},
+		{
+			name:  "frontmatter with multiple fields",
+			input: "---\ndescription: Default accordion\nurl: /demo/\nfor: rh-accordion\n---\n<rh-accordion>\n  <rh-accordion-header>Item</rh-accordion-header>\n</rh-accordion>\n",
+			want:  "<rh-accordion>\n  <rh-accordion-header>Item</rh-accordion-header>\n</rh-accordion>\n",
+		},
+		{
+			name:  "frontmatter with CRLF line endings",
+			input: "---\r\ndescription: A demo\r\n---\r\n<my-element>content</my-element>\r\n",
+			want:  "<my-element>content</my-element>\r\n",
+		},
+		{
+			name:  "frontmatter with leading whitespace",
+			input: "\n\n---\ndescription: A demo\n---\n<my-element>content</my-element>\n",
+			want:  "<my-element>content</my-element>\n",
+		},
+		{
+			name:  "no closing delimiter",
+			input: "---\ndescription: broken\n<my-element>content</my-element>\n",
+			want:  "---\ndescription: broken\n<my-element>content</my-element>\n",
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "only frontmatter no content",
+			input: "---\ndescription: Just metadata\n---\n",
+			want:  "",
+		},
+		{
+			name:  "triple dash in HTML content not stripped",
+			input: "<div>---</div>\n<my-element>content</my-element>\n",
+			want:  "<div>---</div>\n<my-element>content</my-element>\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := string(StripFrontmatter([]byte(tt.input)))
+			if got != tt.want {
+				t.Errorf("StripFrontmatter() =\n%q\nwant:\n%q", got, tt.want)
+			}
+		})
+	}
+}

--- a/serve/middleware/routes/chrome_test.go
+++ b/serve/middleware/routes/chrome_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 
 	"bennypowers.dev/cem/internal/platform/testutil"
-	"bennypowers.dev/cem/internal/textutil"
 )
 
 // testTemplates creates a template registry for testing (with nil context)
@@ -289,52 +288,6 @@ func TestChromeRendering_Chromeless(t *testing.T) {
 	if rendered != string(expected) {
 		t.Errorf("Rendered chromeless does not match golden file.\nGot:\n%s\n\nExpected:\n%s", rendered, string(expected))
 		t.Log("Run 'make update' to update golden files")
-	}
-}
-
-// TestChromeRendering_FrontmatterStripped verifies YAML frontmatter is stripped before rendering
-func TestChromeRendering_FrontmatterStripped(t *testing.T) {
-	demoHTML := testutil.LoadFixtureFile(t, filepath.Join("chrome-rendering", "frontmatter-demo.html"))
-
-	// Strip frontmatter the same way renderDemoFromRoute should
-	stripped := textutil.StripFrontmatter(demoHTML)
-
-	rendered, err := renderDemo(testTemplates(), nil, ChromeData{
-		TagName:      "my-element",
-		DemoTitle:    "Frontmatter Example",
-		DemoHTML:     template.HTML(stripped),
-		EnabledKnobs: "attributes properties",
-		ImportMap:    "{}",
-		Description:  "Testing frontmatter stripping",
-	})
-	if err != nil {
-		t.Fatalf("Failed to render chrome: %v", err)
-	}
-
-	// Frontmatter delimiters and content must not appear in output
-	if strings.Contains(rendered, "---\n") || strings.Contains(rendered, "---\r\n") {
-		t.Error("Rendered output contains frontmatter delimiter '---'")
-	}
-	if strings.Contains(rendered, "Default accordion with multiple collapsible panels") {
-		// The description field from frontmatter should not appear in the demo body.
-		// It may appear in the description slot (passed separately), but not as raw text in the demo area.
-		// Check specifically in the demo area
-		demoStart := strings.Index(rendered, `<cem-serve-demo`)
-		demoEnd := strings.Index(rendered, `</cem-serve-demo>`)
-		if demoStart >= 0 && demoEnd > demoStart {
-			demoArea := rendered[demoStart:demoEnd]
-			if strings.Contains(demoArea, "Default accordion with multiple collapsible panels") {
-				t.Error("Frontmatter description leaked into demo rendering area")
-			}
-		}
-	}
-
-	// Actual demo content must still be present
-	if !strings.Contains(rendered, `<my-element id="example"`) {
-		t.Error("Demo content missing from rendered output")
-	}
-	if !strings.Contains(rendered, `<span slot="label">Hello World</span>`) {
-		t.Error("Demo slot content missing from rendered output")
 	}
 }
 

--- a/serve/middleware/routes/chrome_test.go
+++ b/serve/middleware/routes/chrome_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"bennypowers.dev/cem/internal/platform/testutil"
+	"bennypowers.dev/cem/internal/textutil"
 )
 
 // testTemplates creates a template registry for testing (with nil context)
@@ -288,6 +289,52 @@ func TestChromeRendering_Chromeless(t *testing.T) {
 	if rendered != string(expected) {
 		t.Errorf("Rendered chromeless does not match golden file.\nGot:\n%s\n\nExpected:\n%s", rendered, string(expected))
 		t.Log("Run 'make update' to update golden files")
+	}
+}
+
+// TestChromeRendering_FrontmatterStripped verifies YAML frontmatter is stripped before rendering
+func TestChromeRendering_FrontmatterStripped(t *testing.T) {
+	demoHTML := testutil.LoadFixtureFile(t, filepath.Join("chrome-rendering", "frontmatter-demo.html"))
+
+	// Strip frontmatter the same way renderDemoFromRoute should
+	stripped := textutil.StripFrontmatter(demoHTML)
+
+	rendered, err := renderDemo(testTemplates(), nil, ChromeData{
+		TagName:      "my-element",
+		DemoTitle:    "Frontmatter Example",
+		DemoHTML:     template.HTML(stripped),
+		EnabledKnobs: "attributes properties",
+		ImportMap:    "{}",
+		Description:  "Testing frontmatter stripping",
+	})
+	if err != nil {
+		t.Fatalf("Failed to render chrome: %v", err)
+	}
+
+	// Frontmatter delimiters and content must not appear in output
+	if strings.Contains(rendered, "---\n") || strings.Contains(rendered, "---\r\n") {
+		t.Error("Rendered output contains frontmatter delimiter '---'")
+	}
+	if strings.Contains(rendered, "Default accordion with multiple collapsible panels") {
+		// The description field from frontmatter should not appear in the demo body.
+		// It may appear in the description slot (passed separately), but not as raw text in the demo area.
+		// Check specifically in the demo area
+		demoStart := strings.Index(rendered, `<cem-serve-demo`)
+		demoEnd := strings.Index(rendered, `</cem-serve-demo>`)
+		if demoStart >= 0 && demoEnd > demoStart {
+			demoArea := rendered[demoStart:demoEnd]
+			if strings.Contains(demoArea, "Default accordion with multiple collapsible panels") {
+				t.Error("Frontmatter description leaked into demo rendering area")
+			}
+		}
+	}
+
+	// Actual demo content must still be present
+	if !strings.Contains(rendered, `<my-element id="example"`) {
+		t.Error("Demo content missing from rendered output")
+	}
+	if !strings.Contains(rendered, `<span slot="label">Hello World</span>`) {
+		t.Error("Demo slot content missing from rendered output")
 	}
 }
 

--- a/serve/middleware/routes/frontmatter_test.go
+++ b/serve/middleware/routes/frontmatter_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright © 2025 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package routes_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"bennypowers.dev/cem/cmd/config"
+	"bennypowers.dev/cem/health"
+	"bennypowers.dev/cem/internal/platform"
+	M "bennypowers.dev/cem/manifest"
+	"bennypowers.dev/cem/serve/logger"
+	"bennypowers.dev/cem/serve/middleware"
+	"bennypowers.dev/cem/serve/middleware/routes"
+)
+
+type frontmatterTestContext struct {
+	manifest   []byte
+	watchDir   string
+	demoRoutes map[string]*middleware.DemoRouteEntry
+	fs         platform.FileSystem
+}
+
+func (c *frontmatterTestContext) WatchDir() string                                  { return c.watchDir }
+func (c *frontmatterTestContext) IsWorkspace() bool                                 { return false }
+func (c *frontmatterTestContext) WorkspacePackages() []middleware.WorkspacePackage   { return nil }
+func (c *frontmatterTestContext) Manifest() ([]byte, error)                         { return c.manifest, nil }
+func (c *frontmatterTestContext) ImportMap() middleware.ImportMap                    { return nil }
+func (c *frontmatterTestContext) DemoRoutes() map[string]*middleware.DemoRouteEntry  { return c.demoRoutes }
+func (c *frontmatterTestContext) SourceControlRootURL() string                      { return "" }
+func (c *frontmatterTestContext) Logger() logger.Logger                             { return logger.NewDefaultLogger() }
+func (c *frontmatterTestContext) FileSystem() platform.FileSystem                   { return c.fs }
+func (c *frontmatterTestContext) PackageJSON() (*middleware.PackageJSON, error)      { return nil, nil }
+func (c *frontmatterTestContext) BroadcastError(title, message, file string) error   { return nil }
+func (c *frontmatterTestContext) DemoRenderingMode() string                         { return "light" }
+func (c *frontmatterTestContext) URLRewrites() []config.URLRewrite                  { return nil }
+func (c *frontmatterTestContext) PathResolver() middleware.PathResolver              { return nil }
+func (c *frontmatterTestContext) HealthResult() (*health.HealthResult, error)        { return nil, nil }
+func (c *frontmatterTestContext) IsStaticBuild() bool                               { return false }
+
+func TestFrontmatterStrippedFromDemoHTTPResponse(t *testing.T) {
+	demoContent := []byte("---\ndescription: Visible frontmatter bug\n---\n<test-el>content</test-el>\n")
+
+	manifest := map[string]any{
+		"schemaVersion": "1.0.0",
+		"modules": []map[string]any{{
+			"kind": "javascript-module",
+			"path": "src/test-el.ts",
+			"declarations": []map[string]any{{
+				"kind":          "class",
+				"customElement": true,
+				"name":          "TestEl",
+				"tagName":       "test-el",
+				"demos": []map[string]any{{
+					"description": "Frontmatter demo",
+					"url":         "./demo/frontmatter.html",
+				}},
+			}},
+		}},
+	}
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+
+	watchDir := t.TempDir()
+	fs := platform.NewOSFileSystem()
+	demoDir := watchDir + "/demo"
+	if err := fs.MkdirAll(demoDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := fs.WriteFile(demoDir+"/frontmatter.html", demoContent, 0644); err != nil {
+		t.Fatalf("write demo: %v", err)
+	}
+
+	ctx := &frontmatterTestContext{
+		manifest: manifestBytes,
+		watchDir: watchDir,
+		fs:       fs,
+		demoRoutes: map[string]*middleware.DemoRouteEntry{
+			"/demo/frontmatter.html": {
+				TagName:  "test-el",
+				FilePath: "demo/frontmatter.html",
+				Demo: &M.Demo{
+					Description: "Frontmatter demo",
+					URL:         "./demo/frontmatter.html",
+				},
+				LocalRoute: "/demo/frontmatter.html",
+			},
+		},
+	}
+
+	mw := routes.New(routes.Config{Context: ctx})
+	handler := mw(http.NotFoundHandler())
+
+	req := httptest.NewRequest("GET", "/demo/frontmatter.html", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	body := rec.Body.String()
+
+	// Frontmatter must not appear in rendered output
+	if strings.Contains(body, "Visible frontmatter bug") {
+		t.Error("frontmatter description leaked into HTTP response body")
+	}
+
+	// Demo content must be present
+	if !strings.Contains(body, "<test-el>content</test-el>") {
+		t.Error("demo element content missing from HTTP response")
+	}
+}

--- a/serve/middleware/routes/routes.go
+++ b/serve/middleware/routes/routes.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	"bennypowers.dev/cem/health"
+	"bennypowers.dev/cem/internal/textutil"
 	V "bennypowers.dev/cem/internal/version"
 	M "bennypowers.dev/cem/manifest"
 	"bennypowers.dev/cem/serve/logger"
@@ -658,6 +659,8 @@ func renderDemoFromRoute(entry *DemoRouteEntry, queryParams map[string]string, c
 	if err != nil {
 		return "", fmt.Errorf("reading demo file %s: %w", entry.FilePath, err)
 	}
+
+	demoHTML = textutil.StripFrontmatter(demoHTML)
 
 	// Get import map as JSON (pre-computed during server initialization)
 	var importMapJSON string

--- a/serve/middleware/routes/testdata/chrome-rendering/frontmatter-demo.html
+++ b/serve/middleware/routes/testdata/chrome-rendering/frontmatter-demo.html
@@ -1,0 +1,6 @@
+---
+description: Default accordion with multiple collapsible panels.
+---
+<my-element id="example" variant="primary">
+  <span slot="label">Hello World</span>
+</my-element>

--- a/serve/testdata/demo-routing/demo/frontmatter.html
+++ b/serve/testdata/demo-routing/demo/frontmatter.html
@@ -1,0 +1,6 @@
+---
+description: Default element with multiple collapsible panels.
+---
+<my-element id="frontmatter-example">
+  Frontmatter should be stripped
+</my-element>

--- a/serve/testdata/demo-routing/manifest.json
+++ b/serve/testdata/demo-routing/manifest.json
@@ -14,6 +14,10 @@
             {
               "description": "Basic Demo",
               "url": "./demo/basic.html"
+            },
+            {
+              "description": "Frontmatter Demo",
+              "url": "./demo/frontmatter.html"
             }
           ]
         }


### PR DESCRIPTION
## Summary

- Strip YAML frontmatter from demo HTML files before rendering in the dev server
- Frontmatter was parsed at build time for demo metadata discovery but never removed at serve time, causing raw YAML delimiters and content to appear as visible text

## Changes

- `internal/textutil/frontmatter.go` -- new `StripFrontmatter([]byte) []byte` utility
- `serve/middleware/routes/routes.go` -- call `StripFrontmatter` after reading demo file in `renderDemoFromRoute`
- 11 unit test cases for `StripFrontmatter` (LF, CRLF, leading whitespace, lone CR, missing delimiter, empty, metadata-only, body with dashes)
- HTTP integration test (`package routes_test`) exercising the full handler path with a frontmatter demo fixture
- Frontmatter demo fixture added to `serve/testdata/demo-routing/` for live server test infrastructure

Closes #323

## Test plan

- [x] `make lint` -- 0 issues
- [x] `make test-unit` -- all pass (one pre-existing flaky timing test)
- [x] Integration test verified red (fails when `StripFrontmatter` call removed, passes with it)
- [x] Unit tests cover: no frontmatter, simple, multi-field, CRLF, leading whitespace, no closing delimiter, empty, metadata-only, lone CR, triple dash in body, frontmatter + body with dashes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed demo rendering to properly strip YAML frontmatter metadata from demo HTML files, ensuring that frontmatter blocks are no longer visible in the final rendered demo output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->