### PR TITLE
feat: centralize .git pruning into platform.WalkDir

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@ Getter methods should be named `Foo()`, not `GetFoo()`.
 
 When adding debug logs in go code, always use `bennypowers.dev/cem/internal/logging`, to avoid polluting stdio.
 
+Use `platform.WalkDir` for all directory traversals. It silently prunes `.git` directories and accepts additional dirs to skip via `set.Set[string]`. Never use `filepath.WalkDir` or `fs.WalkDir` directly -- those bypass `.git` pruning.
+
 Run `go vet` to surface gopls suggestions. Common examples:
 - replace `interface{}` with `any`
 - replace `if/else` with `min`

--- a/generate/external_types.go
+++ b/generate/external_types.go
@@ -18,6 +18,7 @@ package generate
 
 import (
 	"encoding/json"
+	"io/fs"
 	"maps"
 	"os"
 	"path/filepath"
@@ -28,6 +29,8 @@ import (
 
 	L "bennypowers.dev/cem/internal/logging"
 	"bennypowers.dev/cem/internal/languages/typescript"
+	"bennypowers.dev/cem/internal/platform"
+	"bennypowers.dev/cem/internal/set"
 	M "bennypowers.dev/cem/manifest"
 	Q "bennypowers.dev/cem/internal/treesitter"
 	"bennypowers.dev/cem/types"
@@ -199,16 +202,11 @@ func (r *ExternalTypeResolver) resolveFromWorkspaceSibling(pkgName string) map[s
 
 	aliases := make(map[string]aliasDefinition)
 
-	err := filepath.WalkDir(siblingPath, func(path string, d os.DirEntry, err error) error {
+	err := platform.WalkDir(os.DirFS(siblingPath), ".", set.NewSet("node_modules", "dist"), func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil // skip errors
 		}
-		// Skip directories we don't want
 		if d.IsDir() {
-			base := d.Name()
-			if base == "node_modules" || base == "dist" || base == ".git" {
-				return filepath.SkipDir
-			}
 			return nil
 		}
 		// Only parse .ts/.tsx files (not .d.ts)
@@ -219,9 +217,10 @@ func (r *ExternalTypeResolver) resolveFromWorkspaceSibling(pkgName string) map[s
 			return nil
 		}
 
-		fileAliases, err := r.scanTypeAliasesFromFile(path)
+		fullPath := filepath.Join(siblingPath, path)
+		fileAliases, err := r.scanTypeAliasesFromFile(fullPath)
 		if err != nil {
-			L.Debug("ExternalTypeResolver: error scanning %s: %v", path, err)
+			L.Debug("ExternalTypeResolver: error scanning %s: %v", fullPath, err)
 			return nil
 		}
 		maps.Copy(aliases, fileAliases)

--- a/internal/modulegraph/module_graph.go
+++ b/internal/modulegraph/module_graph.go
@@ -18,14 +18,16 @@ package modulegraph
 
 import (
 	"fmt"
-	"os"
+	"io/fs"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
-	"bennypowers.dev/cem/lsp/helpers"
+	"bennypowers.dev/cem/internal/platform"
+	"bennypowers.dev/cem/internal/set"
 	"bennypowers.dev/cem/internal/treesitter"
+	"bennypowers.dev/cem/lsp/helpers"
 )
 
 // ModuleGraph tracks the import/export relationships between modules
@@ -427,18 +429,15 @@ func (mg *ModuleGraph) BuildFromWorkspace(workspaceRoot string) error {
 	mg.metrics.IncrementCounter("build_workspace_calls")
 
 	// Walk the workspace to find TypeScript/JavaScript files
-	err := mg.fileParser.WalkWorkspace(workspaceRoot, func(path string, info os.FileInfo, err error) error {
+	skipDirs := set.NewSet("node_modules", "dist", "build")
+	wsFS := mg.fileParser.WorkspaceFS(workspaceRoot)
+	err := platform.WalkDir(wsFS, ".", skipDirs, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			mg.metrics.IncrementCounter("file_walk_errors")
 			return err
 		}
 
-		// Skip node_modules and other common directories
-		if info.IsDir() {
-			dirName := info.Name()
-			if dirName == "node_modules" || dirName == ".git" || dirName == "dist" || dirName == "build" {
-				return filepath.SkipDir
-			}
+		if d.IsDir() {
 			return nil
 		}
 
@@ -452,7 +451,8 @@ func (mg *ModuleGraph) BuildFromWorkspace(workspaceRoot string) error {
 
 		// Parse exports from this file
 		parseStart := time.Now()
-		parseErr := mg.parseFileExports(path, workspaceRoot)
+		fullPath := filepath.Join(workspaceRoot, path)
+		parseErr := mg.parseFileExports(fullPath, workspaceRoot)
 		mg.metrics.RecordDuration("file_parse_time", time.Since(parseStart))
 
 		if parseErr != nil {

--- a/internal/modulegraph/module_graph_interfaces.go
+++ b/internal/modulegraph/module_graph_interfaces.go
@@ -17,7 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package modulegraph
 
 import (
-	"path/filepath"
+	"io/fs"
 	"time"
 
 	"bennypowers.dev/cem/internal/treesitter"
@@ -38,8 +38,9 @@ const DefaultMaxTransitiveDepth = 5
 type FileParser interface {
 	// ReadFile reads the content of a file at the given path
 	ReadFile(path string) ([]byte, error)
-	// WalkWorkspace walks through a workspace directory calling the walkFn for each file
-	WalkWorkspace(workspaceRoot string, walkFn filepath.WalkFunc) error
+	// WorkspaceFS returns an fs.FS rooted at the given workspace directory.
+	// Callers must use platform.WalkDir to walk it.
+	WorkspaceFS(workspaceRoot string) fs.FS
 }
 
 // ExportParser interface abstracts the parsing of export statements from content

--- a/internal/modulegraph/module_graph_parsers.go
+++ b/internal/modulegraph/module_graph_parsers.go
@@ -18,14 +18,13 @@ package modulegraph
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
-	"path/filepath"
 	"strings"
-	"time"
 
 	"bennypowers.dev/cem/internal/languages/typescript"
-	"bennypowers.dev/cem/lsp/helpers"
 	"bennypowers.dev/cem/internal/treesitter"
+	"bennypowers.dev/cem/lsp/helpers"
 	ts "github.com/tree-sitter/go-tree-sitter"
 )
 
@@ -37,54 +36,11 @@ func (p *OSFileParser) ReadFile(path string) ([]byte, error) {
 	return os.ReadFile(path)
 }
 
-// WalkWorkspace implements FileParser using filepath.Walk
-func (p *OSFileParser) WalkWorkspace(workspaceRoot string, walkFn filepath.WalkFunc) error {
-	return filepath.Walk(workspaceRoot, walkFn)
+// WorkspaceFS returns an os.DirFS rooted at the workspace directory.
+func (p *OSFileParser) WorkspaceFS(workspaceRoot string) fs.FS {
+	return os.DirFS(workspaceRoot)
 }
 
-// MockFileParser implements FileParser for testing with in-memory file systems
-type MockFileParser struct {
-	Files map[string][]byte // Map of file paths to their contents
-}
-
-// ReadFile implements FileParser by returning content from the in-memory map
-func (p *MockFileParser) ReadFile(path string) ([]byte, error) {
-	content, exists := p.Files[path]
-	if !exists {
-		return nil, os.ErrNotExist
-	}
-	return content, nil
-}
-
-// WalkWorkspace implements FileParser by iterating through the in-memory file map
-func (p *MockFileParser) WalkWorkspace(workspaceRoot string, walkFn filepath.WalkFunc) error {
-	// Create a simplified mock directory structure
-	// In real usage, this would simulate proper filesystem traversal
-	for path := range p.Files {
-		// Create a mock FileInfo for each file
-		info := &mockFileInfo{name: filepath.Base(path), isDir: false}
-		if err := walkFn(path, info, nil); err != nil {
-			if err == filepath.SkipDir {
-				continue // Skip this path
-			}
-			return err
-		}
-	}
-	return nil
-}
-
-// mockFileInfo implements os.FileInfo for testing
-type mockFileInfo struct {
-	name  string
-	isDir bool
-}
-
-func (m *mockFileInfo) Name() string       { return m.name }
-func (m *mockFileInfo) Size() int64        { return 0 }
-func (m *mockFileInfo) Mode() os.FileMode  { return 0644 }
-func (m *mockFileInfo) ModTime() time.Time { return time.Time{} }
-func (m *mockFileInfo) IsDir() bool        { return m.isDir }
-func (m *mockFileInfo) Sys() any            { return nil }
 
 // DefaultExportParser implements ExportParser using tree-sitter queries
 type DefaultExportParser struct{}

--- a/internal/platform/filesystem.go
+++ b/internal/platform/filesystem.go
@@ -42,7 +42,7 @@ type FileSystem interface {
 	Stat(name string) (fs.FileInfo, error)
 	Exists(path string) bool
 
-	// fs.FS compatibility - allows use with fs.WalkDir
+	// fs.FS compatibility - allows use with platform.WalkDir
 	Open(name string) (fs.File, error)
 }
 

--- a/internal/platform/testutil/fixtures.go
+++ b/internal/platform/testutil/fixtures.go
@@ -60,8 +60,7 @@ func NewFixtureFS(t *testing.T, fixtureDir string, rootPath string) *platform.Ma
 
 	// Walk fixture directory and load all files into memory
 	// Callback returns errors immediately to terminate on first failure
-	err := filepath.WalkDir(fixturePath, func(path string, d fs.DirEntry, err error) error {
-		// Propagate any errors from WalkDir (e.g., permission denied)
+	err := platform.WalkDir(os.DirFS(fixturePath), ".", nil, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -69,20 +68,12 @@ func NewFixtureFS(t *testing.T, fixtureDir string, rootPath string) *platform.Ma
 			return nil
 		}
 
-		// Read fixture file
-		content, err := os.ReadFile(path)
+		content, err := os.ReadFile(filepath.Join(fixturePath, path))
 		if err != nil {
 			return err
 		}
 
-		// Get relative path from fixture directory
-		relPath, err := filepath.Rel(fixturePath, path)
-		if err != nil {
-			return err
-		}
-
-		// Map to virtual filesystem at rootPath
-		virtualPath := filepath.Join(rootPath, relPath)
+		virtualPath := filepath.Join(rootPath, path)
 		mfs.AddFile(virtualPath, string(content), 0644)
 
 		return nil

--- a/internal/platform/walkdir.go
+++ b/internal/platform/walkdir.go
@@ -1,0 +1,40 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package platform
+
+import (
+	"io/fs"
+
+	"bennypowers.dev/cem/internal/set"
+)
+
+var defaultSkipDirs = set.NewSet(".git")
+
+// WalkDir walks the file tree rooted at root on fsys, silently pruning
+// .git directories and any additional directories in skip.
+// All other behavior matches fs.WalkDir.
+func WalkDir(fsys fs.FS, root string, skip set.Set[string], fn fs.WalkDirFunc) error {
+	return fs.WalkDir(fsys, root, func(path string, d fs.DirEntry, err error) error {
+		if d != nil && d.IsDir() {
+			name := d.Name()
+			if defaultSkipDirs.Has(name) || skip.Has(name) {
+				return fs.SkipDir
+			}
+		}
+		return fn(path, d, err)
+	})
+}

--- a/internal/platform/walkdir_test.go
+++ b/internal/platform/walkdir_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package platform_test
+
+import (
+	"errors"
+	"io/fs"
+	"slices"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"bennypowers.dev/cem/internal/platform"
+	"bennypowers.dev/cem/internal/set"
+)
+
+func TestWalkDir(t *testing.T) {
+	fsys := fstest.MapFS{
+		"src/main.go":                    &fstest.MapFile{},
+		"src/util.go":                    &fstest.MapFile{},
+		".git/HEAD":                      &fstest.MapFile{},
+		".git/refs/heads/main":           &fstest.MapFile{},
+		"sub/.git/HEAD":                  &fstest.MapFile{},
+		"node_modules/foo/index.js":      &fstest.MapFile{},
+		"dist/bundle.js":                 &fstest.MapFile{},
+		"lib/helper.go":                  &fstest.MapFile{},
+	}
+
+	t.Run("prunes .git at any depth", func(t *testing.T) {
+		var visited []string
+		err := platform.WalkDir(fsys, ".", set.NewSet(".git"), func(path string, d fs.DirEntry, err error) error {
+			visited = append(visited, path)
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, v := range visited {
+			if v == ".git" || v == "sub/.git" || v == ".git/HEAD" || v == ".git/refs/heads/main" || v == "sub/.git/HEAD" {
+				t.Errorf("visited pruned path: %s", v)
+			}
+		}
+		if !slices.Contains(visited, "src/main.go") {
+			t.Error("did not visit src/main.go")
+		}
+	})
+
+	t.Run("prunes multiple dirs", func(t *testing.T) {
+		var visited []string
+		err := platform.WalkDir(fsys, ".", set.NewSet(".git", "node_modules", "dist"), func(path string, d fs.DirEntry, err error) error {
+			visited = append(visited, path)
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		blocked := map[string]bool{".git": true, "node_modules": true, "dist": true}
+		for _, v := range visited {
+			if blocked[v] {
+				t.Errorf("visited pruned dir: %s", v)
+			}
+		}
+	})
+
+	t.Run("passes through normal dirs and files", func(t *testing.T) {
+		want := map[string]bool{"src": false, "src/main.go": false, "lib": false, "lib/helper.go": false}
+		err := platform.WalkDir(fsys, ".", set.NewSet(".git"), func(path string, d fs.DirEntry, err error) error {
+			if _, ok := want[path]; ok {
+				want[path] = true
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for path, seen := range want {
+			if !seen {
+				t.Errorf("did not visit expected path: %s", path)
+			}
+		}
+	})
+
+	t.Run("caller SkipDir composes", func(t *testing.T) {
+		var visited []string
+		err := platform.WalkDir(fsys, ".", set.NewSet(".git"), func(path string, d fs.DirEntry, err error) error {
+			if d.IsDir() && d.Name() == "node_modules" {
+				return fs.SkipDir
+			}
+			visited = append(visited, path)
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, v := range visited {
+			if v == "node_modules" || v == "node_modules/foo/index.js" {
+				t.Errorf("visited caller-skipped path: %s", v)
+			}
+		}
+	})
+
+	t.Run("propagates errors from fn", func(t *testing.T) {
+		sentinel := errors.New("stop")
+		err := platform.WalkDir(fsys, ".", set.NewSet(".git"), func(path string, d fs.DirEntry, err error) error {
+			if path == "src/main.go" {
+				return sentinel
+			}
+			return nil
+		})
+		if !errors.Is(err, sentinel) {
+			t.Errorf("expected sentinel error, got: %v", err)
+		}
+	})
+
+	t.Run("root dot entry not pruned by caller dot-prefix check", func(t *testing.T) {
+		var visited []string
+		err := platform.WalkDir(fsys, ".", nil, func(path string, d fs.DirEntry, err error) error {
+			if d.IsDir() && path != "." && strings.HasPrefix(d.Name(), ".") {
+				return fs.SkipDir
+			}
+			visited = append(visited, path)
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !slices.Contains(visited, ".") {
+			t.Error("root entry '.' must not be pruned")
+		}
+		if !slices.Contains(visited, "src/main.go") {
+			t.Error("files under root must be visited")
+		}
+	})
+
+	t.Run("nil skip set still prunes .git", func(t *testing.T) {
+		var visited []string
+		err := platform.WalkDir(fsys, ".", nil, func(path string, d fs.DirEntry, err error) error {
+			visited = append(visited, path)
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if slices.Contains(visited, ".git") {
+			t.Error(".git should be pruned even with nil skip set")
+		}
+		if !slices.Contains(visited, "src/main.go") {
+			t.Error("normal files should still be visited")
+		}
+	})
+}

--- a/internal/platform/walkdir_test.go
+++ b/internal/platform/walkdir_test.go
@@ -42,7 +42,7 @@ func TestWalkDir(t *testing.T) {
 
 	t.Run("prunes .git at any depth", func(t *testing.T) {
 		var visited []string
-		err := platform.WalkDir(fsys, ".", set.NewSet(".git"), func(path string, d fs.DirEntry, err error) error {
+		err := platform.WalkDir(fsys, ".", nil, func(path string, d fs.DirEntry, err error) error {
 			visited = append(visited, path)
 			return nil
 		})

--- a/lsp/generate_watcher.go
+++ b/lsp/generate_watcher.go
@@ -19,6 +19,7 @@ package lsp
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -26,6 +27,8 @@ import (
 	"time"
 
 	G "bennypowers.dev/cem/generate"
+	"bennypowers.dev/cem/internal/platform"
+	"bennypowers.dev/cem/internal/set"
 	"bennypowers.dev/cem/lsp/helpers"
 	M "bennypowers.dev/cem/manifest"
 	"bennypowers.dev/cem/types"
@@ -162,26 +165,21 @@ func (w *InProcessGenerateWatcher) watchFiles() error {
 	var filesToWatch []string
 	rootDir := w.workspace.Root()
 
-	err = filepath.WalkDir(rootDir, func(path string, d os.DirEntry, err error) error {
+	err = platform.WalkDir(os.DirFS(rootDir), ".", set.NewSet("node_modules"), func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil // Skip errors
 		}
 
-		// ALWAYS skip node_modules
-		if d.IsDir() && d.Name() == "node_modules" {
-			return filepath.SkipDir
-		}
-
-		// Skip hidden directories
-		if d.IsDir() && strings.HasPrefix(d.Name(), ".") {
-			return filepath.SkipDir
+		// Skip hidden directories (e.g. .vscode, .idea)
+		if d.IsDir() && path != "." && strings.HasPrefix(d.Name(), ".") {
+			return fs.SkipDir
 		}
 
 		// Only watch .ts and .js files
 		if !d.IsDir() && (strings.HasSuffix(path, ".ts") || strings.HasSuffix(path, ".js")) {
-			// Check if this file matches our globs
-			if w.shouldProcessFile(path) {
-				filesToWatch = append(filesToWatch, path)
+			fullPath := filepath.Join(rootDir, path)
+			if w.shouldProcessFile(fullPath) {
+				filesToWatch = append(filesToWatch, fullPath)
 			}
 		}
 

--- a/lsp/generate_watcher.go
+++ b/lsp/generate_watcher.go
@@ -167,7 +167,7 @@ func (w *InProcessGenerateWatcher) watchFiles() error {
 
 	err = platform.WalkDir(os.DirFS(rootDir), ".", set.NewSet("node_modules"), func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return nil // Skip errors
+			return err
 		}
 
 		// Skip hidden directories (e.g. .vscode, .idea)

--- a/lsp/methods/textDocument/references/references.go
+++ b/lsp/methods/textDocument/references/references.go
@@ -292,8 +292,8 @@ func findReferencesInWorkspaceWithFS(workspaceRoot string, elementName string, o
 		gitignoreMatcher = ignore.CompileIgnoreLines(strings.Split(string(gitignoreContent), "\n")...)
 	}
 
-	// Find all relevant files in workspace using fs.WalkDir
-	walkErr := fs.WalkDir(filesystem, workspaceRoot, func(path string, d fs.DirEntry, err error) error {
+	// Find all relevant files in workspace using platform.WalkDir
+	walkErr := platform.WalkDir(filesystem, workspaceRoot, nil, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil // Skip errors and continue
 		}
@@ -306,11 +306,6 @@ func findReferencesInWorkspaceWithFS(workspaceRoot string, elementName string, o
 
 		// Skip directories that should be ignored
 		if d.IsDir() {
-			// Always skip .git directory
-			if d.Name() == ".git" {
-				return fs.SkipDir
-			}
-
 			// Check gitignore for directories
 			if gitignoreMatcher != nil && gitignoreMatcher.MatchesPath(relPath+"/") {
 				return fs.SkipDir

--- a/serve/build.go
+++ b/serve/build.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"bennypowers.dev/cem/internal/platform"
+	"bennypowers.dev/cem/internal/set"
 	"bennypowers.dev/cem/serve/middleware"
 	"bennypowers.dev/cem/serve/middleware/importmap"
 	"bennypowers.dev/cem/serve/middleware/routes"
@@ -228,6 +229,7 @@ func (s *Server) copyStaticAssets(config BuildConfig) error {
 	// /__cem/foo.css -> templates/css/foo.css
 	// /__cem/foo.svg -> templates/images/foo.svg
 	// /__cem/elements/... -> templates/elements/...
+	// fs.WalkDir is fine here: routes.InternalModules is an embedded FS with no .git
 	return fs.WalkDir(routes.InternalModules, "templates", func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
 			return err
@@ -289,6 +291,7 @@ func (s *Server) copyStaticAssets(config BuildConfig) error {
 func (s *Server) buildLightdomCSS(config BuildConfig) error {
 	var combined strings.Builder
 
+	// fs.WalkDir is fine here: routes.InternalModules is an embedded FS with no .git
 	if err := fs.WalkDir(routes.InternalModules, "templates/elements", func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
 			return err
@@ -378,22 +381,14 @@ func (s *Server) buildUserSources(handler http.Handler, config BuildConfig, demo
 	}
 
 	count := 0
-	err = filepath.WalkDir(watchDir, func(path string, d fs.DirEntry, err error) error {
+	err = platform.WalkDir(os.DirFS(watchDir), ".", set.NewSet("node_modules"), func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
-		// Skip node_modules (handled by buildDependencies)
-		rel, _ := filepath.Rel(watchDir, path)
-		if strings.HasPrefix(rel, "node_modules") {
-			if d.IsDir() {
-				return fs.SkipDir
-			}
-			return nil
-		}
-
 		// Skip the output directory to avoid infinite recursion
-		absPath, _ := filepath.Abs(path)
+		fullPath := filepath.Join(watchDir, path)
+		absPath, _ := filepath.Abs(fullPath)
 		if d.IsDir() && absPath == absOutputDir {
 			return fs.SkipDir
 		}
@@ -403,7 +398,7 @@ func (s *Server) buildUserSources(handler http.Handler, config BuildConfig, demo
 		}
 
 		// Skip demo source files (already rendered with chrome by buildPage)
-		if demoSourceFiles[rel] {
+		if demoSourceFiles[path] {
 			return nil
 		}
 
@@ -411,7 +406,7 @@ func (s *Server) buildUserSources(handler http.Handler, config BuildConfig, demo
 		switch ext {
 		case ".ts", ".js", ".css", ".html", ".json", ".svg", ".png", ".jpg", ".gif", ".woff", ".woff2":
 			// Dev server serves files relative to watchDir
-			urlPath := "/" + rel
+			urlPath := "/" + path
 			if ext == ".ts" {
 				urlPath = strings.TrimSuffix(urlPath, ".ts") + ".js"
 			}
@@ -430,7 +425,7 @@ func (s *Server) buildUserSources(handler http.Handler, config BuildConfig, demo
 			}
 
 			// Write to the CWD-relative path so import map URLs resolve
-			outPath := filepath.Join(config.siteRoot(), relDir, rel)
+			outPath := filepath.Join(config.siteRoot(), relDir, path)
 			if ext == ".ts" {
 				outPath = strings.TrimSuffix(outPath, ".ts") + ".js"
 			}
@@ -572,12 +567,13 @@ func (s *Server) rewriteImportMapToCDN(config BuildConfig) error {
 	root := config.siteRoot()
 	count := 0
 
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+	err := platform.WalkDir(os.DirFS(root), ".", nil, func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".html") {
 			return err
 		}
 
-		data, readErr := s.fs.ReadFile(path)
+		fullPath := filepath.Join(root, path)
+		data, readErr := s.fs.ReadFile(fullPath)
 		if readErr != nil {
 			return readErr
 		}
@@ -589,7 +585,7 @@ func (s *Server) rewriteImportMapToCDN(config BuildConfig) error {
 		}
 
 		count++
-		return s.fs.WriteFile(path, []byte(rewritten), 0o644)
+		return s.fs.WriteFile(fullPath, []byte(rewritten), 0o644)
 	})
 
 	if err != nil {

--- a/serve/build.go
+++ b/serve/build.go
@@ -367,6 +367,9 @@ func (s *Server) buildUserSources(handler http.Handler, config BuildConfig, demo
 	if err != nil {
 		return err
 	}
+	if relDir == ".." || strings.HasPrefix(relDir, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("watchDir %s is outside working directory %s", watchDir, cwd)
+	}
 
 	// Resolve output directory to an absolute path for skipping during walk
 	absOutputDir, err := filepath.Abs(config.OutputDir)

--- a/serve/filewatcher.go
+++ b/serve/filewatcher.go
@@ -18,12 +18,14 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package serve
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
+	"bennypowers.dev/cem/internal/platform"
 	"github.com/fsnotify/fsnotify"
 )
 
@@ -156,28 +158,24 @@ func (fw *fileWatcher) Watch(path string) error {
 	}
 
 	// Walk subdirectories and add them to the watcher
-	return filepath.Walk(path, func(p string, info os.FileInfo, err error) error {
+	return platform.WalkDir(os.DirFS(path), ".", nil, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
-		// Skip non-directories
-		if !info.IsDir() {
+		if !d.IsDir() || p == "." {
 			return nil
 		}
 
-		// Skip if it's the root path (already added)
-		if p == path {
-			return nil
-		}
+		fullPath := filepath.Join(path, p)
 
 		// Skip ignored directories
-		if fw.shouldIgnore(p) {
-			return filepath.SkipDir
+		if fw.shouldIgnore(fullPath) {
+			return fs.SkipDir
 		}
 
 		// Add this directory to the watcher
-		if err := fw.watcher.Add(p); err != nil {
+		if err := fw.watcher.Add(fullPath); err != nil {
 			return err
 		}
 
@@ -250,33 +248,34 @@ func (fw *fileWatcher) processEvents() {
 			// as create changes (handles mkdir + immediate file write race)
 			if event.Op&fsnotify.Create == fsnotify.Create {
 				if info, err := os.Stat(event.Name); err == nil && info.IsDir() {
-					_ = filepath.Walk(event.Name, func(p string, fi os.FileInfo, walkErr error) error {
+					_ = platform.WalkDir(os.DirFS(event.Name), ".", nil, func(p string, d fs.DirEntry, walkErr error) error {
 						if walkErr != nil {
 							return walkErr
 						}
-						if fi.IsDir() {
-							if fw.shouldIgnore(p) {
-								return filepath.SkipDir
+						fullPath := filepath.Join(event.Name, p)
+						if d.IsDir() {
+							if fw.shouldIgnore(fullPath) {
+								return fs.SkipDir
 							}
-							if addErr := fw.watcher.Add(p); addErr == nil {
+							if addErr := fw.watcher.Add(fullPath); addErr == nil {
 								if fw.logger != nil {
-									fw.logger.Debug("Watching new directory: %s", p)
+									fw.logger.Debug("Watching new directory: %s", fullPath)
 								}
 							}
 						} else {
-							if fw.shouldIgnore(p) {
+							if fw.shouldIgnore(fullPath) {
 								return nil
 							}
 							// Record pre-existing file as a create change
 							fw.mu.Lock()
-							fw.debouncedFiles[p] = time.Now()
+							fw.debouncedFiles[fullPath] = time.Now()
 							if fw.fileEventTypes == nil {
 								fw.fileEventTypes = make(map[string]string)
 							}
-							fw.fileEventTypes[p] = "create"
+							fw.fileEventTypes[fullPath] = "create"
 							fw.mu.Unlock()
 							if fw.logger != nil {
-								fw.logger.Debug("File create: %s", p)
+								fw.logger.Debug("File create: %s", fullPath)
 							}
 						}
 						return nil


### PR DESCRIPTION
## Summary

- Add `platform.WalkDir` wrapper that silently prunes `.git` directories via built-in default, with caller-provided additional skip dirs via `set.Set[string]`
- Convert all directory traversal call sites to use the shared utility (fixes missing `.git` exclusion in `serve/build.go`)
- Restructure `FileParser.WalkWorkspace` to `WorkspaceFS() fs.FS` for type-system enforcement -- callers must go through `platform.WalkDir`
- Remove dead `MockFileParser` code (zero usages)
- Add AGENTS.md guideline for future code

## Test plan

- [x] New `walkdir_test.go` with 7 table-driven tests covering pruning, composition, error propagation, nil skip, and root dot-entry safety
- [x] All 3895 unit tests pass
- [x] `golangci-lint` clean
- [x] Code review caught and fixed P0: root `"."` entry matching dot-prefix hidden-dir check in `generate_watcher.go`

Closes #328

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized workspace directory traversal by automatically excluding `.git` directories and supporting custom directory skipping across file discovery, watching, and module analysis operations.

* **Tests**
  * Added coverage for new directory walking utilities.

* **Documentation**
  * Added guidelines for consistent directory traversal patterns.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bennypowers/cem/pull/330)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->