### PR TITLE
fix(generate): workspace demo discovery URL generation

### DIFF
--- a/cmd/testdata/fixtures/workspace-generate/.config/cem.yaml
+++ b/cmd/testdata/fixtures/workspace-generate/.config/cem.yaml
@@ -3,6 +3,8 @@ generate:
     - "packages/*/src/**/*.ts"
   demoDiscovery:
     fileGlob: "packages/*/demo/*.html"
+    urlPattern: ":pkg/demo/:demo.html"
+    urlTemplate: "https://test.example.com/components/{{.pkg}}/demo/{{.demo}}/"
 export:
   react:
     output: react

--- a/cmd/workspace_test.go
+++ b/cmd/workspace_test.go
@@ -174,20 +174,32 @@ func TestWorkspaceExport_OutputPerPackage(t *testing.T) {
 }
 
 func TestWorkspaceGenerate_DemoDiscovery(t *testing.T) {
-	// Root config has demoDiscovery.fileGlob: "packages/*/demo/*.html".
-	// The glob should be resolved per-package so each package discovers its own demos.
+	// Root config has demoDiscovery with fileGlob, urlPattern, and urlTemplate.
+	// In workspace mode, demo files are package-relative but the urlPattern
+	// is root-level. The workspace fallback should prepend the package dir name
+	// so the urlPattern matches and URLs are generated.
 	projectDir := generateWorkspaceFixture(t)
 
-	// Check that demo discovery ran for each package by examining stderr warnings.
-	// Demo files are found but may not produce URLs without urlPattern config.
-	// The key invariant: each package only discovers ITS OWN demo files.
-	for _, pkg := range []string{"packages/button", "packages/card"} {
-		manifestPath := filepath.Join(projectDir, pkg, "custom-elements.json")
+	for _, pkg := range []struct {
+		dir     string
+		wantURL string
+	}{
+		{"packages/button", "https://test.example.com/components/button/demo/basic/"},
+		{"packages/card", "https://test.example.com/components/card/demo/basic/"},
+	} {
+		manifestPath := filepath.Join(projectDir, pkg.dir, "custom-elements.json")
 		data, err := os.ReadFile(manifestPath)
 		require.NoError(t, err)
-		// Manifest should exist with modules (demo discovery doesn't affect module count)
-		assert.Contains(t, string(data), `"kind": "javascript-module"`,
-			"%s manifest should have modules", pkg)
+		content := string(data)
+
+		assert.Contains(t, content, `"kind": "javascript-module"`,
+			"%s manifest should have modules", pkg.dir)
+
+		assert.Contains(t, content, `"demos"`,
+			"%s manifest should have demos attached to declarations", pkg.dir)
+
+		assert.Contains(t, content, pkg.wantURL,
+			"%s manifest should contain generated demo URL", pkg.dir)
 	}
 }
 

--- a/generate/demodiscovery/discovery.go
+++ b/generate/demodiscovery/discovery.go
@@ -388,8 +388,15 @@ func generateFallbackURL(
 	// Create a test URL for matching using the same base URL
 	testURL := urlPatternBaseURL + urlPath
 	result := pattern.Exec(testURL, "")
+
 	if result == nil {
-		return "", nil // No match
+		if prefix := workspacePackagePrefix(ctx); prefix != "" {
+			result = pattern.Exec(urlPatternBaseURL+"/"+prefix+urlPath, "")
+		}
+	}
+
+	if result == nil {
+		return "", nil
 	}
 
 	// Get cached template

--- a/generate/demodiscovery/discovery_test.go
+++ b/generate/demodiscovery/discovery_test.go
@@ -105,10 +105,11 @@ func TestExtractDemoMetadata(t *testing.T) {
 }
 
 func TestGenerateFallbackURL(t *testing.T) {
-	ctx := W.NewFileSystemWorkspaceContext(t.TempDir())
+	defaultCtx := W.NewFileSystemWorkspaceContext(t.TempDir())
 
 	tests := []struct {
 		name        string
+		ctx         *W.FileSystemWorkspaceContext
 		config      *C.CemConfig
 		demoPath    string
 		tagAliases  map[string]string
@@ -273,6 +274,36 @@ func TestGenerateFallbackURL(t *testing.T) {
 			expected: "https://site.com/elements/textarea/demo/",
 		},
 		{
+			name: "workspace fallback: package-relative path with root-level pattern",
+			ctx:  W.NewFileSystemWorkspaceContext(filepath.Join(t.TempDir(), "pf-v5-button")),
+			config: &C.CemConfig{
+				Generate: C.GenerateConfig{
+					DemoDiscovery: C.DemoDiscoveryConfig{
+						URLPattern:  ":tag/demo/:demo.html",
+						URLTemplate: "https://site.com/components/{{.tag | alias | slug}}/demo/{{.demo | slug}}/",
+					},
+				},
+			},
+			demoPath:   "demo/primary.html",
+			tagAliases: map[string]string{"pf-v5-button": "button"},
+			expected:   "https://site.com/components/button/demo/primary/",
+		},
+		{
+			name: "workspace fallback: index.html gets SSG routing",
+			ctx:  W.NewFileSystemWorkspaceContext(filepath.Join(t.TempDir(), "pf-v5-alert")),
+			config: &C.CemConfig{
+				Generate: C.GenerateConfig{
+					DemoDiscovery: C.DemoDiscoveryConfig{
+						URLPattern:  ":tag/demo/:demo.html",
+						URLTemplate: "https://site.com/elements/{{.tag | alias | slug}}/demo/{{.demo}}/",
+					},
+				},
+			},
+			demoPath:   "demo/index.html",
+			tagAliases: map[string]string{"pf-v5-alert": "alert"},
+			expected:   "https://site.com/elements/alert/demo/",
+		},
+		{
 			name: "auto-derived alias respects explicit override",
 			config: &C.CemConfig{
 				Generate: C.GenerateConfig{
@@ -293,6 +324,10 @@ func TestGenerateFallbackURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := tt.ctx
+			if ctx == nil {
+				ctx = defaultCtx
+			}
 			result, err := generateFallbackURL(ctx, tt.config, tt.demoPath, tt.tagAliases)
 
 			if tt.expectError {
@@ -366,6 +401,35 @@ func TestExtractDemoTags(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestExtractDemoTagsWithPattern_WorkspaceFallback(t *testing.T) {
+	// Simulate workspace mode: demo file contains multiple elements but the
+	// URLPattern should precisely select only the package element (pf-v5-button).
+	// Without the workspace fallback, content-based discovery returns ALL tags.
+	pkgDir := filepath.Join(t.TempDir(), "pf-v5-button")
+	demoDir := filepath.Join(pkgDir, "demo")
+	if err := os.MkdirAll(demoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Demo contains both pf-v5-button and pf-v5-icon
+	html := "<pf-v5-button><pf-v5-icon></pf-v5-icon>Click</pf-v5-button>"
+	demoFile := filepath.Join(demoDir, "basic.html")
+	if err := os.WriteFile(demoFile, []byte(html), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := W.NewFileSystemWorkspaceContext(pkgDir)
+	tags, err := extractDemoTagsWithPattern(ctx, "demo/basic.html", ":tag/demo/:demo.html", nil)
+	if err != nil {
+		t.Fatalf("extractDemoTagsWithPattern failed: %v", err)
+	}
+
+	// URLPattern matching should precisely return only pf-v5-button (from dir name),
+	// not both pf-v5-button and pf-v5-icon from content scanning.
+	if len(tags) != 1 || tags[0] != "pf-v5-button" {
+		t.Errorf("expected [pf-v5-button], got %v", tags)
+	}
 }
 
 func TestExtractParameterValues(t *testing.T) {

--- a/generate/demodiscovery/map.go
+++ b/generate/demodiscovery/map.go
@@ -128,6 +128,12 @@ func extractDemoTagsWithPattern(
 		if len(parameterTags) > 0 {
 			return parameterTags, nil
 		}
+		if prefix := workspacePackagePrefix(ctx); prefix != "" {
+			retryTags, _ := extractTagsFromURLPatternParameters(filepath.Join(prefix, path), urlPattern)
+			if len(retryTags) > 0 {
+				return retryTags, nil
+			}
+		}
 	}
 
 	// Priority 3: Content-based discovery
@@ -212,6 +218,17 @@ func extractParameterValues(demoPath, urlPattern string) ([]string, error) {
 	}
 
 	return paramValues, nil
+}
+
+// workspacePackagePrefix returns the package directory name from a workspace
+// context, or "" if not applicable. Used as a fallback prefix when root-level
+// URLPatterns don't match package-relative demo paths.
+func workspacePackagePrefix(ctx types.WorkspaceContext) string {
+	pkgDir := filepath.Base(ctx.Root())
+	if pkgDir == "" || pkgDir == "." {
+		return ""
+	}
+	return pkgDir
 }
 
 var customElementTagNameRe = regexp.MustCompile(`^[a-z][.0-9_a-z]*-[\-.0-9_a-z]*$`)

--- a/generate/demodiscovery/map.go
+++ b/generate/demodiscovery/map.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	htmllang "bennypowers.dev/cem/internal/languages/html"
+	"bennypowers.dev/cem/internal/logging"
 	S "bennypowers.dev/cem/internal/set"
 	"bennypowers.dev/cem/types"
 	ts "github.com/tree-sitter/go-tree-sitter"
@@ -129,8 +130,10 @@ func extractDemoTagsWithPattern(
 			return parameterTags, nil
 		}
 		if prefix := workspacePackagePrefix(ctx); prefix != "" {
-			retryTags, _ := extractTagsFromURLPatternParameters(filepath.Join(prefix, path), urlPattern)
-			if len(retryTags) > 0 {
+			retryTags, retryErr := extractTagsFromURLPatternParameters(filepath.Join(prefix, path), urlPattern)
+			if retryErr != nil {
+				logging.Debug("workspace fallback URLPattern extraction failed for %q with pattern %q: %v", path, urlPattern, retryErr)
+			} else if len(retryTags) > 0 {
 				return retryTags, nil
 			}
 		}

--- a/internal/textutil/frontmatter.go
+++ b/internal/textutil/frontmatter.go
@@ -36,6 +36,19 @@ func StripFrontmatter(content []byte) []byte {
 
 	rest := trimmed[openLen:]
 
+	// Check if rest itself starts with closing delimiter (empty frontmatter)
+	if bytes.HasPrefix(rest, []byte("---")) {
+		after := rest[3:]
+		switch {
+		case len(after) == 0:
+			return after
+		case after[0] == '\n':
+			return after[1:]
+		case after[0] == '\r' && len(after) > 1 && after[1] == '\n':
+			return after[2:]
+		}
+	}
+
 	for i := range len(rest) {
 		if rest[i] != '\n' {
 			continue
@@ -55,6 +68,13 @@ func StripFrontmatter(content []byte) []byte {
 		default:
 			continue
 		}
+	}
+
+	// No closing delimiter found: stray "---" line before HTML content.
+	// Strip it so raw delimiters don't appear in rendered output.
+	trimmedRest := bytes.TrimLeft(rest, " \t")
+	if len(trimmedRest) > 0 && trimmedRest[0] == '<' {
+		return rest
 	}
 
 	return content

--- a/internal/textutil/frontmatter_test.go
+++ b/internal/textutil/frontmatter_test.go
@@ -106,6 +106,31 @@ func TestStripFrontmatter(t *testing.T) {
 			input: "---\ndescription: A demo\r\n---\r\n",
 			want:  "",
 		},
+		{
+			name:  "empty frontmatter no closing delimiter",
+			input: "---\n<section>\n  <my-element>content</my-element>\n</section>\n",
+			want:  "<section>\n  <my-element>content</my-element>\n</section>\n",
+		},
+		{
+			name:  "empty frontmatter no closing delimiter CRLF",
+			input: "---\r\n<section>\r\n  <my-element>content</my-element>\r\n</section>\r\n",
+			want:  "<section>\r\n  <my-element>content</my-element>\r\n</section>\r\n",
+		},
+		{
+			name:  "empty frontmatter with closing delimiter",
+			input: "---\n---\n<my-element>content</my-element>\n",
+			want:  "<my-element>content</my-element>\n",
+		},
+		{
+			name:  "empty frontmatter no closing delimiter with leading whitespace",
+			input: "---\n  <my-element>content</my-element>\n",
+			want:  "  <my-element>content</my-element>\n",
+		},
+		{
+			name:  "stray delimiter before non-HTML is not frontmatter",
+			input: "---\nsome plain text without tags\n",
+			want:  "---\nsome plain text without tags\n",
+		},
 	}
 
 	for _, tt := range tests {

--- a/serve/middleware/routes/frontmatter_test.go
+++ b/serve/middleware/routes/frontmatter_test.go
@@ -58,69 +58,83 @@ func (c *frontmatterTestContext) PathResolver() middleware.PathResolver         
 func (c *frontmatterTestContext) HealthResult() (*health.HealthResult, error)        { return nil, nil }
 func (c *frontmatterTestContext) IsStaticBuild() bool                               { return false }
 
+type frontmatterTestFixture struct {
+	handler   http.Handler
+	demoRoute string
+}
+
+func setupFrontmatterTest(t *testing.T, demoContent []byte, demoFilename, renderingMode string) frontmatterTestFixture {
+	t.Helper()
+
+	demoRoute := "/demo/" + demoFilename
+	demoURL := "./demo/" + demoFilename
+
+	manifest := map[string]any{
+		"schemaVersion": "1.0.0",
+		"modules": []map[string]any{{
+			"kind": "javascript-module",
+			"path": "src/test-el.ts",
+			"declarations": []map[string]any{{
+				"kind":          "class",
+				"customElement": true,
+				"name":          "TestEl",
+				"tagName":       "test-el",
+				"demos": []map[string]any{{
+					"description": demoFilename,
+					"url":         demoURL,
+				}},
+			}},
+		}},
+	}
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+
+	watchDir := t.TempDir()
+	fs := platform.NewOSFileSystem()
+	demoDir := watchDir + "/demo"
+	if err := fs.MkdirAll(demoDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := fs.WriteFile(demoDir+"/"+demoFilename, demoContent, 0644); err != nil {
+		t.Fatalf("write demo: %v", err)
+	}
+
+	ctx := &frontmatterTestContext{
+		manifest:      manifestBytes,
+		watchDir:      watchDir,
+		fs:            fs,
+		renderingMode: renderingMode,
+		demoRoutes: map[string]*middleware.DemoRouteEntry{
+			demoRoute: {
+				TagName:    "test-el",
+				FilePath:   "demo/" + demoFilename,
+				Demo:       &M.Demo{Description: demoFilename, URL: demoURL},
+				LocalRoute: demoRoute,
+			},
+		},
+	}
+
+	mw := routes.New(routes.Config{Context: ctx})
+	return frontmatterTestFixture{
+		handler:   mw(http.NotFoundHandler()),
+		demoRoute: demoRoute,
+	}
+}
+
 func TestFrontmatterStrippedFromDemoHTTPResponse(t *testing.T) {
 	modes := []string{"light", "shadow", "iframe", "chromeless"}
 
 	for _, mode := range modes {
 		t.Run(mode, func(t *testing.T) {
-			demoContent := []byte("---\ndescription: Visible frontmatter bug\n---\n<test-el>content</test-el>\n")
+			fix := setupFrontmatterTest(t,
+				[]byte("---\ndescription: Visible frontmatter bug\n---\n<test-el>content</test-el>\n"),
+				"frontmatter.html", mode)
 
-			manifest := map[string]any{
-				"schemaVersion": "1.0.0",
-				"modules": []map[string]any{{
-					"kind": "javascript-module",
-					"path": "src/test-el.ts",
-					"declarations": []map[string]any{{
-						"kind":          "class",
-						"customElement": true,
-						"name":          "TestEl",
-						"tagName":       "test-el",
-						"demos": []map[string]any{{
-							"description": "Frontmatter demo",
-							"url":         "./demo/frontmatter.html",
-						}},
-					}},
-				}},
-			}
-			manifestBytes, err := json.Marshal(manifest)
-			if err != nil {
-				t.Fatalf("marshal manifest: %v", err)
-			}
-
-			watchDir := t.TempDir()
-			fs := platform.NewOSFileSystem()
-			demoDir := watchDir + "/demo"
-			if err := fs.MkdirAll(demoDir, 0755); err != nil {
-				t.Fatalf("mkdir: %v", err)
-			}
-			if err := fs.WriteFile(demoDir+"/frontmatter.html", demoContent, 0644); err != nil {
-				t.Fatalf("write demo: %v", err)
-			}
-
-			ctx := &frontmatterTestContext{
-				manifest:      manifestBytes,
-				watchDir:      watchDir,
-				fs:            fs,
-				renderingMode: mode,
-				demoRoutes: map[string]*middleware.DemoRouteEntry{
-					"/demo/frontmatter.html": {
-						TagName:  "test-el",
-						FilePath: "demo/frontmatter.html",
-						Demo: &M.Demo{
-							Description: "Frontmatter demo",
-							URL:         "./demo/frontmatter.html",
-						},
-						LocalRoute: "/demo/frontmatter.html",
-					},
-				},
-			}
-
-			mw := routes.New(routes.Config{Context: ctx})
-			handler := mw(http.NotFoundHandler())
-
-			req := httptest.NewRequest("GET", "/demo/frontmatter.html", nil)
+			req := httptest.NewRequest("GET", fix.demoRoute, nil)
 			rec := httptest.NewRecorder()
-			handler.ServeHTTP(rec, req)
+			fix.handler.ServeHTTP(rec, req)
 
 			if rec.Code != http.StatusOK {
 				t.Fatalf("expected 200, got %d", rec.Code)
@@ -144,64 +158,13 @@ func TestEmptyFrontmatterStrippedFromDemoHTTPResponse(t *testing.T) {
 
 	for _, mode := range modes {
 		t.Run(mode, func(t *testing.T) {
-			demoContent := []byte("---\n<section>\n  <test-el>content</test-el>\n</section>\n")
+			fix := setupFrontmatterTest(t,
+				[]byte("---\n<section>\n  <test-el>content</test-el>\n</section>\n"),
+				"empty-fm.html", mode)
 
-			manifest := map[string]any{
-				"schemaVersion": "1.0.0",
-				"modules": []map[string]any{{
-					"kind": "javascript-module",
-					"path": "src/test-el.ts",
-					"declarations": []map[string]any{{
-						"kind":          "class",
-						"customElement": true,
-						"name":          "TestEl",
-						"tagName":       "test-el",
-						"demos": []map[string]any{{
-							"description": "Empty frontmatter demo",
-							"url":         "./demo/empty-fm.html",
-						}},
-					}},
-				}},
-			}
-			manifestBytes, err := json.Marshal(manifest)
-			if err != nil {
-				t.Fatalf("marshal manifest: %v", err)
-			}
-
-			watchDir := t.TempDir()
-			fs := platform.NewOSFileSystem()
-			demoDir := watchDir + "/demo"
-			if err := fs.MkdirAll(demoDir, 0755); err != nil {
-				t.Fatalf("mkdir: %v", err)
-			}
-			if err := fs.WriteFile(demoDir+"/empty-fm.html", demoContent, 0644); err != nil {
-				t.Fatalf("write demo: %v", err)
-			}
-
-			ctx := &frontmatterTestContext{
-				manifest:      manifestBytes,
-				watchDir:      watchDir,
-				fs:            fs,
-				renderingMode: mode,
-				demoRoutes: map[string]*middleware.DemoRouteEntry{
-					"/demo/empty-fm.html": {
-						TagName:  "test-el",
-						FilePath: "demo/empty-fm.html",
-						Demo: &M.Demo{
-							Description: "Empty frontmatter demo",
-							URL:         "./demo/empty-fm.html",
-						},
-						LocalRoute: "/demo/empty-fm.html",
-					},
-				},
-			}
-
-			mw := routes.New(routes.Config{Context: ctx})
-			handler := mw(http.NotFoundHandler())
-
-			req := httptest.NewRequest("GET", "/demo/empty-fm.html", nil)
+			req := httptest.NewRequest("GET", fix.demoRoute, nil)
 			rec := httptest.NewRecorder()
-			handler.ServeHTTP(rec, req)
+			fix.handler.ServeHTTP(rec, req)
 
 			if rec.Code != http.StatusOK {
 				t.Fatalf("expected 200, got %d", rec.Code)
@@ -225,64 +188,13 @@ func TestFrontmatterStrippedViaQueryParamOverride(t *testing.T) {
 
 	for _, mode := range modes {
 		t.Run(mode, func(t *testing.T) {
-			demoContent := []byte("---\ndescription: Should not appear\nfor: test-el\n---\n<test-el>visible</test-el>\n")
+			fix := setupFrontmatterTest(t,
+				[]byte("---\ndescription: Should not appear\nfor: test-el\n---\n<test-el>visible</test-el>\n"),
+				"qp.html", "light")
 
-			manifest := map[string]any{
-				"schemaVersion": "1.0.0",
-				"modules": []map[string]any{{
-					"kind": "javascript-module",
-					"path": "src/test-el.ts",
-					"declarations": []map[string]any{{
-						"kind":          "class",
-						"customElement": true,
-						"name":          "TestEl",
-						"tagName":       "test-el",
-						"demos": []map[string]any{{
-							"description": "Query param demo",
-							"url":         "./demo/qp.html",
-						}},
-					}},
-				}},
-			}
-			manifestBytes, err := json.Marshal(manifest)
-			if err != nil {
-				t.Fatalf("marshal manifest: %v", err)
-			}
-
-			watchDir := t.TempDir()
-			fs := platform.NewOSFileSystem()
-			demoDir := watchDir + "/demo"
-			if err := fs.MkdirAll(demoDir, 0755); err != nil {
-				t.Fatalf("mkdir: %v", err)
-			}
-			if err := fs.WriteFile(demoDir+"/qp.html", demoContent, 0644); err != nil {
-				t.Fatalf("write demo: %v", err)
-			}
-
-			ctx := &frontmatterTestContext{
-				manifest:      manifestBytes,
-				watchDir:      watchDir,
-				fs:            fs,
-				renderingMode: "light",
-				demoRoutes: map[string]*middleware.DemoRouteEntry{
-					"/demo/qp.html": {
-						TagName:  "test-el",
-						FilePath: "demo/qp.html",
-						Demo: &M.Demo{
-							Description: "Query param demo",
-							URL:         "./demo/qp.html",
-						},
-						LocalRoute: "/demo/qp.html",
-					},
-				},
-			}
-
-			mw := routes.New(routes.Config{Context: ctx})
-			handler := mw(http.NotFoundHandler())
-
-			req := httptest.NewRequest("GET", "/demo/qp.html?rendering="+mode, nil)
+			req := httptest.NewRequest("GET", fix.demoRoute+"?rendering="+mode, nil)
 			rec := httptest.NewRecorder()
-			handler.ServeHTTP(rec, req)
+			fix.handler.ServeHTTP(rec, req)
 
 			if rec.Code != http.StatusOK {
 				t.Fatalf("expected 200, got %d", rec.Code)

--- a/serve/middleware/routes/frontmatter_test.go
+++ b/serve/middleware/routes/frontmatter_test.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -63,11 +65,21 @@ type frontmatterTestFixture struct {
 	demoRoute string
 }
 
-func setupFrontmatterTest(t *testing.T, demoContent []byte, demoFilename, renderingMode string) frontmatterTestFixture {
+func loadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", "frontmatter", name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return data
+}
+
+func setupFrontmatterTest(t *testing.T, fixtureName, renderingMode string) frontmatterTestFixture {
 	t.Helper()
 
-	demoRoute := "/demo/" + demoFilename
-	demoURL := "./demo/" + demoFilename
+	demoContent := loadFixture(t, fixtureName)
+	demoRoute := "/demo/" + fixtureName
+	demoURL := "./demo/" + fixtureName
 
 	manifest := map[string]any{
 		"schemaVersion": "1.0.0",
@@ -80,7 +92,7 @@ func setupFrontmatterTest(t *testing.T, demoContent []byte, demoFilename, render
 				"name":          "TestEl",
 				"tagName":       "test-el",
 				"demos": []map[string]any{{
-					"description": demoFilename,
+					"description": fixtureName,
 					"url":         demoURL,
 				}},
 			}},
@@ -97,7 +109,7 @@ func setupFrontmatterTest(t *testing.T, demoContent []byte, demoFilename, render
 	if err := fs.MkdirAll(demoDir, 0755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	if err := fs.WriteFile(demoDir+"/"+demoFilename, demoContent, 0644); err != nil {
+	if err := fs.WriteFile(demoDir+"/"+fixtureName, demoContent, 0644); err != nil {
 		t.Fatalf("write demo: %v", err)
 	}
 
@@ -109,8 +121,8 @@ func setupFrontmatterTest(t *testing.T, demoContent []byte, demoFilename, render
 		demoRoutes: map[string]*middleware.DemoRouteEntry{
 			demoRoute: {
 				TagName:    "test-el",
-				FilePath:   "demo/" + demoFilename,
-				Demo:       &M.Demo{Description: demoFilename, URL: demoURL},
+				FilePath:   "demo/" + fixtureName,
+				Demo:       &M.Demo{Description: fixtureName, URL: demoURL},
 				LocalRoute: demoRoute,
 			},
 		},
@@ -128,9 +140,7 @@ func TestFrontmatterStrippedFromDemoHTTPResponse(t *testing.T) {
 
 	for _, mode := range modes {
 		t.Run(mode, func(t *testing.T) {
-			fix := setupFrontmatterTest(t,
-				[]byte("---\ndescription: Visible frontmatter bug\n---\n<test-el>content</test-el>\n"),
-				"frontmatter.html", mode)
+			fix := setupFrontmatterTest(t, "with-frontmatter.html", mode)
 
 			req := httptest.NewRequest("GET", fix.demoRoute, nil)
 			rec := httptest.NewRecorder()
@@ -158,9 +168,7 @@ func TestEmptyFrontmatterStrippedFromDemoHTTPResponse(t *testing.T) {
 
 	for _, mode := range modes {
 		t.Run(mode, func(t *testing.T) {
-			fix := setupFrontmatterTest(t,
-				[]byte("---\n<section>\n  <test-el>content</test-el>\n</section>\n"),
-				"empty-fm.html", mode)
+			fix := setupFrontmatterTest(t, "empty-frontmatter.html", mode)
 
 			req := httptest.NewRequest("GET", fix.demoRoute, nil)
 			rec := httptest.NewRecorder()
@@ -188,9 +196,7 @@ func TestFrontmatterStrippedViaQueryParamOverride(t *testing.T) {
 
 	for _, mode := range modes {
 		t.Run(mode, func(t *testing.T) {
-			fix := setupFrontmatterTest(t,
-				[]byte("---\ndescription: Should not appear\nfor: test-el\n---\n<test-el>visible</test-el>\n"),
-				"qp.html", "light")
+			fix := setupFrontmatterTest(t, "query-param-override.html", "light")
 
 			req := httptest.NewRequest("GET", fix.demoRoute+"?rendering="+mode, nil)
 			rec := httptest.NewRecorder()

--- a/serve/middleware/routes/frontmatter_test.go
+++ b/serve/middleware/routes/frontmatter_test.go
@@ -34,10 +34,11 @@ import (
 )
 
 type frontmatterTestContext struct {
-	manifest   []byte
-	watchDir   string
-	demoRoutes map[string]*middleware.DemoRouteEntry
-	fs         platform.FileSystem
+	manifest      []byte
+	watchDir      string
+	demoRoutes    map[string]*middleware.DemoRouteEntry
+	fs            platform.FileSystem
+	renderingMode string
 }
 
 func (c *frontmatterTestContext) WatchDir() string                                  { return c.watchDir }
@@ -51,84 +52,251 @@ func (c *frontmatterTestContext) Logger() logger.Logger                         
 func (c *frontmatterTestContext) FileSystem() platform.FileSystem                   { return c.fs }
 func (c *frontmatterTestContext) PackageJSON() (*middleware.PackageJSON, error)      { return nil, nil }
 func (c *frontmatterTestContext) BroadcastError(title, message, file string) error   { return nil }
-func (c *frontmatterTestContext) DemoRenderingMode() string                         { return "light" }
+func (c *frontmatterTestContext) DemoRenderingMode() string                         { return c.renderingMode }
 func (c *frontmatterTestContext) URLRewrites() []config.URLRewrite                  { return nil }
 func (c *frontmatterTestContext) PathResolver() middleware.PathResolver              { return nil }
 func (c *frontmatterTestContext) HealthResult() (*health.HealthResult, error)        { return nil, nil }
 func (c *frontmatterTestContext) IsStaticBuild() bool                               { return false }
 
 func TestFrontmatterStrippedFromDemoHTTPResponse(t *testing.T) {
-	demoContent := []byte("---\ndescription: Visible frontmatter bug\n---\n<test-el>content</test-el>\n")
+	modes := []string{"light", "shadow", "iframe", "chromeless"}
 
-	manifest := map[string]any{
-		"schemaVersion": "1.0.0",
-		"modules": []map[string]any{{
-			"kind": "javascript-module",
-			"path": "src/test-el.ts",
-			"declarations": []map[string]any{{
-				"kind":          "class",
-				"customElement": true,
-				"name":          "TestEl",
-				"tagName":       "test-el",
-				"demos": []map[string]any{{
-					"description": "Frontmatter demo",
-					"url":         "./demo/frontmatter.html",
+	for _, mode := range modes {
+		t.Run(mode, func(t *testing.T) {
+			demoContent := []byte("---\ndescription: Visible frontmatter bug\n---\n<test-el>content</test-el>\n")
+
+			manifest := map[string]any{
+				"schemaVersion": "1.0.0",
+				"modules": []map[string]any{{
+					"kind": "javascript-module",
+					"path": "src/test-el.ts",
+					"declarations": []map[string]any{{
+						"kind":          "class",
+						"customElement": true,
+						"name":          "TestEl",
+						"tagName":       "test-el",
+						"demos": []map[string]any{{
+							"description": "Frontmatter demo",
+							"url":         "./demo/frontmatter.html",
+						}},
+					}},
 				}},
-			}},
-		}},
-	}
-	manifestBytes, err := json.Marshal(manifest)
-	if err != nil {
-		t.Fatalf("marshal manifest: %v", err)
-	}
+			}
+			manifestBytes, err := json.Marshal(manifest)
+			if err != nil {
+				t.Fatalf("marshal manifest: %v", err)
+			}
 
-	watchDir := t.TempDir()
-	fs := platform.NewOSFileSystem()
-	demoDir := watchDir + "/demo"
-	if err := fs.MkdirAll(demoDir, 0755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := fs.WriteFile(demoDir+"/frontmatter.html", demoContent, 0644); err != nil {
-		t.Fatalf("write demo: %v", err)
-	}
+			watchDir := t.TempDir()
+			fs := platform.NewOSFileSystem()
+			demoDir := watchDir + "/demo"
+			if err := fs.MkdirAll(demoDir, 0755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if err := fs.WriteFile(demoDir+"/frontmatter.html", demoContent, 0644); err != nil {
+				t.Fatalf("write demo: %v", err)
+			}
 
-	ctx := &frontmatterTestContext{
-		manifest: manifestBytes,
-		watchDir: watchDir,
-		fs:       fs,
-		demoRoutes: map[string]*middleware.DemoRouteEntry{
-			"/demo/frontmatter.html": {
-				TagName:  "test-el",
-				FilePath: "demo/frontmatter.html",
-				Demo: &M.Demo{
-					Description: "Frontmatter demo",
-					URL:         "./demo/frontmatter.html",
+			ctx := &frontmatterTestContext{
+				manifest:      manifestBytes,
+				watchDir:      watchDir,
+				fs:            fs,
+				renderingMode: mode,
+				demoRoutes: map[string]*middleware.DemoRouteEntry{
+					"/demo/frontmatter.html": {
+						TagName:  "test-el",
+						FilePath: "demo/frontmatter.html",
+						Demo: &M.Demo{
+							Description: "Frontmatter demo",
+							URL:         "./demo/frontmatter.html",
+						},
+						LocalRoute: "/demo/frontmatter.html",
+					},
 				},
-				LocalRoute: "/demo/frontmatter.html",
-			},
-		},
+			}
+
+			mw := routes.New(routes.Config{Context: ctx})
+			handler := mw(http.NotFoundHandler())
+
+			req := httptest.NewRequest("GET", "/demo/frontmatter.html", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", rec.Code)
+			}
+
+			body := rec.Body.String()
+
+			if strings.Contains(body, "Visible frontmatter bug") {
+				t.Error("frontmatter description leaked into HTTP response body")
+			}
+
+			if !strings.Contains(body, "<test-el>content</test-el>") {
+				t.Error("demo element content missing from HTTP response")
+			}
+		})
 	}
+}
 
-	mw := routes.New(routes.Config{Context: ctx})
-	handler := mw(http.NotFoundHandler())
+func TestEmptyFrontmatterStrippedFromDemoHTTPResponse(t *testing.T) {
+	modes := []string{"light", "shadow", "iframe", "chromeless"}
 
-	req := httptest.NewRequest("GET", "/demo/frontmatter.html", nil)
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
+	for _, mode := range modes {
+		t.Run(mode, func(t *testing.T) {
+			demoContent := []byte("---\n<section>\n  <test-el>content</test-el>\n</section>\n")
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", rec.Code)
+			manifest := map[string]any{
+				"schemaVersion": "1.0.0",
+				"modules": []map[string]any{{
+					"kind": "javascript-module",
+					"path": "src/test-el.ts",
+					"declarations": []map[string]any{{
+						"kind":          "class",
+						"customElement": true,
+						"name":          "TestEl",
+						"tagName":       "test-el",
+						"demos": []map[string]any{{
+							"description": "Empty frontmatter demo",
+							"url":         "./demo/empty-fm.html",
+						}},
+					}},
+				}},
+			}
+			manifestBytes, err := json.Marshal(manifest)
+			if err != nil {
+				t.Fatalf("marshal manifest: %v", err)
+			}
+
+			watchDir := t.TempDir()
+			fs := platform.NewOSFileSystem()
+			demoDir := watchDir + "/demo"
+			if err := fs.MkdirAll(demoDir, 0755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if err := fs.WriteFile(demoDir+"/empty-fm.html", demoContent, 0644); err != nil {
+				t.Fatalf("write demo: %v", err)
+			}
+
+			ctx := &frontmatterTestContext{
+				manifest:      manifestBytes,
+				watchDir:      watchDir,
+				fs:            fs,
+				renderingMode: mode,
+				demoRoutes: map[string]*middleware.DemoRouteEntry{
+					"/demo/empty-fm.html": {
+						TagName:  "test-el",
+						FilePath: "demo/empty-fm.html",
+						Demo: &M.Demo{
+							Description: "Empty frontmatter demo",
+							URL:         "./demo/empty-fm.html",
+						},
+						LocalRoute: "/demo/empty-fm.html",
+					},
+				},
+			}
+
+			mw := routes.New(routes.Config{Context: ctx})
+			handler := mw(http.NotFoundHandler())
+
+			req := httptest.NewRequest("GET", "/demo/empty-fm.html", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", rec.Code)
+			}
+
+			body := rec.Body.String()
+
+			if strings.Contains(body, "\n---\n") || strings.Contains(body, ">---<") || strings.Contains(body, ">---\n") {
+				t.Error("empty frontmatter delimiter leaked into HTTP response body")
+			}
+
+			if !strings.Contains(body, "<test-el>content</test-el>") {
+				t.Error("demo element content missing from HTTP response")
+			}
+		})
 	}
+}
 
-	body := rec.Body.String()
+func TestFrontmatterStrippedViaQueryParamOverride(t *testing.T) {
+	modes := []string{"light", "shadow", "iframe", "chromeless"}
 
-	// Frontmatter must not appear in rendered output
-	if strings.Contains(body, "Visible frontmatter bug") {
-		t.Error("frontmatter description leaked into HTTP response body")
-	}
+	for _, mode := range modes {
+		t.Run(mode, func(t *testing.T) {
+			demoContent := []byte("---\ndescription: Should not appear\nfor: test-el\n---\n<test-el>visible</test-el>\n")
 
-	// Demo content must be present
-	if !strings.Contains(body, "<test-el>content</test-el>") {
-		t.Error("demo element content missing from HTTP response")
+			manifest := map[string]any{
+				"schemaVersion": "1.0.0",
+				"modules": []map[string]any{{
+					"kind": "javascript-module",
+					"path": "src/test-el.ts",
+					"declarations": []map[string]any{{
+						"kind":          "class",
+						"customElement": true,
+						"name":          "TestEl",
+						"tagName":       "test-el",
+						"demos": []map[string]any{{
+							"description": "Query param demo",
+							"url":         "./demo/qp.html",
+						}},
+					}},
+				}},
+			}
+			manifestBytes, err := json.Marshal(manifest)
+			if err != nil {
+				t.Fatalf("marshal manifest: %v", err)
+			}
+
+			watchDir := t.TempDir()
+			fs := platform.NewOSFileSystem()
+			demoDir := watchDir + "/demo"
+			if err := fs.MkdirAll(demoDir, 0755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if err := fs.WriteFile(demoDir+"/qp.html", demoContent, 0644); err != nil {
+				t.Fatalf("write demo: %v", err)
+			}
+
+			ctx := &frontmatterTestContext{
+				manifest:      manifestBytes,
+				watchDir:      watchDir,
+				fs:            fs,
+				renderingMode: "light",
+				demoRoutes: map[string]*middleware.DemoRouteEntry{
+					"/demo/qp.html": {
+						TagName:  "test-el",
+						FilePath: "demo/qp.html",
+						Demo: &M.Demo{
+							Description: "Query param demo",
+							URL:         "./demo/qp.html",
+						},
+						LocalRoute: "/demo/qp.html",
+					},
+				},
+			}
+
+			mw := routes.New(routes.Config{Context: ctx})
+			handler := mw(http.NotFoundHandler())
+
+			req := httptest.NewRequest("GET", "/demo/qp.html?rendering="+mode, nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", rec.Code)
+			}
+
+			body := rec.Body.String()
+
+			if strings.Contains(body, "Should not appear") {
+				t.Errorf("frontmatter leaked when overriding to %s via ?rendering query param", mode)
+			}
+
+			if !strings.Contains(body, "<test-el>visible</test-el>") {
+				t.Error("demo element content missing from HTTP response")
+			}
+		})
 	}
 }

--- a/serve/middleware/routes/testdata/frontmatter/empty-frontmatter.html
+++ b/serve/middleware/routes/testdata/frontmatter/empty-frontmatter.html
@@ -1,0 +1,4 @@
+---
+<section>
+  <test-el>content</test-el>
+</section>

--- a/serve/middleware/routes/testdata/frontmatter/query-param-override.html
+++ b/serve/middleware/routes/testdata/frontmatter/query-param-override.html
@@ -1,0 +1,5 @@
+---
+description: Should not appear
+for: test-el
+---
+<test-el>visible</test-el>

--- a/serve/middleware/routes/testdata/frontmatter/with-frontmatter.html
+++ b/serve/middleware/routes/testdata/frontmatter/with-frontmatter.html
@@ -1,0 +1,4 @@
+---
+description: Visible frontmatter bug
+---
+<test-el>content</test-el>


### PR DESCRIPTION
## Summary

- Fix demo discovery URL generation in workspace mode where `urlPattern` expects
  root-relative paths (e.g. `pf-v5-alert/demo/index.html`) but demo file paths
  are package-relative (e.g. `demo/index.html`)
- Add `workspacePackagePrefix()` helper that retries URLPattern matching with
  the package directory name prepended
- Fix `StripFrontmatter` to handle whitespace before HTML content when no
  closing `---` delimiter exists
- Expand frontmatter HTTP response tests across all rendering modes

## Test plan

- [x] Unit tests for workspace fallback in `generateFallbackURL` (package-relative
  path + root-level pattern, SSG index.html routing)
- [x] Unit test for precise tag extraction via URLPattern in workspace mode
  (multi-element demo selects only package element)
- [x] E2E test: workspace-generate fixture with `urlPattern`/`urlTemplate` config
  asserts demos appear in generated manifests with correct URLs
- [x] Frontmatter tests: whitespace before HTML, stray delimiter before non-HTML
- [x] HTTP response tests: all rendering modes (light, shadow, iframe, chromeless)
  and query param override
- [x] Manual verification: `cem generate` on patternfly-elements produces 36
  declarations with demos and correct URLs
- [x] `go test ./... -count=1` passes
- [x] `golangci-lint run` clean

Assisted-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frontmatter parsing to correctly handle empty frontmatter delimiters and missing closing delimiters
  * Enhanced demo discovery with workspace-relative path support through improved URL pattern matching fallback

* **New Features**
  * Added query parameter support for controlling demo rendering behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bennypowers/cem/pull/331)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->