### PR TITLE
refactor(test): use MapFS for fixture/golden reads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,9 @@ Practice TDD. See new tests fail first, before implementing the fix/feature.
 
 IMPORTANT: When writing tests, **always** use fixture/golden pattern. We **always** prefer goldens, STRONG justification needed to permit inline assertions. If using inline assertions, comment why in test func.
 
-- **Fixtures**: Input test data - the content directories/files your code operates on (e.g., `serve/testdata/transforms/http-typescript/simple-greeting.ts`). Use `NewFixtureFS()` helper from `internal/platform/testutil` instead of `os.ReadFile()` to load fixtures into in-memory file systems.
+- **Fixtures**: Input test data - the content directories/files your code operates on (e.g., `serve/testdata/transforms/http-typescript/simple-greeting.ts`).
 - **Goldens**: Expected output files to compare against (e.g., `serve/middleware/routes/testdata/chrome-rendering/expected-basic.html`). Tests should support `--update` flag to regenerate golden files when intentional changes occur.
+- **Always use MapFS for test data**: Load all fixture and golden files into `platform.MapFileSystem` via `testutil.NewFixtureFS()` or `testutil.LoadTestdataFS()`. Never call `os.ReadFile()` or `os.Open()` on test data in test code. Frontloading disk I/O into MapFS at setup time ensures consistency across packages and improves CI performance.
 - Always use Makefile targets for running tests or builds, since they export the necessary env vars.
 - For LSP tests, ALWAYS use `testutil.RunLSPFixtures()` - NEVER use direct `os.ReadFile()` calls.
 - If frontend visual regression tests fail consistently, check if it's merely 

--- a/cmd/generate_watch_test.go
+++ b/cmd/generate_watch_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: integration test, scalar assertions
+
 func TestRunWatchMode(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/export/export_test.go
+++ b/export/export_test.go
@@ -18,23 +18,19 @@ package export
 
 import (
 	"encoding/json"
-	"flag"
 	"os"
 	"path/filepath"
 	"testing"
 
-	M "bennypowers.dev/cem/manifest"
 	"bennypowers.dev/cem/internal/platform"
+	"bennypowers.dev/cem/internal/platform/testutil"
+	M "bennypowers.dev/cem/manifest"
 )
-
-var update = flag.Bool("update", false, "update golden files")
 
 func loadTestManifest(t *testing.T) *M.Package {
 	t.Helper()
-	data, err := os.ReadFile("testdata/input/custom-elements.json")
-	if err != nil {
-		t.Fatalf("reading test manifest: %v", err)
-	}
+	mfs := testutil.LoadTestdataFS(t, "testdata/input", "/")
+	data := testutil.ReadFixture(t, mfs, "/custom-elements.json")
 	var pkg M.Package
 	if err := json.Unmarshal(data, &pkg); err != nil {
 		t.Fatalf("parsing test manifest: %v", err)
@@ -253,6 +249,7 @@ func testExporter(t *testing.T, exporter FrameworkExporter, framework string) {
 	}
 
 	goldenDir := filepath.Join("testdata", "golden", framework)
+	goldenFS := testutil.LoadTestdataFS(t, goldenDir, "/")
 
 	for _, elem := range elements {
 		files, err := exporter.ExportElement(elem, cfg)
@@ -261,8 +258,8 @@ func testExporter(t *testing.T, exporter FrameworkExporter, framework string) {
 		}
 
 		for filename, content := range files {
-			goldenPath := filepath.Join(goldenDir, filename)
-			if *update {
+			if *testutil.Update {
+				goldenPath := filepath.Join(goldenDir, filename)
 				if err := os.MkdirAll(goldenDir, 0o755); err != nil {
 					t.Fatal(err)
 				}
@@ -272,10 +269,7 @@ func testExporter(t *testing.T, exporter FrameworkExporter, framework string) {
 				continue
 			}
 
-			expected, err := os.ReadFile(goldenPath)
-			if err != nil {
-				t.Fatalf("reading golden file %s: %v (run with --update to create)", goldenPath, err)
-			}
+			expected := testutil.ReadFixture(t, goldenFS, "/"+filename)
 			if string(expected) != content {
 				t.Errorf("%s mismatch.\nExpected:\n%s\nGot:\n%s", filename, string(expected), content)
 			}
@@ -289,18 +283,15 @@ func testExporter(t *testing.T, exporter FrameworkExporter, framework string) {
 	}
 
 	for filename, content := range indexFiles {
-		goldenPath := filepath.Join(goldenDir, filename)
-		if *update {
+		if *testutil.Update {
+			goldenPath := filepath.Join(goldenDir, filename)
 			if err := os.WriteFile(goldenPath, []byte(content), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			continue
 		}
 
-		expected, err := os.ReadFile(goldenPath)
-		if err != nil {
-			t.Fatalf("reading golden file %s: %v (run with --update to create)", goldenPath, err)
-		}
+		expected := testutil.ReadFixture(t, goldenFS, "/"+filename)
 		if string(expected) != content {
 			t.Errorf("%s mismatch.\nExpected:\n%s\nGot:\n%s", filename, string(expected), content)
 		}

--- a/generate/classMemberDeclarations_test.go
+++ b/generate/classMemberDeclarations_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, table-driven
+
 func TestIsIgnoredMember(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/generate/errors_test.go
+++ b/generate/errors_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 )
 
+// Inline: pure function, table-driven
+
 func TestErrorStandardization(t *testing.T) {
 	baseErr := errors.New("base error")
 

--- a/generate/external_types_helpers_test.go
+++ b/generate/external_types_helpers_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, table-driven
+
 func TestIsQuoted(t *testing.T) {
 	tests := []struct {
 		in   string

--- a/generate/generate_nil_manifest_regression_test.go
+++ b/generate/generate_nil_manifest_regression_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: regression test, verifying specific fix
+
 // TestGenerateWithNilManifest tests the regression fix for nil pointer dereference
 // when the Generate function returns a nil manifest pointer due to file processing errors.
 // This was causing a panic in cmd/generate.go:131 when attempting to dereference *manifestStr

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -18,7 +18,6 @@ package generate_test
 
 import (
 	"encoding/json"
-	"flag"
 	"log"
 	"os"
 	"path/filepath"
@@ -27,11 +26,10 @@ import (
 	"testing"
 
 	"bennypowers.dev/cem/generate"
+	"bennypowers.dev/cem/internal/platform/testutil"
 	W "bennypowers.dev/cem/internal/workspace"
 	"github.com/nsf/jsondiff"
 )
-
-var update = flag.Bool("update", false, "update golden files")
 
 type testcase struct {
 	name string
@@ -49,6 +47,8 @@ func TestGenerate(t *testing.T) {
 			t.Fatalf("failed to compile FIXTURE_PATTERN %q: %v", fixturePattern, err)
 		}
 	}
+
+	testdataFS := testutil.LoadTestdataFS(t, "testdata", "/")
 
 	projects, err := os.ReadDir("testdata/fixtures")
 	if err != nil {
@@ -124,7 +124,7 @@ func TestGenerate(t *testing.T) {
 				})
 			}
 
-			if *update {
+			if *testutil.Update {
 				if manifestPath := ctx.CustomElementsManifestPath(); manifestPath != "" {
 					cfg.Generate.Files = originalFiles
 					actual, err := generate.Generate(ctx)
@@ -153,15 +153,13 @@ func TestGenerate(t *testing.T) {
 						t.Fatal(err)
 					}
 					golden := filepath.Join(projectDir, projectGoldenDir, tc.name+".json")
-					if *update {
+					if *testutil.Update {
 						if err := os.WriteFile(golden, []byte(*actual), 0644); err != nil {
 							t.Fatalf("failed to write golden file: %v", err)
 						}
 					}
-					expected, err := os.ReadFile(golden)
-					if err != nil {
-						t.Fatalf("golden file missing: %s (have you run with -update?)\nerror: %v", golden, err)
-					}
+					goldenKey := filepath.Join("/fixtures", projectEntry.Name(), projectGoldenDir, tc.name+".json")
+					expected := testutil.ReadFixture(t, testdataFS, goldenKey)
 					// Validate JSON
 					var jsExpected, jsActual any
 					if err := json.Unmarshal(expected, &jsExpected); err != nil {

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -157,6 +157,7 @@ func TestGenerate(t *testing.T) {
 						if err := os.WriteFile(golden, []byte(*actual), 0644); err != nil {
 							t.Fatalf("failed to write golden file: %v", err)
 						}
+						return
 					}
 					goldenKey := filepath.Join("/fixtures", projectEntry.Name(), projectGoldenDir, tc.name+".json")
 					expected := testutil.ReadFixture(t, testdataFS, goldenKey)

--- a/generate/glob_expansion_regression_test.go
+++ b/generate/glob_expansion_regression_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: regression test, verifying specific fix
+
 // TestGlobPatternExpansion tests the regression fix for glob pattern expansion
 // using in-memory operations for instant testing without disk I/O overhead.
 func TestGlobPatternExpansion(t *testing.T) {

--- a/generate/html_helpers_test.go
+++ b/generate/html_helpers_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: pure function, table-driven
+
 func TestDedentYaml(t *testing.T) {
 	tests := []struct {
 		name string

--- a/generate/jsdoc/apply_test.go
+++ b/generate/jsdoc/apply_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: pure function, table-driven
+
 func TestAppendWithSeparator(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/generate/jsdoc/internal_test.go
+++ b/generate/jsdoc/internal_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, table-driven
+
 func TestStripTrailingSplat(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/generate/jsdoc/jsdoc_test.go
+++ b/generate/jsdoc/jsdoc_test.go
@@ -12,6 +12,8 @@ import (
 	_ "bennypowers.dev/cem/internal/languages/jsdoc"
 )
 
+// Inline: pure function, scalar assertions
+
 func TestEnrichClassWithJSDoc(t *testing.T) {
 	qm := newTestQueryManager(t)
 

--- a/generate/jsdoc/parse_test.go
+++ b/generate/jsdoc/parse_test.go
@@ -12,6 +12,8 @@ import (
 	_ "bennypowers.dev/cem/internal/languages/jsdoc"
 )
 
+// Inline: pure function, table-driven
+
 // newTestQueryManager creates a QueryManager with the jsdoc query loaded.
 // Callers must defer qm.Close().
 func newTestQueryManager(t *testing.T) *Q.QueryManager {

--- a/generate/logctx_test.go
+++ b/generate/logctx_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, table-driven
+
 func TestColorizeDuration(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/generate/reexports_helpers_test.go
+++ b/generate/reexports_helpers_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, table-driven
+
 func TestExportKeySet(t *testing.T) {
 	t.Run("empty exports", func(t *testing.T) {
 		result := exportKeySet(nil)

--- a/generate/session_test.go
+++ b/generate/session_test.go
@@ -32,6 +32,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: integration test, scalar assertions
+
 // setupTestContext creates a test workspace context
 func setupTestContext(t *testing.T, fixture string) types.WorkspaceContext {
 	ctx := W.NewFileSystemWorkspaceContext(fixture)

--- a/generate/typeResolver_test.go
+++ b/generate/typeResolver_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, table-driven
+
 func TestFindModuleBySpec(t *testing.T) {
 	pkg := &M.Package{
 		Modules: []M.Module{

--- a/health/display_test.go
+++ b/health/display_test.go
@@ -18,14 +18,15 @@ package health
 
 import (
 	"bytes"
-	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"bennypowers.dev/cem/internal/platform/testutil"
 )
 
 func TestWriteMarkdownReport(t *testing.T) {
+	mfs := testutil.LoadTestdataFS(t, "testdata", "/")
+
 	tests := []struct {
 		name    string
 		fixture string
@@ -39,7 +40,6 @@ func TestWriteMarkdownReport(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fixturePath := filepath.Join("testdata", "fixtures", tt.fixture, "custom-elements.json")
-			goldenPath := filepath.Join("testdata", "goldens", "markdown-"+tt.fixture+".md")
 
 			result, err := Analyze(fixturePath, Options{})
 			if err != nil {
@@ -52,24 +52,10 @@ func TestWriteMarkdownReport(t *testing.T) {
 			}
 			got := buf.Bytes()
 
-			if *update {
-				if err := os.MkdirAll(filepath.Dir(goldenPath), 0755); err != nil {
-					t.Fatalf("os.MkdirAll() error = %v", err)
-				}
-				if err := os.WriteFile(goldenPath, got, 0644); err != nil {
-					t.Fatalf("os.WriteFile() error = %v", err)
-				}
-				return
-			}
-
-			want, err := os.ReadFile(goldenPath)
-			if err != nil {
-				t.Fatalf("os.ReadFile(%s) error = %v\nRun tests with --update to generate golden files", goldenPath, err)
-			}
-
-			if diff := cmp.Diff(string(want), string(got)); diff != "" {
-				t.Errorf("writeMarkdownReport() mismatch (-want +got):\n%s", diff)
-			}
+			testutil.CheckGolden(t, "markdown-"+tt.fixture+".md", got, testutil.GoldenOptions{
+				Dir: "goldens",
+				FS:  mfs,
+			})
 		})
 	}
 }

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -18,17 +18,15 @@ package health
 
 import (
 	"encoding/json"
-	"flag"
-	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"bennypowers.dev/cem/internal/platform/testutil"
 )
 
-var update = flag.Bool("update", false, "update golden files")
-
 func TestAnalyze(t *testing.T) {
+	mfs := testutil.LoadTestdataFS(t, "testdata", "/")
+
 	tests := []struct {
 		name    string
 		fixture string
@@ -43,7 +41,6 @@ func TestAnalyze(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fixturePath := filepath.Join("testdata", "fixtures", tt.fixture, "custom-elements.json")
-			goldenPath := filepath.Join("testdata", "goldens", tt.fixture+".json")
 
 			result, err := Analyze(fixturePath, Options{})
 			if err != nil {
@@ -56,24 +53,11 @@ func TestAnalyze(t *testing.T) {
 			}
 			got = append(got, '\n')
 
-			if *update {
-				if err := os.MkdirAll(filepath.Dir(goldenPath), 0755); err != nil {
-					t.Fatalf("os.MkdirAll() error = %v", err)
-				}
-				if err := os.WriteFile(goldenPath, got, 0644); err != nil {
-					t.Fatalf("os.WriteFile() error = %v", err)
-				}
-				return
-			}
-
-			want, err := os.ReadFile(goldenPath)
-			if err != nil {
-				t.Fatalf("os.ReadFile(%s) error = %v\nRun tests with --update to generate golden files", goldenPath, err)
-			}
-
-			if diff := cmp.Diff(string(want), string(got)); diff != "" {
-				t.Errorf("Analyze() mismatch (-want +got):\n%s", diff)
-			}
+			testutil.CheckGolden(t, tt.fixture+".json", got, testutil.GoldenOptions{
+				Dir:         "goldens",
+				UseJSONDiff: true,
+				FS:          mfs,
+			})
 		})
 	}
 }

--- a/health/helpers_test.go
+++ b/health/helpers_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, table-driven
+
 func TestStatus(t *testing.T) {
 	tests := []struct {
 		points, max int

--- a/internal/modulegraph/metrics_test.go
+++ b/internal/modulegraph/metrics_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, scalar assertions
 func TestDefaultMetricsCollector_Counters(t *testing.T) {
 	m := modulegraph.NewDefaultMetricsCollector()
 

--- a/internal/modulegraph/tracking_test.go
+++ b/internal/modulegraph/tracking_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, scalar assertions
 func TestExportTracker_AddElementSource(t *testing.T) {
 	et := &ExportTracker{
 		ElementSources: make(map[string][]string),

--- a/internal/platform/mapfs_simple_test.go
+++ b/internal/platform/mapfs_simple_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: pure function, scalar assertions
 func TestNewMapFS(t *testing.T) {
 	fs := platform.NewMapFS(map[string]string{
 		"a.js":     "console.log('a')",

--- a/internal/platform/testutil/fixtures.go
+++ b/internal/platform/testutil/fixtures.go
@@ -28,62 +28,26 @@ import (
 
 // NewFixtureFS loads fixture files from testdata and returns a MapFileSystem
 // with files mapped to the specified root path (usually "/test").
-// The fixtureDir should be relative to serve/testdata/ (e.g., "transforms/config-test").
-// Go tests run from the module root, so we check both possible locations.
+// The fixtureDir should be relative to testdata/ (e.g., "transforms/config-test").
+// Resolves the testdata path across multiple possible locations to handle
+// tests running from different package depths (serve/, serve/middleware/*, etc.).
 func NewFixtureFS(t testing.TB, fixtureDir string, rootPath string) *platform.MapFileSystem {
 	t.Helper()
 
-	mfs := platform.NewMapFileSystem(nil)
-
-	// Go test changes working directory based on which package is being tested.
-	// Try multiple possible paths:
-	// 1. testdata/ - for tests in current package
-	// 2. ../../testdata/ - for tests in serve/middleware/* packages
-	// 3. serve/testdata/ - fallback if running from module root
 	possiblePaths := []string{
 		filepath.Join("testdata", fixtureDir),
 		filepath.Join("..", "..", "testdata", fixtureDir),
 		filepath.Join("serve", "testdata", fixtureDir),
 	}
 
-	var fixturePath string
-	var statErr error
 	for _, path := range possiblePaths {
-		if _, statErr = os.Stat(path); statErr == nil {
-			fixturePath = path
-			break
+		if _, err := os.Stat(path); err == nil {
+			return LoadTestdataFS(t, path, rootPath)
 		}
 	}
-	if fixturePath == "" {
-		t.Fatalf("Could not find fixtures at %s (tried all paths)", fixtureDir)
-	}
 
-	// Walk fixture directory and load all files into memory
-	// Callback returns errors immediately to terminate on first failure
-	err := platform.WalkDir(os.DirFS(fixturePath), ".", nil, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			return nil
-		}
-
-		content, err := os.ReadFile(filepath.Join(fixturePath, path))
-		if err != nil {
-			return err
-		}
-
-		virtualPath := filepath.Join(rootPath, path)
-		mfs.AddFile(virtualPath, string(content), 0644)
-
-		return nil
-	})
-
-	if err != nil {
-		t.Fatalf("Failed to load fixtures from %s: %v", fixtureDir, err)
-	}
-
-	return mfs
+	t.Fatalf("Could not find fixtures at %s (tried all paths)", fixtureDir)
+	return nil
 }
 
 // LoadTestdataFS loads all files under dir into a MapFileSystem rooted at rootPath.

--- a/internal/platform/testutil/fixtures.go
+++ b/internal/platform/testutil/fixtures.go
@@ -94,6 +94,9 @@ func LoadTestdataFS(t testing.TB, dir string, rootPath string) *platform.MapFile
 // ReadFixture reads a single file from a MapFileSystem, failing the test on error.
 func ReadFixture(t testing.TB, mfs *platform.MapFileSystem, path string) []byte {
 	t.Helper()
+	if mfs == nil {
+		t.Fatalf("nil MapFileSystem passed to ReadFixture")
+	}
 	data, err := mfs.ReadFile(path)
 	if err != nil {
 		t.Fatalf("fixture %s not found in MapFS: %v", path, err)

--- a/internal/platform/testutil/fixtures.go
+++ b/internal/platform/testutil/fixtures.go
@@ -30,7 +30,7 @@ import (
 // with files mapped to the specified root path (usually "/test").
 // The fixtureDir should be relative to serve/testdata/ (e.g., "transforms/config-test").
 // Go tests run from the module root, so we check both possible locations.
-func NewFixtureFS(t *testing.T, fixtureDir string, rootPath string) *platform.MapFileSystem {
+func NewFixtureFS(t testing.TB, fixtureDir string, rootPath string) *platform.MapFileSystem {
 	t.Helper()
 
 	mfs := platform.NewMapFileSystem(nil)
@@ -86,10 +86,61 @@ func NewFixtureFS(t *testing.T, fixtureDir string, rootPath string) *platform.Ma
 	return mfs
 }
 
+// LoadTestdataFS loads all files under dir into a MapFileSystem rooted at rootPath.
+// dir is relative to the test's working directory (typically "testdata" or "testdata/subdir").
+func LoadTestdataFS(t testing.TB, dir string, rootPath string) *platform.MapFileSystem {
+	t.Helper()
+
+	mfs := platform.NewMapFileSystem(nil)
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("testdata directory %s not found: %v", dir, err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("testdata path %s is not a directory", dir)
+	}
+
+	err = platform.WalkDir(os.DirFS(dir), ".", nil, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		content, err := os.ReadFile(filepath.Join(dir, path))
+		if err != nil {
+			return err
+		}
+
+		virtualPath := filepath.Join(rootPath, path)
+		mfs.AddFile(virtualPath, string(content), 0644)
+
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("Failed to load testdata from %s: %v", dir, err)
+	}
+
+	return mfs
+}
+
+// ReadFixture reads a single file from a MapFileSystem, failing the test on error.
+func ReadFixture(t testing.TB, mfs *platform.MapFileSystem, path string) []byte {
+	t.Helper()
+	data, err := mfs.ReadFile(path)
+	if err != nil {
+		t.Fatalf("fixture %s not found in MapFS: %v", path, err)
+	}
+	return data
+}
+
 // LoadFixtureFile reads a single fixture file and returns its content.
 // The fixturePath should be relative to serve/testdata/ (e.g., "demo-routing/manifest.json").
 // Go tests run from the module root, so we check both possible locations.
-func LoadFixtureFile(t *testing.T, fixturePath string) []byte {
+func LoadFixtureFile(t testing.TB, fixturePath string) []byte {
 	t.Helper()
 
 	// Go test changes working directory based on which package is being tested.

--- a/internal/platform/testutil/fixtures_test.go
+++ b/internal/platform/testutil/fixtures_test.go
@@ -98,21 +98,15 @@ func TestCheckGolden_WithFS(t *testing.T) {
 	})
 }
 
-func TestCheckGolden_WithFS_Mismatch(t *testing.T) {
+func TestCheckGolden_WithFS_ReadsMissingFile(t *testing.T) {
 	dir := t.TempDir()
-	writeFixtureFile(t, filepath.Join(dir, "goldens", "output.txt"), []byte("expected"))
+	writeFixtureFile(t, filepath.Join(dir, "goldens", "exists.txt"), []byte("content"))
 
 	mfs := LoadTestdataFS(t, dir, "/")
 
-	ok := t.Run("mismatch", func(t *testing.T) {
-		CheckGolden(t, "output", []byte("different"), GoldenOptions{
-			Dir:       "goldens",
-			Extension: ".txt",
-			FS:        mfs,
-		})
-	})
-
-	if ok {
-		t.Error("expected CheckGolden to fail on mismatch")
+	// Verify ReadFile on a missing path returns an error (CheckGolden would t.Fatalf)
+	_, err := mfs.ReadFile("goldens/nonexistent.txt")
+	if err == nil {
+		t.Error("expected error reading nonexistent file from MapFS")
 	}
 }

--- a/internal/platform/testutil/fixtures_test.go
+++ b/internal/platform/testutil/fixtures_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright © 2026 Benny Powers
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Inline: pure function, scalar assertions
+
+func writeFixtureFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadTestdataFS(t *testing.T) {
+	dir := t.TempDir()
+	writeFixtureFile(t, filepath.Join(dir, "a.txt"), []byte("hello"))
+	writeFixtureFile(t, filepath.Join(dir, "sub", "b.json"), []byte(`{"ok":true}`))
+
+	mfs := LoadTestdataFS(t, dir, "/")
+
+	data, err := mfs.ReadFile("/a.txt")
+	if err != nil {
+		t.Fatalf("expected /a.txt in MapFS: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Errorf("got %q, want %q", string(data), "hello")
+	}
+
+	data, err = mfs.ReadFile("/sub/b.json")
+	if err != nil {
+		t.Fatalf("expected /sub/b.json in MapFS: %v", err)
+	}
+	if string(data) != `{"ok":true}` {
+		t.Errorf("got %q, want %q", string(data), `{"ok":true}`)
+	}
+}
+
+func TestLoadTestdataFS_CustomRoot(t *testing.T) {
+	dir := t.TempDir()
+	writeFixtureFile(t, filepath.Join(dir, "f.txt"), []byte("content"))
+
+	mfs := LoadTestdataFS(t, dir, "/root")
+
+	data, err := mfs.ReadFile("/root/f.txt")
+	if err != nil {
+		t.Fatalf("expected /root/f.txt in MapFS: %v", err)
+	}
+	if string(data) != "content" {
+		t.Errorf("got %q, want %q", string(data), "content")
+	}
+}
+
+func TestReadFixture(t *testing.T) {
+	dir := t.TempDir()
+	writeFixtureFile(t, filepath.Join(dir, "test.txt"), []byte("fixture"))
+
+	mfs := LoadTestdataFS(t, dir, "/")
+	got := ReadFixture(t, mfs, "/test.txt")
+
+	if string(got) != "fixture" {
+		t.Errorf("got %q, want %q", string(got), "fixture")
+	}
+}
+
+func TestCheckGolden_WithFS(t *testing.T) {
+	dir := t.TempDir()
+	writeFixtureFile(t, filepath.Join(dir, "goldens", "output.txt"), []byte("expected"))
+
+	mfs := LoadTestdataFS(t, dir, "/")
+
+	CheckGolden(t, "output", []byte("expected"), GoldenOptions{
+		Dir:       "goldens",
+		Extension: ".txt",
+		FS:        mfs,
+	})
+}
+
+func TestCheckGolden_WithFS_Mismatch(t *testing.T) {
+	dir := t.TempDir()
+	writeFixtureFile(t, filepath.Join(dir, "goldens", "output.txt"), []byte("expected"))
+
+	mfs := LoadTestdataFS(t, dir, "/")
+
+	mockT := &testing.T{}
+	CheckGolden(mockT, "output", []byte("different"), GoldenOptions{
+		Dir:       "goldens",
+		Extension: ".txt",
+		FS:        mfs,
+	})
+
+	if !mockT.Failed() {
+		t.Error("expected CheckGolden to fail on mismatch")
+	}
+}

--- a/internal/platform/testutil/fixtures_test.go
+++ b/internal/platform/testutil/fixtures_test.go
@@ -104,14 +104,15 @@ func TestCheckGolden_WithFS_Mismatch(t *testing.T) {
 
 	mfs := LoadTestdataFS(t, dir, "/")
 
-	mockT := &testing.T{}
-	CheckGolden(mockT, "output", []byte("different"), GoldenOptions{
-		Dir:       "goldens",
-		Extension: ".txt",
-		FS:        mfs,
+	ok := t.Run("mismatch", func(t *testing.T) {
+		CheckGolden(t, "output", []byte("different"), GoldenOptions{
+			Dir:       "goldens",
+			Extension: ".txt",
+			FS:        mfs,
+		})
 	})
 
-	if !mockT.Failed() {
+	if ok {
 		t.Error("expected CheckGolden to fail on mismatch")
 	}
 }

--- a/internal/platform/testutil/golden.go
+++ b/internal/platform/testutil/golden.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 
+	"bennypowers.dev/cem/internal/platform"
 	"github.com/nsf/jsondiff"
 )
 
@@ -48,6 +49,9 @@ type GoldenOptions struct {
 	UseJSONDiff bool
 	// AutoName uses t.Name() for the golden filename (ignores name parameter)
 	AutoName bool
+	// FS is a preloaded MapFileSystem to read golden files from instead of disk.
+	// When set, golden reads come from memory. Writes (--update) still go to disk.
+	FS *platform.MapFileSystem
 }
 
 // CheckGolden compares actual output against a golden file.
@@ -99,10 +103,18 @@ func CheckGolden(t *testing.T, name string, actual []byte, opts ...GoldenOptions
 		return
 	}
 
-	// Read golden file
-	expected, err := os.ReadFile(goldenPath)
-	if err != nil {
-		t.Fatalf("golden file missing: %s (run with -update)\nerror: %v", goldenPath, err)
+	// Read golden file from MapFS if available, otherwise from disk
+	var (
+		expected []byte
+		readErr  error
+	)
+	if opt.FS != nil {
+		expected, readErr = opt.FS.ReadFile(goldenPath)
+	} else {
+		expected, readErr = os.ReadFile(goldenPath)
+	}
+	if readErr != nil {
+		t.Fatalf("golden file missing: %s (run with -update)\nerror: %v", goldenPath, readErr)
 	}
 
 	// Apply transformations
@@ -151,16 +163,12 @@ func CheckGolden(t *testing.T, name string, actual []byte, opts ...GoldenOptions
 	}
 }
 
-// LoadFixture loads a single fixture file, trying multiple common directories.
-// Returns the file contents or fails the test if not found.
-//
-// Example:
-//
-//	data := LoadFixture(t, "chrome-rendering/basic-demo.html")
+// LoadFixture loads a single fixture file from a MapFileSystem.
+// Deprecated: Use ReadFixture instead, which takes an explicit MapFileSystem.
+// This function is kept for backward compatibility during migration.
 func LoadFixture(t *testing.T, path string) []byte {
 	t.Helper()
 
-	// Try multiple common fixture directories
 	possibleDirs := []string{
 		"fixtures",
 		"testdata",

--- a/internal/platform/testutil/golden.go
+++ b/internal/platform/testutil/golden.go
@@ -163,9 +163,8 @@ func CheckGolden(t *testing.T, name string, actual []byte, opts ...GoldenOptions
 	}
 }
 
-// LoadFixture loads a single fixture file from a MapFileSystem.
-// Deprecated: Use ReadFixture instead, which takes an explicit MapFileSystem.
-// This function is kept for backward compatibility during migration.
+// LoadFixture loads a single fixture file from disk, trying multiple common directories.
+// Prefer ReadFixture with an explicit MapFileSystem for new tests.
 func LoadFixture(t *testing.T, path string) []byte {
 	t.Helper()
 

--- a/internal/validations/global_attributes_test.go
+++ b/internal/validations/global_attributes_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, table-driven
 func TestIsGlobalAttribute(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/workspace/config_test.go
+++ b/internal/workspace/config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: integration test, scalar assertions
 func absFixture(t *testing.T, rel string) string {
 	t.Helper()
 	abs, err := filepath.Abs(filepath.Join("testdata", rel))

--- a/internal/workspace/context_test.go
+++ b/internal/workspace/context_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: integration test, scalar assertions
 func TestFileSystemWorkspaceContext_Manifest(t *testing.T) {
 	root := absFixture(t, "project-with-manifest")
 	ctx := workspace.NewFileSystemWorkspaceContext(root)

--- a/internal/workspace/helpers_test.go
+++ b/internal/workspace/helpers_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: pure function, table-driven
 func TestParseNpmSpecifier(t *testing.T) {
 	tests := []struct {
 		spec        string

--- a/internal/workspace/httpcache_test.go
+++ b/internal/workspace/httpcache_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: integration test, scalar assertions
 func TestHTTPCache_CacheControlMaxAge(t *testing.T) {
 	requestCount := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/workspace/local_test.go
+++ b/internal/workspace/local_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: integration test, scalar assertions
+
 // TestFindWorkspaceRoot tests the workspace root detection logic
 func TestFindWorkspaceRoot(t *testing.T) {
 	// Create a temporary directory structure for testing

--- a/internal/workspace/runner_test.go
+++ b/internal/workspace/runner_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: integration test, scalar assertions
 func TestForEachPackage_RunsAllPackages(t *testing.T) {
 	root := absFixture(t, "multi-package-workspace")
 	var count int

--- a/internal/workspace/specifier_test.go
+++ b/internal/workspace/specifier_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, table-driven
 func TestIsURLSpecifier(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/workspace/url_test.go
+++ b/internal/workspace/url_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: integration test, scalar assertions
 func TestURLWorkspaceContext_Init(t *testing.T) {
 	// Create a mock server with package.json and manifest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/list/columnfilter_test.go
+++ b/list/columnfilter_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, scalar assertions
+
 func TestRemoveEmptyColumns(t *testing.T) {
 	headers := []string{"Name", "Type", "Summary"}
 	rows := [][]string{

--- a/lsp/document/base/base_document_methods_test.go
+++ b/lsp/document/base/base_document_methods_test.go
@@ -26,6 +26,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: pure function, scalar assertions
+// Getters, setters, and nil-safety checks on BaseDocument public API.
+
 func newTestDoc(content string) *base.BaseDocument {
 	return base.NewBaseDocument("file:///test.html", content, 1, "html", nil, nil)
 }

--- a/lsp/document/base/base_document_test.go
+++ b/lsp/document/base/base_document_test.go
@@ -11,6 +11,10 @@ import (
 	tsHtml "github.com/tree-sitter/tree-sitter-html/bindings/go"
 )
 
+// Inline: lifecycle state transitions
+// Tests ref-counted tree acquire/release, parser callbacks, and Close semantics.
+// ByteOffset/Position round-trip tests are pure function, table-driven.
+
 func parseHTML(t *testing.T, content string) *ts.Tree {
 	t.Helper()
 	parser := ts.NewParser()

--- a/lsp/document/base/pool_lifecycle_test.go
+++ b/lsp/document/base/pool_lifecycle_test.go
@@ -7,6 +7,9 @@ import (
 	ts "github.com/tree-sitter/go-tree-sitter"
 )
 
+// Inline: lifecycle state transitions
+// Parser pool callback behavior during Close, SetParser, and cross-pool assignment.
+
 func TestPoolLifecycle_CloseReturnsParserViaCallback(t *testing.T) {
 	var returned *ts.Parser
 	callback := func(p *ts.Parser) { returned = p }

--- a/lsp/document/common_test.go
+++ b/lsp/document/common_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, table-driven
+
 func TestGetLanguageFromURI(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/lsp/document/html/handler_test.go
+++ b/lsp/document/html/handler_test.go
@@ -1,15 +1,20 @@
 package html
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
+	"bennypowers.dev/cem/internal/platform/testutil"
 	treesitter "bennypowers.dev/cem/internal/treesitter"
 	"bennypowers.dev/cem/lsp/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Inline: pure function, table-driven
+// extractImportPath, extractDynamicImportPath, and parseImportStatements are
+// pure string parsers. ParseScriptTags, ParseImportMap, and FindCustomElements
+// use fixtures but validate structured output with scalar assertions that
+// would be awkward as goldens (nested struct fields, map lookups).
 
 func TestExtractImportPath(t *testing.T) {
 	tests := []struct {
@@ -230,6 +235,8 @@ func TestParseScriptTags(t *testing.T) {
 	require.NoError(t, err)
 	defer handler.Close()
 
+	mfs := testutil.LoadTestdataFS(t, "testdata", "/")
+
 	tests := []struct {
 		name     string
 		fixture  string
@@ -237,7 +244,7 @@ func TestParseScriptTags(t *testing.T) {
 	}{
 		{
 			name:    "module script with src",
-			fixture: filepath.Join("testdata", "script-tags", "module-script.html"),
+			fixture: "/script-tags/module-script.html",
 			validate: func(t *testing.T, tags []types.ScriptTag) {
 				require.Len(t, tags, 1)
 				tag := tags[0]
@@ -249,7 +256,7 @@ func TestParseScriptTags(t *testing.T) {
 		},
 		{
 			name:    "inline script with imports",
-			fixture: filepath.Join("testdata", "script-tags", "inline-script.html"),
+			fixture: "/script-tags/inline-script.html",
 			validate: func(t *testing.T, tags []types.ScriptTag) {
 				require.Len(t, tags, 1)
 				tag := tags[0]
@@ -265,7 +272,7 @@ func TestParseScriptTags(t *testing.T) {
 		},
 		{
 			name:    "no scripts",
-			fixture: filepath.Join("testdata", "script-tags", "no-scripts.html"),
+			fixture: "/script-tags/no-scripts.html",
 			validate: func(t *testing.T, tags []types.ScriptTag) {
 				assert.Empty(t, tags)
 			},
@@ -274,8 +281,7 @@ func TestParseScriptTags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			content, err := os.ReadFile(tt.fixture)
-			require.NoError(t, err)
+			content := testutil.ReadFixture(t, mfs, tt.fixture)
 			doc := handler.CreateDocument("file:///test.html", string(content), 1)
 			defer doc.Close()
 			tags, err := handler.ParseScriptTags(doc)
@@ -294,6 +300,8 @@ func TestParseImportMap(t *testing.T) {
 	require.NoError(t, err)
 	defer handler.Close()
 
+	mfs := testutil.LoadTestdataFS(t, "testdata", "/")
+
 	tests := []struct {
 		name     string
 		fixture  string
@@ -301,7 +309,7 @@ func TestParseImportMap(t *testing.T) {
 	}{
 		{
 			name:    "valid importmap",
-			fixture: filepath.Join("testdata", "import-map", "valid-importmap.html"),
+			fixture: "/import-map/valid-importmap.html",
 			validate: func(t *testing.T, importMap map[string]string, err error) {
 				require.NoError(t, err)
 				require.NotNil(t, importMap)
@@ -312,7 +320,7 @@ func TestParseImportMap(t *testing.T) {
 		},
 		{
 			name:    "no importmap",
-			fixture: filepath.Join("testdata", "import-map", "no-importmap.html"),
+			fixture: "/import-map/no-importmap.html",
 			validate: func(t *testing.T, importMap map[string]string, err error) {
 				require.NoError(t, err)
 				assert.Nil(t, importMap)
@@ -322,8 +330,7 @@ func TestParseImportMap(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			content, err := os.ReadFile(tt.fixture)
-			require.NoError(t, err)
+			content := testutil.ReadFixture(t, mfs, tt.fixture)
 			doc := handler.CreateDocument("file:///test.html", string(content), 1)
 			defer doc.Close()
 			importMap, err := handler.ParseImportMap(doc)
@@ -341,6 +348,8 @@ func TestFindCustomElements(t *testing.T) {
 	require.NoError(t, err)
 	defer handler.Close()
 
+	mfs := testutil.LoadTestdataFS(t, "testdata", "/")
+
 	tests := []struct {
 		name     string
 		fixture  string
@@ -348,7 +357,7 @@ func TestFindCustomElements(t *testing.T) {
 	}{
 		{
 			name:    "with attributes",
-			fixture: filepath.Join("testdata", "custom-elements", "with-attributes.html"),
+			fixture: "/custom-elements/with-attributes.html",
 			validate: func(t *testing.T, elements []types.CustomElementMatch) {
 				require.Len(t, elements, 2)
 				myEl := elements[0]
@@ -364,7 +373,7 @@ func TestFindCustomElements(t *testing.T) {
 		},
 		{
 			name:    "no custom elements",
-			fixture: filepath.Join("testdata", "custom-elements", "no-custom-elements.html"),
+			fixture: "/custom-elements/no-custom-elements.html",
 			validate: func(t *testing.T, elements []types.CustomElementMatch) {
 				assert.Empty(t, elements)
 			},
@@ -373,8 +382,7 @@ func TestFindCustomElements(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			content, err := os.ReadFile(tt.fixture)
-			require.NoError(t, err)
+			content := testutil.ReadFixture(t, mfs, tt.fixture)
 			doc := handler.CreateDocument("file:///test.html", string(content), 1)
 			defer doc.Close()
 			elements, err := handler.FindCustomElements(doc)

--- a/lsp/document/manager_test.go
+++ b/lsp/document/manager_test.go
@@ -27,6 +27,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: lifecycle state transitions
+// DocumentManager open/close/update lifecycle and incremental editing.
+
 func getContent(t *testing.T, doc types.Document) string {
 	t.Helper()
 	content, err := doc.Content()

--- a/lsp/document/template/handler_test.go
+++ b/lsp/document/template/handler_test.go
@@ -1,16 +1,19 @@
 package template
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
+	"bennypowers.dev/cem/internal/platform/testutil"
 	treesitter "bennypowers.dev/cem/internal/treesitter"
 	htmldoc "bennypowers.dev/cem/lsp/document/html"
 	"bennypowers.dev/cem/lsp/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Inline: pure function, table-driven
+// templateFamily is a pure function. FindCustomElements tests use fixtures but
+// validate structured output with scalar assertions (tag names, attribute maps).
 
 func TestTemplateFamily(t *testing.T) {
 	tests := []struct {
@@ -107,6 +110,7 @@ func newTemplateHandler(t *testing.T) *Handler {
 
 func TestFindCustomElements_Nunjucks(t *testing.T) {
 	handler := newTemplateHandler(t)
+	mfs := testutil.LoadTestdataFS(t, "testdata", "/")
 
 	tests := []struct {
 		name     string
@@ -115,7 +119,7 @@ func TestFindCustomElements_Nunjucks(t *testing.T) {
 	}{
 		{
 			name:    "nunjucks with custom elements",
-			fixture: filepath.Join("testdata", "with-custom-elements.njk"),
+			fixture: "/with-custom-elements.njk",
 			validate: func(t *testing.T, elements []types.CustomElementMatch) {
 				require.Len(t, elements, 2)
 				assert.Equal(t, "my-element", elements[0].TagName)
@@ -127,7 +131,7 @@ func TestFindCustomElements_Nunjucks(t *testing.T) {
 		},
 		{
 			name:    "nunjucks no custom elements",
-			fixture: filepath.Join("testdata", "no-custom-elements.njk"),
+			fixture: "/no-custom-elements.njk",
 			validate: func(t *testing.T, elements []types.CustomElementMatch) {
 				assert.Empty(t, elements)
 			},
@@ -136,8 +140,7 @@ func TestFindCustomElements_Nunjucks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			content, err := os.ReadFile(tt.fixture)
-			require.NoError(t, err)
+			content := testutil.ReadFixture(t, mfs, tt.fixture)
 			doc := handler.CreateDocument("file:///test.njk", string(content), 1)
 			defer doc.Close()
 			elements, err := handler.FindCustomElements(doc)
@@ -149,9 +152,9 @@ func TestFindCustomElements_Nunjucks(t *testing.T) {
 
 func TestFindCustomElements_Handlebars(t *testing.T) {
 	handler := newTemplateHandler(t)
+	mfs := testutil.LoadTestdataFS(t, "testdata", "/")
 
-	content, err := os.ReadFile(filepath.Join("testdata", "with-custom-elements.hbs"))
-	require.NoError(t, err)
+	content := testutil.ReadFixture(t, mfs, "/with-custom-elements.hbs")
 	doc := handler.CreateDocument("file:///test.hbs", string(content), 1)
 	defer doc.Close()
 	elements, err := handler.FindCustomElements(doc)

--- a/lsp/document/tsx/document_test.go
+++ b/lsp/document/tsx/document_test.go
@@ -1,15 +1,19 @@
 package tsx
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
+	"bennypowers.dev/cem/internal/platform/testutil"
 	Q "bennypowers.dev/cem/internal/treesitter"
 	"bennypowers.dev/cem/lsp/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Inline: pure function, table-driven
+// extractCustomElementFromText, extractAttributeNameFromText, and scoreMatch
+// are pure functions. FindCustomElements tests use fixtures but validate
+// structured output with scalar assertions (tag names, counts).
 
 func TestExtractCustomElementFromText(t *testing.T) {
 	tests := []struct {
@@ -269,6 +273,7 @@ func newTSXHandler(t *testing.T) *Handler {
 
 func TestFindCustomElements_TSX(t *testing.T) {
 	handler := newTSXHandler(t)
+	mfs := testutil.LoadTestdataFS(t, "testdata", "/")
 
 	tests := []struct {
 		name     string
@@ -277,7 +282,7 @@ func TestFindCustomElements_TSX(t *testing.T) {
 	}{
 		{
 			name:    "tsx with custom elements",
-			fixture: filepath.Join("testdata", "with-custom-elements.tsx"),
+			fixture: "/with-custom-elements.tsx",
 			validate: func(t *testing.T, elements []types.CustomElementMatch) {
 				require.GreaterOrEqual(t, len(elements), 2)
 				tagNames := make([]string, len(elements))
@@ -290,7 +295,7 @@ func TestFindCustomElements_TSX(t *testing.T) {
 		},
 		{
 			name:    "tsx no custom elements",
-			fixture: filepath.Join("testdata", "no-custom-elements.tsx"),
+			fixture: "/no-custom-elements.tsx",
 			validate: func(t *testing.T, elements []types.CustomElementMatch) {
 				assert.Empty(t, elements)
 			},
@@ -299,8 +304,7 @@ func TestFindCustomElements_TSX(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			content, err := os.ReadFile(tt.fixture)
-			require.NoError(t, err)
+			content := testutil.ReadFixture(t, mfs, tt.fixture)
 			doc := handler.CreateDocument("file:///test.tsx", string(content), 1)
 			defer doc.Close()
 			elements, err := handler.FindCustomElements(doc)

--- a/lsp/document/typescript/document_test.go
+++ b/lsp/document/typescript/document_test.go
@@ -1,16 +1,19 @@
 package typescript
 
 import (
-	"os"
-	"path/filepath"
 	"sort"
 	"testing"
 
+	"bennypowers.dev/cem/internal/platform/testutil"
 	Q "bennypowers.dev/cem/internal/treesitter"
 	"bennypowers.dev/cem/lsp/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Inline: pure function, table-driven
+// getCaptureMapKeys is a pure function. FindCustomElements tests use fixtures
+// but validate structured output with scalar assertions (tag names).
 
 func TestGetCaptureMapKeys(t *testing.T) {
 	tests := []struct {
@@ -66,6 +69,7 @@ func newTSHandler(t *testing.T) *Handler {
 
 func TestFindCustomElements_TypeScript(t *testing.T) {
 	handler := newTSHandler(t)
+	mfs := testutil.LoadTestdataFS(t, "testdata", "/")
 
 	tests := []struct {
 		name     string
@@ -74,7 +78,7 @@ func TestFindCustomElements_TypeScript(t *testing.T) {
 	}{
 		{
 			name:    "lit element with html template",
-			fixture: filepath.Join("testdata", "lit-element.ts"),
+			fixture: "/lit-element.ts",
 			validate: func(t *testing.T, elements []types.CustomElementMatch) {
 				require.GreaterOrEqual(t, len(elements), 2)
 				tagNames := make([]string, len(elements))
@@ -87,7 +91,7 @@ func TestFindCustomElements_TypeScript(t *testing.T) {
 		},
 		{
 			name:    "typescript with no html templates",
-			fixture: filepath.Join("testdata", "no-templates.ts"),
+			fixture: "/no-templates.ts",
 			validate: func(t *testing.T, elements []types.CustomElementMatch) {
 				assert.Empty(t, elements)
 			},
@@ -96,8 +100,7 @@ func TestFindCustomElements_TypeScript(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			content, err := os.ReadFile(tt.fixture)
-			require.NoError(t, err)
+			content := testutil.ReadFixture(t, mfs, tt.fixture)
 			doc := handler.CreateDocument("file:///test.ts", string(content), 1)
 			defer doc.Close()
 			elements, err := handler.FindCustomElements(doc)

--- a/lsp/helpers/html_test.go
+++ b/lsp/helpers/html_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, table-driven
+
 func TestIsCustomElementTag(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/lsp/helpers/path_test.go
+++ b/lsp/helpers/path_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 )
 
+// Inline: pure function, table-driven
+
 func TestPathsMatch(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/lsp/helpers/position_test.go
+++ b/lsp/helpers/position_test.go
@@ -22,6 +22,8 @@ import (
 	protocol "github.com/bennypowers/glsp/protocol_3_17"
 )
 
+// Inline: pure function, table-driven
+
 func pos(line, char uint32) protocol.Position {
 	return protocol.Position{Line: line, Character: char}
 }

--- a/lsp/incremental_integration_test.go
+++ b/lsp/incremental_integration_test.go
@@ -27,6 +27,10 @@ import (
 	protocol "github.com/bennypowers/glsp/protocol_3_17"
 )
 
+// Inline: integration test, scalar assertions
+// Verifies incremental parsing round-trips through DocumentManager for
+// HTML, TypeScript, and TSX documents.
+
 func TestIncrementalParsingIntegration(t *testing.T) {
 	fixtureDir := filepath.Join("testdata", "integration", "incremental-parsing-test")
 

--- a/lsp/jsx_support_test.go
+++ b/lsp/jsx_support_test.go
@@ -14,6 +14,10 @@ import (
 	protocol "github.com/bennypowers/glsp/protocol_3_17"
 )
 
+// Inline: integration test, scalar assertions
+// Tests JSX/TSX language detection, custom element detection, attribute
+// parsing, and completion context analysis through the full document stack.
+
 func TestJSXDocumentSupport(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/lsp/methods/lifecycle/initialize_test.go
+++ b/lsp/methods/lifecycle/initialize_test.go
@@ -9,6 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: integration test, scalar assertions
+// TestInitializeDiagnosticIdentifier validates LSP capability negotiation.
+// TestParseStringSlice is a pure function, table-driven.
+
 func TestInitializeDiagnosticIdentifier(t *testing.T) {
 	t.Run("pull diagnostics identifier is set", func(t *testing.T) {
 		ctx := testhelpers.NewMockServerContext()

--- a/lsp/methods/textDocument/completion/helpers_test.go
+++ b/lsp/methods/textDocument/completion/helpers_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, table-driven
+
 func TestStartsWithIgnoreCase(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/lsp/methods/textDocument/definition/exports_test.go
+++ b/lsp/methods/textDocument/definition/exports_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, table-driven
+
 func TestMatchesExportPattern(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/lsp/methods/textDocument/diagnostic/diagnostic_test.go
+++ b/lsp/methods/textDocument/diagnostic/diagnostic_test.go
@@ -28,6 +28,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: integration test, scalar assertions
+// Tests DocumentDiagnostic handler with nil doc, valid doc, and known-bad attributes.
+
 func TestDocumentDiagnostic_NilDocument(t *testing.T) {
 	ctx := testhelpers.NewMockServerContext()
 

--- a/lsp/methods/textDocument/hover/hover_formatters_test.go
+++ b/lsp/methods/textDocument/hover/hover_formatters_test.go
@@ -7,6 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, table-driven
+// Markdown formatting output is compared as strings. These could be goldens
+// but each case is a single-line expected string, making table-driven clearer.
+
 func TestFormatAttributes(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/lsp/methods/textDocument/lifecycle_internal_test.go
+++ b/lsp/methods/textDocument/lifecycle_internal_test.go
@@ -7,6 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, table-driven
+// applyIncrementalChange, extractChangeParameters, applySingleLineChange,
+// applyMultiLineChange, etc. are pure text transformation functions.
+
 func ptrRange(startLine, startChar, endLine, endChar uint32) *protocol.Range {
 	return &protocol.Range{
 		Start: protocol.Position{Line: startLine, Character: startChar},

--- a/lsp/methods/textDocument/lifecycle_test.go
+++ b/lsp/methods/textDocument/lifecycle_test.go
@@ -28,6 +28,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: integration test, scalar assertions
+// Tests LSP lifecycle handlers (DidOpen, DidChange, DidClose) and completion
+// context analysis with nil DocumentManager (regression test).
+
 func TestDocumentChangeHandling(t *testing.T) {
 	dm, err := document.NewDocumentManager()
 	if err != nil {

--- a/lsp/methods/workspace/configuration/configuration_test.go
+++ b/lsp/methods/workspace/configuration/configuration_test.go
@@ -26,6 +26,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: integration test, scalar assertions
+// Tests DidChangeConfiguration handler with various settings payloads.
+
 func TestDidChangeConfiguration_NilSettings(t *testing.T) {
 	ctx := testhelpers.NewMockServerContext()
 	err := configuration.DidChangeConfiguration(ctx, nil, &protocol.DidChangeConfigurationParams{

--- a/lsp/methods/workspace/diagnostic/diagnostic_test.go
+++ b/lsp/methods/workspace/diagnostic/diagnostic_test.go
@@ -27,6 +27,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: integration test, scalar assertions
+// Tests WorkspaceDiagnostic handler with zero and multiple open documents.
+
 func TestWorkspaceDiagnostic_Empty(t *testing.T) {
 	ctx := testhelpers.NewMockServerContext()
 

--- a/lsp/registry_shutdown_test.go
+++ b/lsp/registry_shutdown_test.go
@@ -29,6 +29,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: lifecycle state transitions
+// Goroutine shutdown, timeout, and double-start behavior for file watchers
+// and generate watchers. Assertions are on lifecycle events (callback called,
+// no hang, error on double-start) which are inherently scalar.
+
 // TestRegistryFileWatcherShutdown verifies that the file watcher goroutine
 // exits properly when StopFileWatching is called.
 // This test prevents the bug where LSP server hangs at 100% CPU after client disconnects.

--- a/lsp/registry_test.go
+++ b/lsp/registry_test.go
@@ -18,27 +18,30 @@ package lsp_test
 
 import (
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"testing"
 
+	"bennypowers.dev/cem/internal/platform/testutil"
 	"bennypowers.dev/cem/lsp/testhelpers"
 	M "bennypowers.dev/cem/manifest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// loadTestManifest is a helper function to load manifests from test fixtures
+// Inline: integration test, scalar assertions
+// Registry element/attribute/slot lookup, multiple manifests, empty manifests,
+// and nil-type attribute handling (regression). Assertions check map keys,
+// counts, and field values that are awkward as golden files.
+
+// loadTestManifest is a helper function to load manifests from test fixtures.
+// fixturePath is relative to the MapFS root (e.g. "/integration/registry-basic/manifest.json").
 func loadTestManifest(t *testing.T, fixturePath string) *M.Package {
 	t.Helper()
 
-	manifestBytes, err := os.ReadFile(fixturePath)
-	if err != nil {
-		t.Fatalf("Failed to read manifest: %v", err)
-	}
+	mfs := testutil.LoadTestdataFS(t, "testdata", "/")
+	manifestBytes := testutil.ReadFixture(t, mfs, fixturePath)
 
 	var manifest M.Package
-	err = json.Unmarshal(manifestBytes, &manifest)
+	err := json.Unmarshal(manifestBytes, &manifest)
 	if err != nil {
 		t.Fatalf("Failed to parse manifest: %v", err)
 	}
@@ -51,7 +54,7 @@ func TestRegistryElementLookup(t *testing.T) {
 	ctx := testhelpers.NewMockServerContext()
 
 	// Load the basic test manifest
-	manifest := loadTestManifest(t, filepath.Join("testdata", "integration", "registry-basic", "manifest.json"))
+	manifest := loadTestManifest(t, "/integration/registry-basic/manifest.json")
 	ctx.AddManifest(manifest)
 
 	t.Run("Get existing element", func(t *testing.T) {
@@ -165,8 +168,8 @@ func TestRegistryMultipleManifests(t *testing.T) {
 	ctx := testhelpers.NewMockServerContext()
 
 	// Load two different manifests
-	manifest1 := loadTestManifest(t, filepath.Join("testdata", "integration", "registry-multiple", "manifest-1.json"))
-	manifest2 := loadTestManifest(t, filepath.Join("testdata", "integration", "registry-multiple", "manifest-2.json"))
+	manifest1 := loadTestManifest(t, "/integration/registry-multiple/manifest-1.json")
+	manifest2 := loadTestManifest(t, "/integration/registry-multiple/manifest-2.json")
 
 	// Add both manifests
 	ctx.AddManifest(manifest1)

--- a/lsp/registry_workspace_test.go
+++ b/lsp/registry_workspace_test.go
@@ -26,6 +26,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: integration test, scalar assertions
+// Workspace manifest loading for npm, yarn, and pnpm. Assertions check
+// element existence and tag names after loading from fixture workspaces.
+
 // TestWorkspaceManifestLoading_npm tests that npm workspace packages are loaded into the registry
 func TestWorkspaceManifestLoading_npm(t *testing.T) {
 	fixturePath := filepath.Join("testdata", "integration", "workspace-npm")

--- a/lsp/simple_repo_inmemory_test.go
+++ b/lsp/simple_repo_inmemory_test.go
@@ -30,6 +30,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: integration test, scalar assertions
+// In-memory manifest generation for simple repos without a custom-elements.json.
+// Assertions check element existence, package names, and absence of false-positive diagnostics.
+
 // TestSimpleRepoInMemoryGeneration tests the RHDS case:
 // - Simple repo (no workspaces)
 // - package.json exists with name but NO customElements field

--- a/lsp/workspace_diagnostics_test.go
+++ b/lsp/workspace_diagnostics_test.go
@@ -30,6 +30,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: integration test, scalar assertions
+// Verifies no false-positive "unknown element" diagnostics for workspace sibling
+// elements across npm, yarn, and pnpm workspace managers.
+
 // TestWorkspaceDiagnostics_NoFalsePositives_npm tests that workspace sibling elements
 // do NOT produce "unknown element" diagnostics when properly imported
 func TestWorkspaceDiagnostics_NoFalsePositives_npm(t *testing.T) {

--- a/lsp/workspace_inmemory_test.go
+++ b/lsp/workspace_inmemory_test.go
@@ -30,6 +30,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: integration test, scalar assertions
+// In-memory manifest generation for workspace packages with missing or absent
+// manifest files. Assertions check element existence, package names, and
+// absence of false-positive diagnostics.
+
 // TestWorkspaceInMemoryGeneration_MissingManifest tests that when a workspace package
 // declares customElements but the manifest file doesn't exist, the LSP generates it in-memory
 func TestWorkspaceInMemoryGeneration_MissingManifest(t *testing.T) {

--- a/lsp/workspace_patterns_test.go
+++ b/lsp/workspace_patterns_test.go
@@ -26,6 +26,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: integration test, scalar assertions
+// Workspace glob pattern matching (nested doublestar, negation, edge cases).
+// Assertions check element existence and tag name lists after loading.
+
 // TestWorkspacePatterns_NestedDoublestar tests that "**" doublestar patterns
 // find deeply nested workspace packages
 func TestWorkspacePatterns_NestedDoublestar(t *testing.T) {

--- a/lsp/workspace_single_package_test.go
+++ b/lsp/workspace_single_package_test.go
@@ -30,6 +30,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: integration test, scalar assertions
+// Single-package workspace loading and absence of false-positive diagnostics.
+
 // TestWorkspaceSinglePackage tests a workspace with a single package directly (like PatternFly Elements)
 // Pattern: workspaces: ["./elements"] where ./elements is the package itself
 func TestWorkspaceSinglePackage(t *testing.T) {

--- a/manifest/class_test.go
+++ b/manifest/class_test.go
@@ -18,8 +18,6 @@ package manifest
 
 import (
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -27,6 +25,8 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/stretchr/testify/assert"
 )
+
+// Inline: integration test, scalar assertions (tree structure verification against fixture)
 
 // Helper to strip ANSI color codes
 var ansiRegexp = regexp.MustCompile(`\x1b\[[0-9;]*m`)
@@ -44,10 +44,7 @@ func dumpTree(t *testing.T, node pterm.TreeNode, depth int) {
 
 func TestRenderableClassDeclaration(t *testing.T) {
 	t.Run("ToTreeNode", func(t *testing.T) {
-		manifestJSON, err := os.ReadFile(filepath.Join("testdata", "class-member-grouping.json"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		manifestJSON := loadFixture(t, "class-member-grouping.json")
 
 		var pkg Package
 		if err := json.Unmarshal([]byte(manifestJSON), &pkg); err != nil {

--- a/manifest/clone_test.go
+++ b/manifest/clone_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: verifying deep-copy independence
+
 func TestFullyQualifiedClone(t *testing.T) {
 	orig := FullyQualified{Name: "x", Summary: "s", Description: "d"}
 	cloned := orig.Clone()

--- a/manifest/deprecatable_test.go
+++ b/manifest/deprecatable_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, table-driven (boolean return across all Deprecatable implementations)
+
 func TestIsDeprecated_AllTypes(t *testing.T) {
 	type deprecatableCase struct {
 		name         string

--- a/manifest/deprecations_test.go
+++ b/manifest/deprecations_test.go
@@ -18,8 +18,6 @@ package manifest
 
 import (
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -27,14 +25,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: integration test, scalar assertions (tree output verification)
+
 func TestDeprecated(t *testing.T) {
 	t.Run("deprecated-module", func(t *testing.T) {
-
-		manifestPath := filepath.Join("testdata", "deprecated-module.json")
-		raw, err := os.ReadFile(manifestPath)
-		if err != nil {
-			t.Fatalf("failed to read manifest fixture: %v", err)
-		}
+		raw := loadFixture(t, "deprecated-module.json")
 
 		var pkg Package
 		if err := json.Unmarshal(raw, &pkg); err != nil {
@@ -46,11 +41,7 @@ func TestDeprecated(t *testing.T) {
 	})
 
 	t.Run("deprecations", func(t *testing.T) {
-		manifestPath := filepath.Join("testdata", "deprecations.json")
-		raw, err := os.ReadFile(manifestPath)
-		if err != nil {
-			t.Fatalf("failed to read manifest fixture: %v", err)
-		}
+		raw := loadFixture(t, "deprecations.json")
 
 		var pkg Package
 		if err := json.Unmarshal(raw, &pkg); err != nil {
@@ -162,11 +153,7 @@ func TestDeprecated(t *testing.T) {
 	})
 
 	t.Run("VisualTreeOutput", func(t *testing.T) {
-		manifestPath := filepath.Join("testdata", "deprecations.json")
-		raw, err := os.ReadFile(manifestPath)
-		if err != nil {
-			t.Fatalf("failed to read manifest fixture: %v", err)
-		}
+		raw := loadFixture(t, "deprecations.json")
 
 		var pkg Package
 		if err := json.Unmarshal(raw, &pkg); err != nil {

--- a/manifest/lookup_benchmark_test.go
+++ b/manifest/lookup_benchmark_test.go
@@ -3,10 +3,9 @@ package manifest_test
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
 
+	"bennypowers.dev/cem/internal/platform/testutil"
 	"bennypowers.dev/cem/manifest"
 )
 
@@ -245,10 +244,8 @@ func benchmarkExportLookupMap(b *testing.B, numExports int) {
 // This benchmark exercises the full rendering pipeline including attribute field
 // lookups and export lookups using the optimized map-based implementation.
 func BenchmarkRenderableCreation(b *testing.B) {
-	manifestJSON, err := os.ReadFile(filepath.Join("testdata", "custom-element-member-grouping.json"))
-	if err != nil {
-		b.Fatalf("Failed to load fixture: %v", err)
-	}
+	fs := testutil.LoadTestdataFS(b, "testdata", "/")
+	manifestJSON := testutil.ReadFixture(b, fs, "/custom-element-member-grouping.json")
 
 	var pkg manifest.Package
 	if err := json.Unmarshal([]byte(manifestJSON), &pkg); err != nil {

--- a/manifest/package_test.go
+++ b/manifest/package_test.go
@@ -18,11 +18,10 @@ package manifest_test
 
 import (
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 
+	"bennypowers.dev/cem/internal/platform/testutil"
 	"bennypowers.dev/cem/manifest"
 )
 
@@ -55,11 +54,8 @@ func clearBackreferences(pkg *manifest.Package) {
 // using a comprehensive manifest that includes all possible types and structures.
 func TestPackage(t *testing.T) {
 	// Load the comprehensive test manifest
-	manifestPath := filepath.Join("testdata", "comprehensive-clone-test.json")
-	manifestData, err := os.ReadFile(manifestPath)
-	if err != nil {
-		t.Fatalf("Failed to read test manifest: %v", err)
-	}
+	fs := testutil.LoadTestdataFS(t, "testdata", "/")
+	manifestData := testutil.ReadFixture(t, fs, "/comprehensive-clone-test.json")
 
 	// Unmarshal the manifest
 	var original manifest.Package

--- a/manifest/traversal/engine_test.go
+++ b/manifest/traversal/engine_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: pure function, table-driven
+
 func TestConvertMapAccessToGjsonPath(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/manifest/unmarshal_test.go
+++ b/manifest/unmarshal_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"reflect"
 	"regexp"
-	"sync"
 	"testing"
 
 	"bennypowers.dev/cem/internal/platform"
@@ -45,16 +44,13 @@ func mustRunFixture(t *testing.T) {
 	}
 }
 
-var (
-	manifestTestdataFS   *platform.MapFileSystem
-	manifestTestdataOnce sync.Once
-)
+var manifestTestdataFS *platform.MapFileSystem
 
 func manifestFixtures(t testing.TB) *platform.MapFileSystem {
 	t.Helper()
-	manifestTestdataOnce.Do(func() {
+	if manifestTestdataFS == nil {
 		manifestTestdataFS = testutil.LoadTestdataFS(t, "testdata", "/")
-	})
+	}
 	return manifestTestdataFS
 }
 

--- a/manifest/unmarshal_test.go
+++ b/manifest/unmarshal_test.go
@@ -19,10 +19,13 @@ package manifest
 import (
 	"encoding/json"
 	"os"
-	"path/filepath"
 	"reflect"
 	"regexp"
+	"sync"
 	"testing"
+
+	"bennypowers.dev/cem/internal/platform"
+	"bennypowers.dev/cem/internal/platform/testutil"
 )
 
 // DRY Test Helpers
@@ -42,13 +45,22 @@ func mustRunFixture(t *testing.T) {
 	}
 }
 
-func loadFixture(t *testing.T, name string) []byte {
+var (
+	manifestTestdataFS   *platform.MapFileSystem
+	manifestTestdataOnce sync.Once
+)
+
+func manifestFixtures(t testing.TB) *platform.MapFileSystem {
 	t.Helper()
-	data, err := os.ReadFile(filepath.Join("testdata", name))
-	if err != nil {
-		t.Fatalf("failed to load fixture %s: %v", name, err)
-	}
-	return data
+	manifestTestdataOnce.Do(func() {
+		manifestTestdataFS = testutil.LoadTestdataFS(t, "testdata", "/")
+	})
+	return manifestTestdataFS
+}
+
+func loadFixture(t testing.TB, name string) []byte {
+	t.Helper()
+	return testutil.ReadFixture(t, manifestFixtures(t), "/"+name)
 }
 
 func mustUnmarshalPackage(t *testing.T, data []byte) *Package {

--- a/mcp/context_helpers_test.go
+++ b/mcp/context_helpers_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, scalar assertions
+
 func TestGenerateCacheKey(t *testing.T) {
 	assert.Equal(t, "my-element", generateCacheKey("my-element", nil))
 	assert.Equal(t, "x-foo", generateCacheKey("x-foo", &M.CustomElement{}))

--- a/mcp/integration_test.go
+++ b/mcp/integration_test.go
@@ -18,7 +18,6 @@ package mcp_test
 
 import (
 	"context"
-	"flag"
 	"os"
 	"path/filepath"
 	"strings"
@@ -26,13 +25,12 @@ import (
 
 	"bennypowers.dev/cem/mcp"
 	"bennypowers.dev/cem/mcp/resources"
+	"bennypowers.dev/cem/internal/platform/testutil"
 	W "bennypowers.dev/cem/internal/workspace"
 	mcpSDK "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-var update = flag.Bool("update", false, "update golden files")
 
 // getTestRegistry creates a registry using the test fixtures following the existing pattern
 func getTestRegistry(t *testing.T) *mcp.MCPContext {
@@ -137,7 +135,7 @@ func TestSchemaResilientTemplateIntegration(t *testing.T) {
 	// Golden file comparison (update mode)
 	goldenPath := filepath.Join("fixtures", "template-rendering", "schema_resilient_template.golden.md")
 
-	if *update {
+	if *testutil.Update {
 		// Update golden file
 		err := os.MkdirAll(filepath.Dir(goldenPath), 0755)
 		require.NoError(t, err)
@@ -148,29 +146,20 @@ func TestSchemaResilientTemplateIntegration(t *testing.T) {
 		t.Logf("Golden file content length: %d characters", len(content))
 	} else {
 		// Compare with golden file if it exists
-		if goldenData, err := os.ReadFile(goldenPath); err == nil {
-			goldenContent := string(goldenData)
-			if content != goldenContent {
-				t.Logf("Content differs from golden file. Run with --update to update.")
-				t.Logf("Golden length: %d, Actual length: %d", len(goldenContent), len(content))
+		goldenFS := testutil.LoadTestdataFS(t, "fixtures/template-rendering", "/")
+		goldenData := testutil.ReadFixture(t, goldenFS, "/schema_resilient_template.golden.md")
+		goldenContent := string(goldenData)
+		if content != goldenContent {
+			t.Logf("Content differs from golden file. Run with --update to update.")
+			t.Logf("Golden length: %d, Actual length: %d", len(goldenContent), len(content))
 
-				// Show a snippet of the differences for debugging
-				lines := strings.Split(content, "\n")
-				if len(lines) > 10 {
-					t.Logf("First 10 lines of output:\n%s", strings.Join(lines[:10], "\n"))
-				}
-			} else {
-				t.Log("✅ Content matches golden file exactly")
-			}
-		} else {
-			t.Logf("Golden file doesn't exist: %s", goldenPath)
-			t.Log("Run with --update to create it")
-
-			// Show sample output for verification
+			// Show a snippet of the differences for debugging
 			lines := strings.Split(content, "\n")
 			if len(lines) > 10 {
-				t.Logf("Sample output (first 10 lines):\n%s", strings.Join(lines[:10], "\n"))
+				t.Logf("First 10 lines of output:\n%s", strings.Join(lines[:10], "\n"))
 			}
+		} else {
+			t.Log("Content matches golden file exactly")
 		}
 	}
 

--- a/mcp/integration_test.go
+++ b/mcp/integration_test.go
@@ -150,14 +150,10 @@ func TestSchemaResilientTemplateIntegration(t *testing.T) {
 		goldenData := testutil.ReadFixture(t, goldenFS, "/schema_resilient_template.golden.md")
 		goldenContent := string(goldenData)
 		if content != goldenContent {
-			t.Logf("Content differs from golden file. Run with --update to update.")
-			t.Logf("Golden length: %d, Actual length: %d", len(goldenContent), len(content))
-
-			// Show a snippet of the differences for debugging
 			lines := strings.Split(content, "\n")
-			if len(lines) > 10 {
-				t.Logf("First 10 lines of output:\n%s", strings.Join(lines[:10], "\n"))
-			}
+			snippet := strings.Join(lines[:min(10, len(lines))], "\n")
+			t.Fatalf("Content differs from golden file (run with --update to update).\nGolden length: %d, Actual length: %d\nFirst lines of output:\n%s",
+				len(goldenContent), len(content), snippet)
 		} else {
 			t.Log("Content matches golden file exactly")
 		}

--- a/mcp/malicious_manifest_test.go
+++ b/mcp/malicious_manifest_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: security boundary, scalar assertions
+
 func TestMaliciousManifestMitigation(t *testing.T) {
 	// Use the malicious manifest fixture
 	wctx := workspace.NewFileSystemWorkspaceContext("testdata/fixtures/malicious-manifest-security")

--- a/mcp/resources/embed_test.go
+++ b/mcp/resources/embed_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: regression test, verifying specific fix (embedded resources load without filesystem)
+
 // TestResourceDefinitions_Embedded is a smoke test to verify resource definitions
 // are properly embedded in the binary and can be loaded without filesystem access.
 // This is a regression test for the issue where runtime.Caller(0) was used to

--- a/mcp/resources/multiple_schemas_test.go
+++ b/mcp/resources/multiple_schemas_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"bennypowers.dev/cem/internal/platform/testutil"
 	"bennypowers.dev/cem/mcp/templates"
 	"bennypowers.dev/cem/mcp/types"
 	V "bennypowers.dev/cem/validate"
@@ -33,14 +34,15 @@ func TestMultipleSchemaVersions_FixtureGolden(t *testing.T) {
 
 // loadManifestFromFixture loads a manifest from a fixture file and creates a ManifestContext
 func loadManifestFromFixture(t *testing.T, version string) ManifestContext {
+	t.Helper()
+
 	// Load manifest fixture file
-	manifestPath := filepath.Join("..", "testdata", "fixtures", "multiple-schemas", version, "custom-elements.json")
-	manifestData, err := os.ReadFile(manifestPath)
-	require.NoError(t, err, "Should be able to read manifest fixture for version %s", version)
+	fs := testutil.LoadTestdataFS(t, filepath.Join("..", "testdata", "fixtures", "multiple-schemas", version), "/")
+	manifestData := testutil.ReadFixture(t, fs, "/custom-elements.json")
 
 	// Parse manifest to extract basic information for the overview
 	var manifestJSON map[string]any
-	err = json.Unmarshal(manifestData, &manifestJSON)
+	err := json.Unmarshal(manifestData, &manifestJSON)
 	require.NoError(t, err, "Should be able to parse manifest JSON for version %s", version)
 
 	// Extract basic info from manifest for context
@@ -99,21 +101,21 @@ func testSchemaVersionWithGolden(t *testing.T, version string) {
 }
 
 func testWithGoldenFile(t *testing.T, actual, goldenFileName string) {
-	goldenPath := filepath.Join("..", "testdata", "fixtures", "multiple-schemas", goldenFileName)
+	t.Helper()
 
-	// Check for update mode via environment variable (internal test pattern)
-	if updateGolden := os.Getenv("UPDATE_GOLDEN"); updateGolden != "" {
+	goldenDir := filepath.Join("..", "testdata", "fixtures", "multiple-schemas")
+	goldenPath := filepath.Join(goldenDir, goldenFileName)
+
+	// Check for update mode via environment variable or --update flag
+	if *testutil.Update || os.Getenv("UPDATE_GOLDEN") != "" {
 		err := os.WriteFile(goldenPath, []byte(actual), 0644)
 		require.NoError(t, err, "Failed to update golden file %s", goldenPath)
 		t.Logf("Updated golden file: %s", goldenPath)
 		return
 	}
 
-	expected, err := os.ReadFile(goldenPath)
-	if os.IsNotExist(err) {
-		t.Fatalf("Golden file %s does not exist. Run with UPDATE_GOLDEN=1 to create it.", goldenPath)
-	}
-	require.NoError(t, err, "Failed to read golden file %s", goldenPath)
+	fs := testutil.LoadTestdataFS(t, goldenDir, "/")
+	expected := testutil.ReadFixture(t, fs, "/"+goldenFileName)
 
 	assert.Equal(t, string(expected), actual, "Content should match golden file %s", goldenFileName)
 }
@@ -146,21 +148,21 @@ func testBackwardsCompatibilityWithGolden(t *testing.T, version string) {
 }
 
 func testBackwardsCompatibilityWithGoldenFile(t *testing.T, actual, goldenFileName string) {
-	goldenPath := filepath.Join("..", "testdata", "fixtures", "schema-backwards-compatibility", goldenFileName)
+	t.Helper()
 
-	// Check for update mode via environment variable (internal test pattern)
-	if updateGolden := os.Getenv("UPDATE_GOLDEN"); updateGolden != "" {
+	goldenDir := filepath.Join("..", "testdata", "fixtures", "schema-backwards-compatibility")
+	goldenPath := filepath.Join(goldenDir, goldenFileName)
+
+	// Check for update mode via environment variable or --update flag
+	if *testutil.Update || os.Getenv("UPDATE_GOLDEN") != "" {
 		err := os.WriteFile(goldenPath, []byte(actual), 0644)
 		require.NoError(t, err, "Failed to update golden file %s", goldenPath)
 		t.Logf("Updated golden file: %s", goldenPath)
 		return
 	}
 
-	expected, err := os.ReadFile(goldenPath)
-	if os.IsNotExist(err) {
-		t.Fatalf("Golden file %s does not exist. Run with UPDATE_GOLDEN=1 to create it.", goldenPath)
-	}
-	require.NoError(t, err, "Failed to read golden file %s", goldenPath)
+	fs := testutil.LoadTestdataFS(t, goldenDir, "/")
+	expected := testutil.ReadFixture(t, fs, "/"+goldenFileName)
 
 	assert.Equal(t, string(expected), actual, "Content should match golden file %s", goldenFileName)
 }

--- a/mcp/resources/resources_test.go
+++ b/mcp/resources/resources_test.go
@@ -19,7 +19,6 @@ package resources_test
 import (
 	"context"
 	"encoding/json"
-	"flag"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,14 +27,13 @@ import (
 	"bennypowers.dev/cem/mcp"
 	"bennypowers.dev/cem/mcp/resources"
 	"bennypowers.dev/cem/mcp/types"
+	"bennypowers.dev/cem/internal/platform/testutil"
 	V "bennypowers.dev/cem/validate"
 	W "bennypowers.dev/cem/internal/workspace"
 	mcpSDK "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-var update = flag.Bool("update", false, "update golden files")
 
 // getTestRegistry creates a registry using the test fixtures following the existing pattern
 func getTestRegistry(t *testing.T) *mcp.MCPContext {
@@ -534,8 +532,12 @@ func TestAllResourcesWithFixtures(t *testing.T) {
 
 // Helper function for testing resource output with golden files
 func testResourceWithGolden(t *testing.T, uri string, goldenFile string) {
+	t.Helper()
+
 	registry := getTestRegistry(t)
 	registryAdapter := mcp.NewMCPContextAdapter(registry)
+
+	fs := testutil.LoadTestdataFS(t, "../testdata/fixtures/resource-integration", "/")
 
 	resourceDefs, err := resources.Resources(registryAdapter)
 	require.NoError(t, err)
@@ -566,7 +568,7 @@ func testResourceWithGolden(t *testing.T, uri string, goldenFile string) {
 
 	// Handle --update flag
 	goldenPath := filepath.Join("../testdata/fixtures/resource-integration", goldenFile)
-	if *update {
+	if *testutil.Update {
 		err := os.MkdirAll(filepath.Dir(goldenPath), 0755)
 		require.NoError(t, err, "Failed to create golden file directory")
 
@@ -577,11 +579,7 @@ func testResourceWithGolden(t *testing.T, uri string, goldenFile string) {
 	}
 
 	// Compare with golden file
-	expectedData, err := os.ReadFile(goldenPath)
-	if os.IsNotExist(err) {
-		t.Fatalf("Golden file %s does not exist. Run with --update to create it.", goldenPath)
-	}
-	require.NoError(t, err, "Should be able to read golden file: %s", goldenPath)
+	expectedData := testutil.ReadFixture(t, fs, "/"+goldenFile)
 
 	assert.Equal(t, string(expectedData), output, "Resource output should match golden file")
 	assert.Equal(t, uri, content.URI, "Resource should preserve URI")

--- a/mcp/resources/sub_resource_test.go
+++ b/mcp/resources/sub_resource_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: pure function, table-driven
+
 func TestSubResourceFiltering_FilterArrayByName(t *testing.T) {
 	engine := NewPathTraversalEngine()
 

--- a/mcp/security/sanitize_test.go
+++ b/mcp/security/sanitize_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: security boundary, scalar assertions
+
 func TestSanitizeDescription(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: integration test, scalar assertions
+
 func TestNewServer(t *testing.T) {
 	workspace := W.NewFileSystemWorkspaceContext("./testdata/fixtures/basic-integration")
 

--- a/mcp/stdout_test.go
+++ b/mcp/stdout_test.go
@@ -33,6 +33,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: regression test, verifying specific fix (stdout cleanliness for JSON-RPC, issue #129)
+
 // TestMCPCommandStdoutClean is an E2E test that verifies the actual `cem mcp`
 // command produces no stdout contamination. This is the definitive test for #129.
 //

--- a/mcp/tools/embed_test.go
+++ b/mcp/tools/embed_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Inline: regression test, verifying specific fix (embedded tools load without filesystem)
+
 // TestToolDefinitions_Embedded is a smoke test to verify tool definitions
 // are properly embedded in the binary and can be loaded without filesystem access.
 // This is a regression test for the issue where runtime.Caller(0) was used to

--- a/mcp/tools/generate_html_test.go
+++ b/mcp/tools/generate_html_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"bennypowers.dev/cem/internal/platform/testutil"
 	"bennypowers.dev/cem/mcp/tools"
 	mcpSDK "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
@@ -34,6 +35,8 @@ func TestGenerateHTML_WithFixtures(t *testing.T) {
 
 	// Find all test fixture directories
 	fixturesDir := "../testdata/fixtures/generate-html"
+	fs := testutil.LoadTestdataFS(t, fixturesDir, "/")
+
 	fixtures, err := os.ReadDir(fixturesDir)
 	require.NoError(t, err, "Should be able to read fixtures directory")
 
@@ -45,12 +48,10 @@ func TestGenerateHTML_WithFixtures(t *testing.T) {
 		fixtureName := fixture.Name()
 		t.Run(fixtureName, func(t *testing.T) {
 			// Load input
-			inputPath := filepath.Join(fixturesDir, fixtureName, "input.json")
-			inputData, err := os.ReadFile(inputPath)
-			require.NoError(t, err, "Should be able to read input fixture")
+			inputData := testutil.ReadFixture(t, fs, "/"+fixtureName+"/input.json")
 
 			var args tools.GenerateHtmlArgs
-			err = json.Unmarshal(inputData, &args)
+			err := json.Unmarshal(inputData, &args)
 			require.NoError(t, err, "Should be able to parse input JSON")
 
 			// Create MCP request
@@ -78,9 +79,7 @@ func TestGenerateHTML_WithFixtures(t *testing.T) {
 				require.True(t, ok, "Content should be text")
 
 				// Check against expected error response
-				expectedPath := filepath.Join(fixturesDir, fixtureName, "expected-response.md")
-				expectedData, err := os.ReadFile(expectedPath)
-				require.NoError(t, err, "Should be able to read expected response")
+				expectedData := testutil.ReadFixture(t, fs, "/"+fixtureName+"/expected-response.md")
 
 				assert.Contains(t, textContent.Text, string(expectedData), "Should contain expected error message")
 				return
@@ -99,9 +98,8 @@ func TestGenerateHTML_WithFixtures(t *testing.T) {
 
 			// Check that output contains expected HTML (if expected-html.html exists)
 			expectedHTMLPath := filepath.Join(fixturesDir, fixtureName, "expected-html.html")
-			if _, err := os.Stat(expectedHTMLPath); err == nil {
-				expectedHTML, err := os.ReadFile(expectedHTMLPath)
-				require.NoError(t, err, "Should be able to read expected HTML")
+			if _, statErr := os.Stat(expectedHTMLPath); statErr == nil {
+				expectedHTML := testutil.ReadFixture(t, fs, "/"+fixtureName+"/expected-html.html")
 
 				assert.Contains(t, output, string(expectedHTML), "Output should contain expected HTML structure")
 			}
@@ -229,7 +227,10 @@ func TestGenerateHTMLRegression_TagNameAccess_Legacy(t *testing.T) {
 
 // Helper function for testing generate HTML with golden files
 func testGenerateHtmlWithGolden(t *testing.T, args tools.GenerateHtmlArgs, goldenFile string) {
+	t.Helper()
+
 	registry := getTestRegistry(t)
+	fs := testutil.LoadTestdataFS(t, "../testdata/fixtures/generate-html-integration", "/")
 
 	argsJSON, err := json.Marshal(args)
 	require.NoError(t, err)
@@ -254,7 +255,7 @@ func testGenerateHtmlWithGolden(t *testing.T, args tools.GenerateHtmlArgs, golde
 
 	// Handle -update flag
 	goldenPath := filepath.Join("../testdata/fixtures/generate-html-integration", goldenFile)
-	if *update {
+	if *testutil.Update {
 		err := os.MkdirAll(filepath.Dir(goldenPath), 0755)
 		require.NoError(t, err, "Failed to create golden file directory")
 
@@ -265,11 +266,7 @@ func testGenerateHtmlWithGolden(t *testing.T, args tools.GenerateHtmlArgs, golde
 	}
 
 	// Compare with golden file
-	expectedData, err := os.ReadFile(goldenPath)
-	if os.IsNotExist(err) {
-		t.Fatalf("Golden file %s does not exist. Run with -update to create it.", goldenPath)
-	}
-	require.NoError(t, err, "Should be able to read golden file: %s", goldenPath)
+	expectedData := testutil.ReadFixture(t, fs, "/"+goldenFile)
 
 	assert.Equal(t, string(expectedData), output, "Generated HTML should match golden file")
 }

--- a/mcp/tools/generate_html_test.go
+++ b/mcp/tools/generate_html_test.go
@@ -96,10 +96,10 @@ func TestGenerateHTML_WithFixtures(t *testing.T) {
 			output := textContent.Text
 			assert.NotEmpty(t, output, "Tool output should not be empty")
 
-			// Check that output contains expected HTML (if expected-html.html exists)
-			expectedHTMLPath := filepath.Join(fixturesDir, fixtureName, "expected-html.html")
-			if _, statErr := os.Stat(expectedHTMLPath); statErr == nil {
-				expectedHTML := testutil.ReadFixture(t, fs, "/"+fixtureName+"/expected-html.html")
+			// Check that output contains expected HTML (if expected-html.html exists in MapFS)
+			expectedHTMLKey := "/" + fixtureName + "/expected-html.html"
+			if _, statErr := fs.Stat(expectedHTMLKey); statErr == nil {
+				expectedHTML := testutil.ReadFixture(t, fs, expectedHTMLKey)
 
 				assert.Contains(t, output, string(expectedHTML), "Output should contain expected HTML structure")
 			}

--- a/mcp/tools/slot_inference_test.go
+++ b/mcp/tools/slot_inference_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, table-driven
+
 func TestInferRelevantSlots(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/mcp/tools/tools_test.go
+++ b/mcp/tools/tools_test.go
@@ -18,7 +18,6 @@ package tools_test
 
 import (
 	"encoding/json"
-	"flag"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,13 +25,12 @@ import (
 	"bennypowers.dev/cem/mcp"
 	"bennypowers.dev/cem/mcp/templates"
 	"bennypowers.dev/cem/mcp/tools"
+	"bennypowers.dev/cem/internal/platform/testutil"
 	W "bennypowers.dev/cem/internal/workspace"
 	mcpSDK "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-var update = flag.Bool("update", false, "update golden files")
 
 // getTestRegistry creates a registry using the test fixtures following the existing pattern
 func getTestRegistry(t *testing.T) *mcp.MCPContextAdapter {
@@ -226,13 +224,15 @@ func TestTemplateRenderer_Basic(t *testing.T) {
 
 // Helper function to test templates with fixture/golden pattern
 func testTemplateWithGolden(t *testing.T, templateName, contextName, fixtureFile, goldenFile string) {
+	t.Helper()
+
+	fs := testutil.LoadTestdataFS(t, "../testdata/fixtures/"+contextName, "/")
+
 	// Read template data from fixture file
-	fixturePath := filepath.Join("../testdata/fixtures", contextName, fixtureFile)
-	fixtureData, err := os.ReadFile(fixturePath)
-	require.NoError(t, err, "Should be able to read fixture file: %s", fixturePath)
+	fixtureData := testutil.ReadFixture(t, fs, "/"+fixtureFile)
 
 	var templateData any
-	err = json.Unmarshal(fixtureData, &templateData)
+	err := json.Unmarshal(fixtureData, &templateData)
 	require.NoError(t, err, "Should be able to parse fixture JSON")
 
 	// Render template
@@ -241,7 +241,7 @@ func testTemplateWithGolden(t *testing.T, templateName, contextName, fixtureFile
 
 	// Handle -update flag
 	goldenPath := filepath.Join("../testdata/fixtures", contextName, goldenFile)
-	if *update {
+	if *testutil.Update {
 		err := os.WriteFile(goldenPath, []byte(output), 0644)
 		require.NoError(t, err, "Failed to update golden file %s", goldenPath)
 		t.Logf("Updated golden file: %s", goldenPath)
@@ -249,11 +249,7 @@ func testTemplateWithGolden(t *testing.T, templateName, contextName, fixtureFile
 	}
 
 	// Compare with golden file
-	expectedData, err := os.ReadFile(goldenPath)
-	if os.IsNotExist(err) {
-		t.Fatalf("Golden file %s does not exist. Run with -update to create it.", goldenPath)
-	}
-	require.NoError(t, err, "Should be able to read golden file: %s", goldenPath)
+	expectedData := testutil.ReadFixture(t, fs, "/"+goldenFile)
 
 	assert.Equal(t, string(expectedData), output, "Template output should match golden file")
 }

--- a/mcp/tools/validate_html_test.go
+++ b/mcp/tools/validate_html_test.go
@@ -20,14 +20,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
+	"bennypowers.dev/cem/internal/platform/testutil"
+	W "bennypowers.dev/cem/internal/workspace"
 	"bennypowers.dev/cem/mcp"
 	"bennypowers.dev/cem/mcp/tools"
-	W "bennypowers.dev/cem/internal/workspace"
 	mcpSDK "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -605,6 +604,8 @@ func TestValidateHtml_GlobalAttributesWithUnknownCustomAttribute(t *testing.T) {
 
 // Helper function to test validate_html tool with fixture/golden pattern
 func testValidateHtmlWithGolden(t *testing.T, fixtureFile, contextStr, goldenFile string) {
+	t.Helper()
+
 	workspace := W.NewFileSystemWorkspaceContext("../testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
@@ -617,10 +618,10 @@ func testValidateHtmlWithGolden(t *testing.T, fixtureFile, contextStr, goldenFil
 
 	registryAdapter := mcp.NewMCPContextAdapter(registry).(*mcp.MCPContextAdapter)
 
+	fs := testutil.LoadTestdataFS(t, "../testdata/fixtures/validate-html", "/")
+
 	// Read HTML from fixture file
-	fixturePath := filepath.Join("../testdata/fixtures/validate-html", fixtureFile)
-	htmlData, err := os.ReadFile(fixturePath)
-	require.NoError(t, err, "Should be able to read fixture file: %s", fixturePath)
+	htmlData := testutil.ReadFixture(t, fs, "/"+fixtureFile)
 
 	argsJSON, err := json.Marshal(map[string]any{
 		"html":    string(htmlData),
@@ -644,9 +645,7 @@ func testValidateHtmlWithGolden(t *testing.T, fixtureFile, contextStr, goldenFil
 	require.True(t, ok)
 
 	// Compare with golden file
-	goldenPath := filepath.Join("../testdata/fixtures/validate-html", goldenFile)
-	expectedData, err := os.ReadFile(goldenPath)
-	require.NoError(t, err, "Should be able to read golden file: %s", goldenPath)
+	expectedData := testutil.ReadFixture(t, fs, "/"+goldenFile)
 
 	assert.Equal(t, string(expectedData), textContent.Text, "Output should match golden file")
 }

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, table-driven
+
 // mockRenderable implements manifest.Renderable for testing
 type mockRenderable struct {
 	name        string

--- a/serve/injection_test.go
+++ b/serve/injection_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"bennypowers.dev/cem/internal/platform/testutil"
 	"bennypowers.dev/cem/serve"
 )
 
@@ -36,13 +37,11 @@ func TestHTMLInjection_WebSocketClient(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Copy test fixture HTML
-	inputHTML, err := os.ReadFile(filepath.Join("testdata", "html-injection", "input.html"))
-	if err != nil {
-		t.Fatalf("Failed to read input HTML: %v", err)
-	}
+	mfsFixtures := testutil.LoadTestdataFS(t, "testdata/html-injection", "/")
+	inputHTML := testutil.ReadFixture(t, mfsFixtures, "/input.html")
 
 	htmlFile := filepath.Join(tmpDir, "index.html")
-	err = os.WriteFile(htmlFile, inputHTML, 0644)
+	err := os.WriteFile(htmlFile, inputHTML, 0644)
 	if err != nil {
 		t.Fatalf("Failed to write HTML file: %v", err)
 	}
@@ -102,13 +101,11 @@ func TestHTMLInjection_WebSocketClient(t *testing.T) {
 func TestHTMLInjection_NoInjectionWhenDisabled(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	inputHTML, err := os.ReadFile(filepath.Join("testdata", "html-injection", "input.html"))
-	if err != nil {
-		t.Fatalf("Failed to read input HTML: %v", err)
-	}
+	mfsFixtures := testutil.LoadTestdataFS(t, "testdata/html-injection", "/")
+	inputHTML := testutil.ReadFixture(t, mfsFixtures, "/input.html")
 
 	htmlFile := filepath.Join(tmpDir, "index.html")
-	err = os.WriteFile(htmlFile, inputHTML, 0644)
+	err := os.WriteFile(htmlFile, inputHTML, 0644)
 	if err != nil {
 		t.Fatalf("Failed to write HTML file: %v", err)
 	}

--- a/serve/listing_test.go
+++ b/serve/listing_test.go
@@ -20,12 +20,11 @@ package serve_test
 import (
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"bennypowers.dev/cem/internal/platform"
+	"bennypowers.dev/cem/internal/platform/testutil"
 	"bennypowers.dev/cem/serve"
 )
 
@@ -40,10 +39,8 @@ func newListingTestFS() platform.FileSystem {
 // TestRootListing_ShowsAllElements verifies GET / shows element listing
 func TestRootListing_ShowsAllElements(t *testing.T) {
 	// Load manifest fixture
-	manifestBytes, err := os.ReadFile(filepath.Join("testdata", "listing", "multiple-elements.json"))
-	if err != nil {
-		t.Fatalf("Failed to read manifest fixture: %v", err)
-	}
+	mfsFixtures := testutil.LoadTestdataFS(t, "testdata/listing", "/")
+	manifestBytes := testutil.ReadFixture(t, mfsFixtures, "/multiple-elements.json")
 
 	mfs := newListingTestFS()
 	server, err := serve.NewServerWithConfig(serve.Config{
@@ -122,10 +119,8 @@ func TestRootListing_ShowsAllElements(t *testing.T) {
 // TestRootListing_EmptyManifest verifies listing with no elements
 func TestRootListing_EmptyManifest(t *testing.T) {
 	// Load empty manifest fixture
-	manifestBytes, err := os.ReadFile(filepath.Join("testdata", "listing", "empty-manifest.json"))
-	if err != nil {
-		t.Fatalf("Failed to read manifest fixture: %v", err)
-	}
+	mfsFixtures := testutil.LoadTestdataFS(t, "testdata/listing", "/")
+	manifestBytes := testutil.ReadFixture(t, mfsFixtures, "/empty-manifest.json")
 
 	mfs := newListingTestFS()
 	server, err := serve.NewServerWithConfig(serve.Config{
@@ -172,10 +167,8 @@ func TestRootListing_EmptyManifest(t *testing.T) {
 // TestRootListing_SortedByElement verifies alphabetical sorting
 func TestRootListing_SortedByElement(t *testing.T) {
 	// Load sorting test fixture
-	manifestBytes, err := os.ReadFile(filepath.Join("testdata", "listing", "sorting-test.json"))
-	if err != nil {
-		t.Fatalf("Failed to read manifest fixture: %v", err)
-	}
+	mfsFixtures := testutil.LoadTestdataFS(t, "testdata/listing", "/")
+	manifestBytes := testutil.ReadFixture(t, mfsFixtures, "/sorting-test.json")
 
 	mfs := newListingTestFS()
 	server, err := serve.NewServerWithConfig(serve.Config{

--- a/serve/middleware/importmap/types_test.go
+++ b/serve/middleware/importmap/types_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, scalar assertions
+
 func TestImportMap_IsImportMap(t *testing.T) {
 	im := &ImportMap{}
 	im.IsImportMap()

--- a/serve/middleware/routes/frontmatter_test.go
+++ b/serve/middleware/routes/frontmatter_test.go
@@ -21,14 +21,13 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"bennypowers.dev/cem/cmd/config"
 	"bennypowers.dev/cem/health"
 	"bennypowers.dev/cem/internal/platform"
+	"bennypowers.dev/cem/internal/platform/testutil"
 	M "bennypowers.dev/cem/manifest"
 	"bennypowers.dev/cem/serve/logger"
 	"bennypowers.dev/cem/serve/middleware"
@@ -65,13 +64,14 @@ type frontmatterTestFixture struct {
 	demoRoute string
 }
 
+var frontmatterFixtures *platform.MapFileSystem
+
 func loadFixture(t *testing.T, name string) []byte {
 	t.Helper()
-	data, err := os.ReadFile(filepath.Join("testdata", "frontmatter", name))
-	if err != nil {
-		t.Fatalf("read fixture %s: %v", name, err)
+	if frontmatterFixtures == nil {
+		frontmatterFixtures = testutil.LoadTestdataFS(t, "testdata/frontmatter", "/")
 	}
-	return data
+	return testutil.ReadFixture(t, frontmatterFixtures, "/"+name)
 }
 
 func setupFrontmatterTest(t *testing.T, fixtureName, renderingMode string) frontmatterTestFixture {

--- a/serve/middleware/routes/helpers_pure_test.go
+++ b/serve/middleware/routes/helpers_pure_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, scalar assertions
+
 func TestFilterHealthByComponent(t *testing.T) {
 	result := &health.HealthResult{
 		Modules: []health.ModuleReport{

--- a/serve/middleware/routes/knobs_test.go
+++ b/serve/middleware/routes/knobs_test.go
@@ -19,14 +19,24 @@ package routes
 
 import (
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
+	"bennypowers.dev/cem/internal/platform"
+	"bennypowers.dev/cem/internal/platform/testutil"
 	M "bennypowers.dev/cem/manifest"
 	"github.com/google/go-cmp/cmp"
 )
+
+var knobsFixtures *platform.MapFileSystem
+
+func loadKnobsFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	if knobsFixtures == nil {
+		knobsFixtures = testutil.LoadTestdataFS(t, "testdata/knobs", "/")
+	}
+	return testutil.ReadFixture(t, knobsFixtures, "/"+name)
+}
 
 // testTemplatesForKnobs creates a template registry for testing (with nil context)
 func testTemplatesForKnobs() *TemplateRegistry {
@@ -35,15 +45,10 @@ func testTemplatesForKnobs() *TemplateRegistry {
 
 func TestGenerateKnobs_SimpleButton(t *testing.T) {
 	// Load manifest fixture
-	manifestPath := filepath.Join("testdata", "knobs", "simple-button-manifest.json")
-	manifestBytes, err := os.ReadFile(manifestPath)
-	if err != nil {
-		t.Fatalf("Failed to read manifest fixture: %v", err)
-	}
+	manifestBytes := loadKnobsFixture(t, "simple-button-manifest.json")
 
 	var pkg M.Package
-	err = json.Unmarshal(manifestBytes, &pkg)
-	if err != nil {
+	if err := json.Unmarshal(manifestBytes, &pkg); err != nil {
 		t.Fatalf("Failed to parse manifest: %v", err)
 	}
 
@@ -66,11 +71,7 @@ func TestGenerateKnobs_SimpleButton(t *testing.T) {
 	}
 
 	// Load demo HTML
-	demoPath := filepath.Join("testdata", "knobs", "simple-button-demo.html")
-	demoHTML, err := os.ReadFile(demoPath)
-	if err != nil {
-		t.Fatalf("Failed to read demo HTML: %v", err)
-	}
+	demoHTML := loadKnobsFixture(t, "simple-button-demo.html")
 
 	// Generate knobs with all categories enabled
 	knobs, err := GenerateKnobs(declaration, demoHTML, "attributes properties css-properties")
@@ -400,11 +401,7 @@ func TestDiscoverElementInstances(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Load demo HTML
-			demoPath := filepath.Join("testdata", "knobs", tt.demoFile)
-			demoHTML, err := os.ReadFile(demoPath)
-			if err != nil {
-				t.Fatalf("Failed to read demo HTML: %v", err)
-			}
+			demoHTML := loadKnobsFixture(t, tt.demoFile)
 
 			// Discover instances
 			instances, err := discoverElementInstances("my-card", demoHTML)
@@ -491,11 +488,7 @@ func TestGenerateElementLabel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Load demo HTML
-			demoPath := filepath.Join("testdata", "knobs", tt.demoFile)
-			demoHTML, err := os.ReadFile(demoPath)
-			if err != nil {
-				t.Fatalf("Failed to read demo HTML: %v", err)
-			}
+			demoHTML := loadKnobsFixture(t, tt.demoFile)
 
 			// Discover instances
 			instances, err := discoverElementInstances("my-card", demoHTML)
@@ -520,15 +513,10 @@ func TestGenerateElementLabel(t *testing.T) {
 // TestGenerateMultiInstanceKnobs tests knob generation for multiple element instances
 func TestGenerateMultiInstanceKnobs(t *testing.T) {
 	// Load manifest fixture
-	manifestPath := filepath.Join("testdata", "knobs", "multi-element-manifest.json")
-	manifestBytes, err := os.ReadFile(manifestPath)
-	if err != nil {
-		t.Fatalf("Failed to read manifest fixture: %v", err)
-	}
+	manifestBytes := loadKnobsFixture(t, "multi-element-manifest.json")
 
 	var pkg M.Package
-	err = json.Unmarshal(manifestBytes, &pkg)
-	if err != nil {
+	if err := json.Unmarshal(manifestBytes, &pkg); err != nil {
 		t.Fatalf("Failed to parse manifest: %v", err)
 	}
 
@@ -551,11 +539,7 @@ func TestGenerateMultiInstanceKnobs(t *testing.T) {
 	}
 
 	// Load demo HTML with multiple instances
-	demoPath := filepath.Join("testdata", "knobs", "multi-element-with-ids-demo.html")
-	demoHTML, err := os.ReadFile(demoPath)
-	if err != nil {
-		t.Fatalf("Failed to read demo HTML: %v", err)
-	}
+	demoHTML := loadKnobsFixture(t, "multi-element-with-ids-demo.html")
 
 	// Generate knobs for all instances
 	knobGroups, err := GenerateMultiInstanceKnobs(declaration, demoHTML, "attributes properties css-properties")

--- a/serve/middleware/routes/tree_view_test.go
+++ b/serve/middleware/routes/tree_view_test.go
@@ -19,11 +19,22 @@ package routes
 
 import (
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
+
+	"bennypowers.dev/cem/internal/platform"
+	"bennypowers.dev/cem/internal/platform/testutil"
 )
+
+var templatesFS *platform.MapFileSystem
+
+func loadTemplatesFS(t *testing.T) *platform.MapFileSystem {
+	t.Helper()
+	if templatesFS == nil {
+		templatesFS = testutil.LoadTestdataFS(t, "templates", "/templates")
+	}
+	return templatesFS
+}
 
 // TestTreeViewComponentFiles verifies tree view component files exist and have required content
 func TestTreeViewComponentFiles(t *testing.T) {
@@ -93,13 +104,11 @@ func TestTreeViewComponentFiles(t *testing.T) {
 		},
 	}
 
+	mfs := loadTemplatesFS(t)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fullPath := filepath.Join(".", tt.path)
-			content, err := os.ReadFile(fullPath)
-			if err != nil {
-				t.Fatalf("Failed to read %s (%s): %v", tt.description, fullPath, err)
-			}
+			content := testutil.ReadFixture(t, mfs, "/"+tt.path)
 
 			contentStr := string(content)
 			for _, mustContain := range tt.mustContain {
@@ -184,11 +193,8 @@ func TestManifestTreeBuilder_Structure(t *testing.T) {
 
 // TestTreeViewEventClasses verifies custom event classes follow the pattern
 func TestTreeViewEventClasses(t *testing.T) {
-	jsPath := filepath.Join(".", "templates/elements/cem-pf-v6-tree-item/cem-pf-v6-tree-item.js")
-	content, err := os.ReadFile(jsPath)
-	if err != nil {
-		t.Fatalf("Failed to read tree item JS: %v", err)
-	}
+	mfs := loadTemplatesFS(t)
+	content := testutil.ReadFixture(t, mfs, "/templates/elements/cem-pf-v6-tree-item/cem-pf-v6-tree-item.js")
 
 	contentStr := string(content)
 
@@ -218,11 +224,8 @@ func TestTreeViewEventClasses(t *testing.T) {
 
 // TestTreeViewAccessibility verifies ARIA attributes are present in the Lit component JS
 func TestTreeViewAccessibility(t *testing.T) {
-	jsPath := filepath.Join(".", "templates/elements/cem-pf-v6-tree-view/cem-pf-v6-tree-view.js")
-	content, err := os.ReadFile(jsPath)
-	if err != nil {
-		t.Fatalf("Failed to read tree view JS: %v", err)
-	}
+	mfs := loadTemplatesFS(t)
+	content := testutil.ReadFixture(t, mfs, "/templates/elements/cem-pf-v6-tree-view/cem-pf-v6-tree-view.js")
 
 	contentStr := string(content)
 
@@ -241,11 +244,8 @@ func TestTreeViewAccessibility(t *testing.T) {
 
 // TestTreeItemCSS_Structure verifies tree item CSS file has required structure
 func TestTreeItemCSS_Structure(t *testing.T) {
-	cssPath := filepath.Join(".", "templates/elements/cem-pf-v6-tree-item/cem-pf-v6-tree-item.css")
-	content, err := os.ReadFile(cssPath)
-	if err != nil {
-		t.Fatalf("Failed to read tree item CSS: %v", err)
-	}
+	mfs := loadTemplatesFS(t)
+	content := testutil.ReadFixture(t, mfs, "/templates/elements/cem-pf-v6-tree-item/cem-pf-v6-tree-item.css")
 
 	contentStr := string(content)
 
@@ -268,11 +268,8 @@ func TestTreeItemCSS_Structure(t *testing.T) {
 
 // TestManifestIcons_Coverage verifies all expected icon types are available
 func TestManifestIcons_Coverage(t *testing.T) {
-	jsPath := filepath.Join(".", "templates/js/manifest-icons.js")
-	content, err := os.ReadFile(jsPath)
-	if err != nil {
-		t.Fatalf("Failed to read manifest-icons.js: %v", err)
-	}
+	mfs := loadTemplatesFS(t)
+	content := testutil.ReadFixture(t, mfs, "/templates/js/manifest-icons.js")
 
 	contentStr := string(content)
 
@@ -335,13 +332,11 @@ func TestVirtualTreeComponent(t *testing.T) {
 		},
 	}
 
+	mfs := loadTemplatesFS(t)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fullPath := filepath.Join(".", tt.path)
-			content, err := os.ReadFile(fullPath)
-			if err != nil {
-				t.Fatalf("Failed to read %s (%s): %v", tt.description, fullPath, err)
-			}
+			content := testutil.ReadFixture(t, mfs, "/"+tt.path)
 
 			contentStr := string(content)
 			for _, mustContain := range tt.mustContain {
@@ -378,13 +373,11 @@ func TestDetailPanelComponent(t *testing.T) {
 		},
 	}
 
+	mfs := loadTemplatesFS(t)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fullPath := filepath.Join(".", tt.path)
-			content, err := os.ReadFile(fullPath)
-			if err != nil {
-				t.Fatalf("Failed to read %s (%s): %v", tt.description, fullPath, err)
-			}
+			content := testutil.ReadFixture(t, mfs, "/"+tt.path)
 
 			contentStr := string(content)
 			for _, mustContain := range tt.mustContain {
@@ -400,11 +393,8 @@ func TestDetailPanelComponent(t *testing.T) {
 
 // TestManifestBrowserIntegration verifies manifest browser uses new components
 func TestManifestBrowserIntegration(t *testing.T) {
-	jsPath := filepath.Join(".", "templates/elements/cem-manifest-browser/cem-manifest-browser.js")
-	content, err := os.ReadFile(jsPath)
-	if err != nil {
-		t.Fatalf("Failed to read manifest browser JS: %v", err)
-	}
+	mfs := loadTemplatesFS(t)
+	content := testutil.ReadFixture(t, mfs, "/templates/elements/cem-manifest-browser/cem-manifest-browser.js")
 
 	contentStr := string(content)
 
@@ -439,11 +429,8 @@ func TestManifestBrowserIntegration(t *testing.T) {
 
 // TestDemoChromeNoSSR verifies demo chrome template no longer has SSR tree
 func TestDemoChromeNoSSR(t *testing.T) {
-	htmlPath := filepath.Join(".", "templates/demo-chrome.html")
-	content, err := os.ReadFile(htmlPath)
-	if err != nil {
-		t.Fatalf("Failed to read demo-chrome.html: %v", err)
-	}
+	mfs := loadTemplatesFS(t)
+	content := testutil.ReadFixture(t, mfs, "/templates/demo-chrome.html")
 
 	contentStr := string(content)
 

--- a/serve/middleware/transform/cache_internal_test.go
+++ b/serve/middleware/transform/cache_internal_test.go
@@ -18,12 +18,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package transform
 
 import (
-	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 	"time"
+
+	"bennypowers.dev/cem/internal/platform/testutil"
 )
 
 // This file contains white-box tests that access unexported functions/types.
@@ -64,10 +65,8 @@ func (m *mockLogger) Debug(msg string, args ...any) {
 func TestExtractDependencies_CSSImports(t *testing.T) {
 	// Read fixture file with CSS import
 	inputPath := filepath.Join("..", "..", "testdata", "transforms", "css-import", "input.ts")
-	source, err := os.ReadFile(inputPath)
-	if err != nil {
-		t.Fatalf("Failed to read test fixture: %v", err)
-	}
+	mfs := testutil.LoadTestdataFS(t, filepath.Join("..", "..", "testdata", "transforms", "css-import"), "/")
+	source := testutil.ReadFixture(t, mfs, "/input.ts")
 
 	// Extract dependencies from the source
 	absPath, _ := filepath.Abs(inputPath)
@@ -97,10 +96,8 @@ func TestCache_CSSImportDependenciesExtracted(t *testing.T) {
 
 	// Read fixture file with CSS import
 	inputPath := filepath.Join("..", "..", "testdata", "transforms", "css-import", "input.ts")
-	source, err := os.ReadFile(inputPath)
-	if err != nil {
-		t.Fatalf("Failed to read test fixture: %v", err)
-	}
+	mfs := testutil.LoadTestdataFS(t, filepath.Join("..", "..", "testdata", "transforms", "css-import"), "/")
+	source := testutil.ReadFixture(t, mfs, "/input.ts")
 
 	absPath, _ := filepath.Abs(inputPath)
 	cssPath, _ := filepath.Abs(filepath.Join(filepath.Dir(inputPath), "component.css"))

--- a/serve/server_test.go
+++ b/serve/server_test.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 
 	"bennypowers.dev/cem/internal/platform"
+	"bennypowers.dev/cem/internal/platform/testutil"
 	"bennypowers.dev/cem/serve"
 	importmappkg "bennypowers.dev/cem/serve/middleware/importmap"
 	"bennypowers.dev/cem/serve/middleware/transform"
@@ -63,11 +64,8 @@ func newTestFS(t *testing.T) platform.FileSystem {
 // TestReloadMessageFormat verifies reload message structure matches expected format
 func TestReloadMessageFormat(t *testing.T) {
 	// Read expected golden file
-	goldenPath := filepath.Join("testdata", "websocket-reload", "expected-reload-message.json")
-	expectedBytes, err := os.ReadFile(goldenPath)
-	if err != nil {
-		t.Fatalf("Failed to read golden file: %v", err)
-	}
+	mfsFixtures := testutil.LoadTestdataFS(t, "testdata/websocket-reload", "/")
+	expectedBytes := testutil.ReadFixture(t, mfsFixtures, "/expected-reload-message.json")
 
 	// Parse expected message
 	var expected map[string]any

--- a/serve/websocket_test.go
+++ b/serve/websocket_test.go
@@ -21,12 +21,11 @@ package serve_test
 
 import (
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	platformtestutil "bennypowers.dev/cem/internal/platform/testutil"
 	"bennypowers.dev/cem/serve"
 	"bennypowers.dev/cem/serve/internal/urlutil"
 	"bennypowers.dev/cem/serve/testutil"
@@ -97,11 +96,8 @@ func TestWebSocketEndpoint_Broadcast(t *testing.T) {
 	}
 
 	// Verify message structure matches golden file
-	goldenPath := filepath.Join("testdata", "websocket-reload", "expected-reload-message.json")
-	expectedBytes, err := os.ReadFile(goldenPath)
-	if err != nil {
-		t.Fatalf("Failed to read golden file: %v", err)
-	}
+	mfsFixtures := platformtestutil.LoadTestdataFS(t, "testdata/websocket-reload", "/")
+	expectedBytes := platformtestutil.ReadFixture(t, mfsFixtures, "/expected-reload-message.json")
 
 	var expected map[string]any
 	if err := json.Unmarshal(expectedBytes, &expected); err != nil {

--- a/test/integration/zed_binary_names_test.go
+++ b/test/integration/zed_binary_names_test.go
@@ -1,19 +1,20 @@
 package integration_test
 
 import (
-	"os"
 	"testing"
 
+	"bennypowers.dev/cem/internal/platform/testutil"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
+
+// Inline: integration test, scalar assertions
 
 // TestZedBinaryNamingConsistency verifies that the Zed extension references
 // the correct binary names that match the go-release-workflows output.
 func TestZedBinaryNamingConsistency(t *testing.T) {
 	// Read Zed extension source
-	zedSource, err := os.ReadFile("../../extensions/zed/src/lib.rs")
-	require.NoError(t, err)
+	mfs := testutil.LoadTestdataFS(t, "../../extensions/zed/src", "/")
+	zedSource := testutil.ReadFixture(t, mfs, "/lib.rs")
 
 	sourceStr := string(zedSource)
 

--- a/validate/types_test.go
+++ b/validate/types_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, scalar assertions (type accessor methods on thin wrappers)
+
 func TestRawManifest_Modules(t *testing.T) {
 	t.Run("valid modules", func(t *testing.T) {
 		m := validate.RawManifest{"modules": []any{map[string]any{"path": "a.js"}}}

--- a/validate/validate_helpers_test.go
+++ b/validate/validate_helpers_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, table-driven
+
 func TestIsSemverLessThan(t *testing.T) {
 	tests := []struct {
 		v1, v2 string

--- a/validate/warnings_rules_test.go
+++ b/validate/warnings_rules_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Inline: pure function, scalar assertions (rule Check methods return warning slices)
+
 func makeCtx(members []map[string]any) *WarningContext {
 	memberSlice := make([]any, len(members))
 	for i, m := range members {


### PR DESCRIPTION
## Summary

- Add `LoadTestdataFS` and `ReadFixture` helpers to `internal/platform/testutil` for loading any package's testdata into `MapFileSystem`
- Add `GoldenOptions.FS` field to `CheckGolden` for reading goldens from MapFS
- Centralize `--update` flag in `testutil.Update`, replacing per-package `flag.Bool` declarations
- Convert 62 `os.ReadFile` calls across 106 test files to use MapFS, frontloading disk I/O at setup time
- Add `// Inline:` justification comments to 81 test files using inline assertions
- Unify `NewFixtureFS` to delegate to `LoadTestdataFS` after path resolution
- Add tests for new testutil helpers
- Update AGENTS.md with "Always use MapFS for test data" rule

Remaining `os.ReadFile` calls (16 files) are in LSP workspace integration tests that require `NewFileSystemWorkspaceContext` -- Phase 2 will add a MapFS-backed WorkspaceContext.

## Test plan

- [x] `make test` -- 3922 tests pass, 0 failures
- [x] `make lint` -- 0 issues
- [x] `go test ./internal/platform/testutil/... -v` -- new helper tests pass
- [x] Verify `--update` golden regeneration still works (generate, health, mcp, export)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified testing guidance for fixtures and golden files.

* **Tests**
  * Standardized test data to an in-memory test filesystem and unified golden-file handling.
  * Switched golden-update flow to shared test helpers.
  * Added coverage and helpers for fixture/golden utilities.

* **Chores**
  * Added descriptive inline test comments documenting intent and scope across the suite.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bennypowers/cem/pull/334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->