### PR TITLE
refactor(test): MapFS-backed WorkspaceContext for in-memory test workspaces

### DIFF
--- a/generate/designtokens_validation_test.go
+++ b/generate/designtokens_validation_test.go
@@ -19,6 +19,7 @@ package generate
 import (
 	"errors"
 	"io"
+	"io/fs"
 	"strings"
 	"testing"
 
@@ -71,6 +72,8 @@ func (m *mockWorkspaceContext) PackageJSON() (*M.PackageJSON, error)        { re
 func (m *mockWorkspaceContext) Manifest() (*M.Package, error)               { return nil, nil }
 func (m *mockWorkspaceContext) CustomElementsManifestPath() string          { return "" }
 func (m *mockWorkspaceContext) ReadFile(string) (io.ReadCloser, error)      { return nil, nil }
+func (m *mockWorkspaceContext) Stat(string) (fs.FileInfo, error)            { return nil, nil }
+func (m *mockWorkspaceContext) ReadDir(string) ([]fs.DirEntry, error)       { return nil, nil }
 func (m *mockWorkspaceContext) OutputWriter(string) (io.WriteCloser, error) { return nil, nil }
 func (m *mockWorkspaceContext) ModulePathToFS(string) string                { return "" }
 func (m *mockWorkspaceContext) FSPathToModule(string) (string, error)       { return "", nil }

--- a/internal/designtokens/designtokens_test.go
+++ b/internal/designtokens/designtokens_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -43,6 +44,8 @@ func (s *stubWorkspaceContext) CustomElementsManifestPath() string   { return ""
 func (s *stubWorkspaceContext) ReadFile(path string) (io.ReadCloser, error) {
 	return nil, fmt.Errorf("stubWorkspaceContext.ReadFile(%q): not implemented", path)
 }
+func (s *stubWorkspaceContext) Stat(string) (fs.FileInfo, error)            { return nil, nil }
+func (s *stubWorkspaceContext) ReadDir(string) ([]fs.DirEntry, error)       { return nil, nil }
 func (s *stubWorkspaceContext) Glob(string) ([]string, error)               { return nil, nil }
 func (s *stubWorkspaceContext) OutputWriter(string) (io.WriteCloser, error) { return nil, nil }
 func (s *stubWorkspaceContext) Cleanup() error                              { return nil }

--- a/internal/platform/testutil/workspace/testdata/workspace-context/custom-elements.json
+++ b/internal/platform/testutil/workspace/testdata/workspace-context/custom-elements.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "name": "MyElement",
+          "tagName": "my-element",
+          "customElement": true,
+          "attributes": [
+            {
+              "name": "label",
+              "type": { "text": "string" },
+              "description": "The label text"
+            }
+          ],
+          "slots": [
+            {
+              "name": "",
+              "description": "Default slot"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/internal/platform/testutil/workspace/testdata/workspace-context/package.json
+++ b/internal/platform/testutil/workspace/testdata/workspace-context/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-workspace-context",
+  "version": "1.0.0",
+  "customElements": "custom-elements.json"
+}

--- a/internal/platform/testutil/workspace/testdata/workspace-context/src/my-element.js
+++ b/internal/platform/testutil/workspace/testdata/workspace-context/src/my-element.js
@@ -1,0 +1,2 @@
+export class MyElement extends HTMLElement {}
+customElements.define('my-element', MyElement);

--- a/internal/platform/testutil/workspace/workspace.go
+++ b/internal/platform/testutil/workspace/workspace.go
@@ -1,0 +1,258 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package workspace
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	C "bennypowers.dev/cem/cmd/config"
+	IC "bennypowers.dev/cem/internal/config"
+	"bennypowers.dev/cem/internal/platform"
+	"bennypowers.dev/cem/internal/platform/testutil"
+	M "bennypowers.dev/cem/manifest"
+	"bennypowers.dev/cem/types"
+	"github.com/bmatcuk/doublestar"
+)
+
+var _ types.WorkspaceContext = (*MapWorkspaceContext)(nil)
+
+// MapWorkspaceContext implements types.WorkspaceContext backed by a platform.MapFileSystem.
+// All reads come from in-memory MapFS, no disk I/O after construction.
+type MapWorkspaceContext struct {
+	mfs                        *platform.MapFileSystem
+	root                       string
+	config                     *C.CemConfig
+	customElementsManifestPath string
+	manifest                   *M.Package
+	packageJSON                *M.PackageJSON
+	designTokensCache          types.DesignTokensCache
+}
+
+// NewMapWorkspaceContext loads dir into MapFS and returns a WorkspaceContext backed by it.
+// dir is relative to the test's working directory.
+func NewMapWorkspaceContext(t testing.TB, dir string) *MapWorkspaceContext {
+	t.Helper()
+	mfs := testutil.LoadTestdataFS(t, dir, "/")
+	return &MapWorkspaceContext{
+		mfs:               mfs,
+		root:              "/",
+		designTokensCache: &noopDesignTokensCache{},
+	}
+}
+
+func (c *MapWorkspaceContext) Init() error {
+	data, err := c.mfs.ReadFile("package.json")
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("MapWorkspaceContext: reading package.json: %w", err)
+	}
+
+	if err == nil {
+		var pkg M.PackageJSON
+		if err := json.Unmarshal(data, &pkg); err != nil {
+			return fmt.Errorf("MapWorkspaceContext: parsing package.json: %w", err)
+		}
+		c.packageJSON = &pkg
+
+		if pkg.CustomElements != "" {
+			c.customElementsManifestPath = filepath.Join(c.root, pkg.CustomElements)
+		}
+	}
+
+	if c.customElementsManifestPath == "" {
+		c.customElementsManifestPath = filepath.Join(c.root, "custom-elements.json")
+	}
+
+	c.config = &IC.CemConfig{
+		ProjectDir: c.root,
+		Generate: IC.GenerateConfig{
+			Files:   make([]string, 0),
+			Exclude: make([]string, 0),
+		},
+	}
+
+	return nil
+}
+
+func (c *MapWorkspaceContext) ConfigFile() string {
+	return ""
+}
+
+func (c *MapWorkspaceContext) Config() (*C.CemConfig, error) {
+	return c.config, nil
+}
+
+func (c *MapWorkspaceContext) PackageJSON() (*M.PackageJSON, error) {
+	return c.packageJSON, nil
+}
+
+func (c *MapWorkspaceContext) Manifest() (*M.Package, error) {
+	if c.manifest != nil {
+		return c.manifest, nil
+	}
+
+	if c.customElementsManifestPath == "" {
+		return nil, errors.New("no manifest path configured")
+	}
+
+	rc, err := c.ReadFile(c.customElementsManifestPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rc.Close() }()
+
+	var pkg M.Package
+	if err := json.NewDecoder(rc).Decode(&pkg); err != nil {
+		return nil, fmt.Errorf("MapWorkspaceContext: parsing manifest: %w", err)
+	}
+
+	c.manifest = &pkg
+	return c.manifest, nil
+}
+
+func (c *MapWorkspaceContext) CustomElementsManifestPath() string {
+	return c.customElementsManifestPath
+}
+
+func (c *MapWorkspaceContext) ReadFile(path string) (io.ReadCloser, error) {
+	clean := c.cleanPath(path)
+	data, err := c.mfs.ReadFile(clean)
+	if err != nil {
+		return nil, fmt.Errorf("MapWorkspaceContext: %w", err)
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func (c *MapWorkspaceContext) Stat(path string) (fs.FileInfo, error) {
+	clean := c.cleanPath(path)
+	return c.mfs.Stat(clean)
+}
+
+func (c *MapWorkspaceContext) ReadDir(path string) ([]fs.DirEntry, error) {
+	clean := c.cleanPath(path)
+	return fs.ReadDir(c.mfs.GetMapFS(), clean)
+}
+
+func (c *MapWorkspaceContext) Glob(pattern string) ([]string, error) {
+	mapFS := c.mfs.GetMapFS()
+	seen := make(map[string]bool)
+	var matches []string
+
+	for filePath := range mapFS {
+		// Match the file itself
+		if matched, _ := doublestar.Match(pattern, filePath); matched {
+			if !seen[filePath] {
+				seen[filePath] = true
+				matches = append(matches, filePath)
+			}
+		}
+		// Match intermediate directories derived from file paths
+		dir := filePath
+		for {
+			dir = filepath.Dir(dir)
+			if dir == "." || dir == "/" || dir == "" {
+				break
+			}
+			if seen[dir] {
+				break
+			}
+			if matched, _ := doublestar.Match(pattern, dir); matched {
+				seen[dir] = true
+				matches = append(matches, dir)
+			}
+		}
+	}
+	return matches, nil
+}
+
+func (c *MapWorkspaceContext) OutputWriter(path string) (io.WriteCloser, error) {
+	return &mapFSWriter{mfs: c.mfs, path: path}, nil
+}
+
+func (c *MapWorkspaceContext) Root() string {
+	return c.root
+}
+
+func (c *MapWorkspaceContext) Cleanup() error {
+	return nil
+}
+
+func (c *MapWorkspaceContext) ModulePathToFS(modulePath string) string {
+	if filepath.IsAbs(modulePath) {
+		return modulePath
+	}
+	return filepath.Join(c.root, modulePath)
+}
+
+func (c *MapWorkspaceContext) FSPathToModule(fsPath string) (string, error) {
+	rel, err := filepath.Rel(c.root, fsPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to compute relative path from %s to %s: %w", c.root, fsPath, err)
+	}
+	return rel, nil
+}
+
+func (c *MapWorkspaceContext) ResolveModuleDependency(modulePath, dependencyPath string) (string, error) {
+	if filepath.IsAbs(dependencyPath) {
+		rel, err := filepath.Rel(c.root, dependencyPath)
+		if err != nil {
+			return "", err
+		}
+		return rel, nil
+	}
+	moduleDir := filepath.Dir(modulePath)
+	resolved := filepath.Join(moduleDir, dependencyPath)
+	return filepath.Clean(resolved), nil
+}
+
+func (c *MapWorkspaceContext) DesignTokensCache() types.DesignTokensCache {
+	return c.designTokensCache
+}
+
+func (c *MapWorkspaceContext) cleanPath(path string) string {
+	return strings.TrimPrefix(filepath.Clean(path), "/")
+}
+
+type mapFSWriter struct {
+	mfs  *platform.MapFileSystem
+	path string
+	buf  bytes.Buffer
+}
+
+func (w *mapFSWriter) Write(p []byte) (int, error) {
+	return w.buf.Write(p)
+}
+
+func (w *mapFSWriter) Close() error {
+	return w.mfs.WriteFile(w.path, w.buf.Bytes(), 0644)
+}
+
+type noopDesignTokensCache struct{}
+
+func (n *noopDesignTokensCache) LoadOrReuse(_ types.WorkspaceContext) (types.DesignTokens, error) {
+	return nil, nil
+}
+
+func (n *noopDesignTokensCache) Clear() {}

--- a/internal/platform/testutil/workspace/workspace.go
+++ b/internal/platform/testutil/workspace/workspace.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"io/fs"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -184,6 +185,7 @@ func (c *MapWorkspaceContext) Glob(pattern string) ([]string, error) {
 			}
 		}
 	}
+	sort.Strings(matches)
 	return matches, nil
 }
 

--- a/internal/platform/testutil/workspace/workspace.go
+++ b/internal/platform/testutil/workspace/workspace.go
@@ -152,7 +152,7 @@ func (c *MapWorkspaceContext) Stat(path string) (fs.FileInfo, error) {
 
 func (c *MapWorkspaceContext) ReadDir(path string) ([]fs.DirEntry, error) {
 	clean := c.cleanPath(path)
-	return fs.ReadDir(c.mfs.GetMapFS(), clean)
+	return c.mfs.ReadDir(clean)
 }
 
 func (c *MapWorkspaceContext) Glob(pattern string) ([]string, error) {

--- a/internal/platform/testutil/workspace/workspace_test.go
+++ b/internal/platform/testutil/workspace/workspace_test.go
@@ -105,6 +105,61 @@ func TestMapWorkspaceContext_Glob(t *testing.T) {
 	assert.Contains(t, matches, "custom-elements.json")
 }
 
+func TestMapWorkspaceContext_Stat(t *testing.T) {
+	ctx := workspace.NewMapWorkspaceContext(t, "testdata/workspace-context")
+	err := ctx.Init()
+	require.NoError(t, err)
+
+	t.Run("existing file", func(t *testing.T) {
+		info, err := ctx.Stat("/package.json")
+		require.NoError(t, err)
+		assert.False(t, info.IsDir())
+		assert.Greater(t, info.Size(), int64(0))
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		_, err := ctx.Stat("/nonexistent.json")
+		assert.Error(t, err)
+	})
+
+	t.Run("directory", func(t *testing.T) {
+		info, err := ctx.Stat("/src")
+		require.NoError(t, err)
+		assert.True(t, info.IsDir())
+	})
+}
+
+func TestMapWorkspaceContext_ReadDir(t *testing.T) {
+	ctx := workspace.NewMapWorkspaceContext(t, "testdata/workspace-context")
+	err := ctx.Init()
+	require.NoError(t, err)
+
+	t.Run("root directory", func(t *testing.T) {
+		entries, err := ctx.ReadDir("/")
+		require.NoError(t, err)
+		assert.NotEmpty(t, entries)
+
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		assert.Contains(t, names, "package.json")
+		assert.Contains(t, names, "src")
+	})
+
+	t.Run("subdirectory", func(t *testing.T) {
+		entries, err := ctx.ReadDir("/src")
+		require.NoError(t, err)
+		assert.Len(t, entries, 1)
+		assert.Equal(t, "my-element.js", entries[0].Name())
+	})
+
+	t.Run("missing directory", func(t *testing.T) {
+		_, err := ctx.ReadDir("/nonexistent")
+		assert.Error(t, err)
+	})
+}
+
 func TestMapWorkspaceContext_PathResolution(t *testing.T) {
 	ctx := workspace.NewMapWorkspaceContext(t, "testdata/workspace-context")
 	err := ctx.Init()

--- a/internal/platform/testutil/workspace/workspace_test.go
+++ b/internal/platform/testutil/workspace/workspace_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package workspace_test
+
+import (
+	"io"
+	"testing"
+
+	"bennypowers.dev/cem/internal/platform/testutil/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapWorkspaceContext_Init(t *testing.T) {
+	ctx := workspace.NewMapWorkspaceContext(t, "testdata/workspace-context")
+	err := ctx.Init()
+	require.NoError(t, err)
+}
+
+func TestMapWorkspaceContext_Root(t *testing.T) {
+	ctx := workspace.NewMapWorkspaceContext(t, "testdata/workspace-context")
+	err := ctx.Init()
+	require.NoError(t, err)
+
+	assert.Equal(t, "/", ctx.Root())
+}
+
+func TestMapWorkspaceContext_PackageJSON(t *testing.T) {
+	ctx := workspace.NewMapWorkspaceContext(t, "testdata/workspace-context")
+	err := ctx.Init()
+	require.NoError(t, err)
+
+	pkg, err := ctx.PackageJSON()
+	require.NoError(t, err)
+	require.NotNil(t, pkg)
+	assert.Equal(t, "test-workspace-context", pkg.Name)
+	assert.Equal(t, "custom-elements.json", pkg.CustomElements)
+}
+
+func TestMapWorkspaceContext_Manifest(t *testing.T) {
+	ctx := workspace.NewMapWorkspaceContext(t, "testdata/workspace-context")
+	err := ctx.Init()
+	require.NoError(t, err)
+
+	manifest, err := ctx.Manifest()
+	require.NoError(t, err)
+	require.NotNil(t, manifest)
+	assert.Equal(t, "2.1.0", manifest.SchemaVersion)
+	assert.Len(t, manifest.Modules, 1)
+}
+
+func TestMapWorkspaceContext_CustomElementsManifestPath(t *testing.T) {
+	ctx := workspace.NewMapWorkspaceContext(t, "testdata/workspace-context")
+	err := ctx.Init()
+	require.NoError(t, err)
+
+	assert.Equal(t, "/custom-elements.json", ctx.CustomElementsManifestPath())
+}
+
+func TestMapWorkspaceContext_ReadFile(t *testing.T) {
+	ctx := workspace.NewMapWorkspaceContext(t, "testdata/workspace-context")
+	err := ctx.Init()
+	require.NoError(t, err)
+
+	rc, err := ctx.ReadFile("/src/my-element.js")
+	require.NoError(t, err)
+	defer func() { _ = rc.Close() }()
+
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "MyElement")
+}
+
+func TestMapWorkspaceContext_ReadFile_NotFound(t *testing.T) {
+	ctx := workspace.NewMapWorkspaceContext(t, "testdata/workspace-context")
+	err := ctx.Init()
+	require.NoError(t, err)
+
+	_, err = ctx.ReadFile("/nonexistent.js")
+	assert.Error(t, err)
+}
+
+func TestMapWorkspaceContext_Glob(t *testing.T) {
+	ctx := workspace.NewMapWorkspaceContext(t, "testdata/workspace-context")
+	err := ctx.Init()
+	require.NoError(t, err)
+
+	matches, err := ctx.Glob("*.json")
+	require.NoError(t, err)
+	assert.Contains(t, matches, "package.json")
+	assert.Contains(t, matches, "custom-elements.json")
+}
+
+func TestMapWorkspaceContext_PathResolution(t *testing.T) {
+	ctx := workspace.NewMapWorkspaceContext(t, "testdata/workspace-context")
+	err := ctx.Init()
+	require.NoError(t, err)
+
+	t.Run("ModulePathToFS", func(t *testing.T) {
+		result := ctx.ModulePathToFS("src/my-element.js")
+		assert.Equal(t, "/src/my-element.js", result)
+	})
+
+	t.Run("FSPathToModule", func(t *testing.T) {
+		mod, err := ctx.FSPathToModule("/src/my-element.js")
+		require.NoError(t, err)
+		assert.Equal(t, "src/my-element.js", mod)
+	})
+
+	t.Run("ResolveModuleDependency_relative", func(t *testing.T) {
+		resolved, err := ctx.ResolveModuleDependency("src/my-element.js", "./helper.js")
+		require.NoError(t, err)
+		assert.Equal(t, "src/helper.js", resolved)
+	})
+}
+
+func TestMapWorkspaceContext_Config(t *testing.T) {
+	ctx := workspace.NewMapWorkspaceContext(t, "testdata/workspace-context")
+	err := ctx.Init()
+	require.NoError(t, err)
+
+	cfg, err := ctx.Config()
+	require.NoError(t, err)
+	assert.NotNil(t, cfg)
+}
+
+func TestMapWorkspaceContext_DesignTokensCache(t *testing.T) {
+	ctx := workspace.NewMapWorkspaceContext(t, "testdata/workspace-context")
+	err := ctx.Init()
+	require.NoError(t, err)
+
+	cache := ctx.DesignTokensCache()
+	assert.NotNil(t, cache)
+}
+
+func TestMapWorkspaceContext_Cleanup(t *testing.T) {
+	ctx := workspace.NewMapWorkspaceContext(t, "testdata/workspace-context")
+	err := ctx.Init()
+	require.NoError(t, err)
+	assert.NoError(t, ctx.Cleanup())
+}

--- a/internal/workspace/cache_test.go
+++ b/internal/workspace/cache_test.go
@@ -20,6 +20,7 @@ package workspace_test
 import (
 	"errors"
 	"io"
+	"io/fs"
 	"strings"
 	"testing"
 
@@ -64,6 +65,8 @@ func (m *mockWorkspaceContext) PackageJSON() (*M.PackageJSON, error)            
 func (m *mockWorkspaceContext) Manifest() (*M.Package, error)                    { return nil, nil }
 func (m *mockWorkspaceContext) CustomElementsManifestPath() string               { return "" }
 func (m *mockWorkspaceContext) ReadFile(path string) (io.ReadCloser, error)      { return nil, nil }
+func (m *mockWorkspaceContext) Stat(_ string) (fs.FileInfo, error)               { return nil, nil }
+func (m *mockWorkspaceContext) ReadDir(_ string) ([]fs.DirEntry, error)          { return nil, nil }
 func (m *mockWorkspaceContext) Glob(pattern string) ([]string, error)            { return nil, nil }
 func (m *mockWorkspaceContext) OutputWriter(path string) (io.WriteCloser, error) { return nil, nil }
 func (m *mockWorkspaceContext) Root() string                                     { return "" }

--- a/internal/workspace/local.go
+++ b/internal/workspace/local.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -201,6 +202,14 @@ func (c *FileSystemWorkspaceContext) ReadFile(path string) (io.ReadCloser, error
 		return nil, fmt.Errorf("FileSystemWorkspaceContext could not open: %w", err)
 	}
 	return rc, nil
+}
+
+func (c *FileSystemWorkspaceContext) Stat(path string) (fs.FileInfo, error) {
+	return os.Stat(path)
+}
+
+func (c *FileSystemWorkspaceContext) ReadDir(path string) ([]fs.DirEntry, error) {
+	return os.ReadDir(path)
 }
 
 func (c *FileSystemWorkspaceContext) Glob(pattern string) ([]string, error) {

--- a/internal/workspace/remote.go
+++ b/internal/workspace/remote.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"os"
 	"path"
@@ -275,6 +276,22 @@ func (c *RemoteWorkspaceContext) ReadFile(path string) (io.ReadCloser, error) {
 		absPath = filepath.Join(c.cacheDir, path)
 	}
 	return os.Open(absPath)
+}
+
+func (c *RemoteWorkspaceContext) Stat(path string) (fs.FileInfo, error) {
+	absPath := path
+	if !filepath.IsAbs(path) {
+		absPath = filepath.Join(c.cacheDir, path)
+	}
+	return os.Stat(absPath)
+}
+
+func (c *RemoteWorkspaceContext) ReadDir(path string) ([]fs.DirEntry, error) {
+	absPath := path
+	if !filepath.IsAbs(path) {
+		absPath = filepath.Join(c.cacheDir, path)
+	}
+	return os.ReadDir(absPath)
 }
 
 func (c *RemoteWorkspaceContext) Glob(pattern string) ([]string, error) {

--- a/internal/workspace/url.go
+++ b/internal/workspace/url.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/url"
 	"path"
 	"strings"
@@ -138,6 +139,14 @@ func (c *URLWorkspaceContext) ReadFile(filePath string) (io.ReadCloser, error) {
 		return nil, err
 	}
 	return io.NopCloser(bytes.NewReader(content)), nil
+}
+
+func (c *URLWorkspaceContext) Stat(_ string) (fs.FileInfo, error) {
+	return nil, ErrRemoteUnsupported
+}
+
+func (c *URLWorkspaceContext) ReadDir(_ string) ([]fs.DirEntry, error) {
+	return nil, ErrRemoteUnsupported
 }
 
 func (c *URLWorkspaceContext) Glob(pattern string) ([]string, error) {

--- a/lsp/registry.go
+++ b/lsp/registry.go
@@ -323,7 +323,8 @@ func (r *Registry) loadWorkspacePackageManifests(workspace types.WorkspaceContex
 	helpers.SafeDebugLog("Found %d workspace packages", len(workspacePackages))
 
 	for _, pkgPath := range workspacePackages {
-		r.loadWorkspacePackage(pkgPath, workspace)
+		helpers.SafeDebugLog("Loading workspace package from: %s", pkgPath)
+		r.loadPackageManifest(pkgPath, workspace)
 	}
 
 	return nil
@@ -539,12 +540,6 @@ func (r *Registry) filterNegatedPackages(workspace types.WorkspaceContext, packa
 	return filtered
 }
 
-// loadWorkspacePackage loads a manifest from a single workspace package directory
-func (r *Registry) loadWorkspacePackage(pkgPath string, workspace types.WorkspaceContext) {
-	helpers.SafeDebugLog("Loading workspace package from: %s", pkgPath)
-	r.loadPackageManifest(pkgPath, workspace)
-}
-
 // loadNodeModulesManifests loads manifests from node_modules packages
 func (r *Registry) loadNodeModulesManifests(workspace types.WorkspaceContext) error {
 	nodeModulesPath := filepath.Join(workspace.Root(), "node_modules")
@@ -600,15 +595,8 @@ func (r *Registry) loadPackageManifest(packagePath string, workspace types.Works
 		return
 	}
 
-	// Check whether the manifest file exists to decide between generation and parse error
-	var exists bool
-	if workspace != nil {
-		_, statErr := workspace.Stat(manifestPath)
-		exists = statErr == nil
-	} else {
-		_, statErr := os.Stat(manifestPath)
-		exists = statErr == nil
-	}
+	_, statErr := workspace.Stat(manifestPath)
+	exists := statErr == nil
 
 	if !exists {
 		helpers.SafeDebugLog("Manifest file %s doesn't exist, generating in-memory for %s", manifestPath, packageJSON.Name)
@@ -726,23 +714,22 @@ func (r *Registry) loadAdditionalPackage(spec string) error {
 	return nil
 }
 
-// readPackageJSON reads and parses a package.json file.
-// When workspace is non-nil, reads through the workspace interface;
-// otherwise falls back to os.ReadFile for absolute paths (e.g. node_modules).
-func (r *Registry) readPackageJSON(path string, workspace types.WorkspaceContext) (*M.PackageJSON, error) {
-	var data []byte
-	var err error
-
+// readFileViaWorkspace reads a file through the workspace interface when available,
+// falling back to os.ReadFile for absolute paths (e.g. ReloadManifestsDirectly).
+func readFileViaWorkspace(path string, workspace types.WorkspaceContext) ([]byte, error) {
 	if workspace != nil {
-		rc, readErr := workspace.ReadFile(path)
-		if readErr != nil {
-			return nil, readErr
+		rc, err := workspace.ReadFile(path)
+		if err != nil {
+			return nil, err
 		}
 		defer func() { _ = rc.Close() }()
-		data, err = io.ReadAll(rc)
-	} else {
-		data, err = os.ReadFile(path)
+		return io.ReadAll(rc)
 	}
+	return os.ReadFile(path)
+}
+
+func (r *Registry) readPackageJSON(path string, workspace types.WorkspaceContext) (*M.PackageJSON, error) {
+	data, err := readFileViaWorkspace(path, workspace)
 	if err != nil {
 		return nil, err
 	}
@@ -759,22 +746,8 @@ func (r *Registry) readPackageJSON(path string, workspace types.WorkspaceContext
 	return &pkg, nil
 }
 
-// loadManifestFileWithPackageName loads a custom elements manifest from a file with package name.
-// When workspace is non-nil, reads through the workspace interface.
 func (r *Registry) loadManifestFileWithPackageName(path string, packageName string, workspace types.WorkspaceContext) (*M.Package, error) {
-	var data []byte
-	var err error
-
-	if workspace != nil {
-		rc, readErr := workspace.ReadFile(path)
-		if readErr != nil {
-			return nil, readErr
-		}
-		defer func() { _ = rc.Close() }()
-		data, err = io.ReadAll(rc)
-	} else {
-		data, err = os.ReadFile(path)
-	}
+	data, err := readFileViaWorkspace(path, workspace)
 	if err != nil {
 		return nil, err
 	}

--- a/lsp/registry.go
+++ b/lsp/registry.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -321,9 +322,8 @@ func (r *Registry) loadWorkspacePackageManifests(workspace types.WorkspaceContex
 
 	helpers.SafeDebugLog("Found %d workspace packages", len(workspacePackages))
 
-	// Load manifest from each workspace package
 	for _, pkgPath := range workspacePackages {
-		r.loadWorkspacePackage(pkgPath)
+		r.loadWorkspacePackage(pkgPath, workspace)
 	}
 
 	return nil
@@ -334,28 +334,22 @@ func (r *Registry) discoverWorkspacePackages(workspace types.WorkspaceContext) (
 	root := workspace.Root()
 	var workspacePatterns []string
 
-	// Detect package manager and get workspace patterns
-	// 1. Try pnpm (pnpm-workspace.yaml)
-	// pnpm uses a separate YAML file for workspace configuration instead of package.json
 	pnpmWorkspaceFile := filepath.Join(root, "pnpm-workspace.yaml")
-	if _, err := os.Stat(pnpmWorkspaceFile); err == nil {
-		patterns, err := r.parsePnpmWorkspace(pnpmWorkspaceFile)
+	if _, err := workspace.Stat(pnpmWorkspaceFile); err == nil {
+		patterns, err := r.parsePnpmWorkspace(pnpmWorkspaceFile, workspace)
 		if err == nil {
 			workspacePatterns = patterns
 			helpers.SafeDebugLog("Detected pnpm workspace with %d patterns", len(patterns))
 		}
 	}
 
-	// 2. Try npm/yarn (package.json workspaces field)
-	// Only check package.json if we haven't found patterns yet (pnpm takes precedence)
 	if len(workspacePatterns) == 0 {
 		packageJSONPath := filepath.Join(root, "package.json")
-		if _, err := os.Stat(packageJSONPath); err == nil {
-			patterns, err := r.parseNpmYarnWorkspaces(packageJSONPath)
+		if _, err := workspace.Stat(packageJSONPath); err == nil {
+			patterns, err := r.parseNpmYarnWorkspaces(packageJSONPath, workspace)
 			if err == nil && len(patterns) > 0 {
 				workspacePatterns = patterns
-				// Determine if npm or yarn based on lock file (for debug logging only)
-				if _, err := os.Stat(filepath.Join(root, "yarn.lock")); err == nil {
+				if _, err := workspace.Stat(filepath.Join(root, "yarn.lock")); err == nil {
 					helpers.SafeDebugLog("Detected yarn workspace with %d patterns", len(patterns))
 				} else {
 					helpers.SafeDebugLog("Detected npm workspace with %d patterns", len(patterns))
@@ -401,8 +395,14 @@ func (r *Registry) discoverWorkspacePackages(workspace types.WorkspaceContext) (
 }
 
 // parsePnpmWorkspace parses pnpm-workspace.yaml and returns workspace patterns
-func (r *Registry) parsePnpmWorkspace(path string) ([]string, error) {
-	data, err := os.ReadFile(path)
+func (r *Registry) parsePnpmWorkspace(path string, workspace types.WorkspaceContext) ([]string, error) {
+	rc, err := workspace.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read pnpm-workspace.yaml: %w", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	data, err := io.ReadAll(rc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read pnpm-workspace.yaml: %w", err)
 	}
@@ -419,8 +419,14 @@ func (r *Registry) parsePnpmWorkspace(path string) ([]string, error) {
 }
 
 // parseNpmYarnWorkspaces parses package.json workspaces field
-func (r *Registry) parseNpmYarnWorkspaces(path string) ([]string, error) {
-	data, err := os.ReadFile(path)
+func (r *Registry) parseNpmYarnWorkspaces(path string, workspace types.WorkspaceContext) ([]string, error) {
+	rc, err := workspace.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read package.json: %w", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	data, err := io.ReadAll(rc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read package.json: %w", err)
 	}
@@ -474,18 +480,16 @@ func (r *Registry) expandWorkspacePattern(workspace types.WorkspaceContext, patt
 
 	root := workspace.Root()
 
-	// Filter to only directories that contain package.json
 	var packageDirs []string
 	for _, relPath := range matches {
 		absPath := filepath.Join(root, relPath)
-		info, err := os.Stat(absPath)
+		info, err := workspace.Stat(absPath)
 		if err != nil || !info.IsDir() {
 			continue
 		}
 
-		// Check if this directory has a package.json
 		packageJSONPath := filepath.Join(absPath, "package.json")
-		if _, err := os.Stat(packageJSONPath); err == nil {
+		if _, err := workspace.Stat(packageJSONPath); err == nil {
 			packageDirs = append(packageDirs, absPath)
 		}
 	}
@@ -536,16 +540,15 @@ func (r *Registry) filterNegatedPackages(workspace types.WorkspaceContext, packa
 }
 
 // loadWorkspacePackage loads a manifest from a single workspace package directory
-func (r *Registry) loadWorkspacePackage(pkgPath string) {
+func (r *Registry) loadWorkspacePackage(pkgPath string, workspace types.WorkspaceContext) {
 	helpers.SafeDebugLog("Loading workspace package from: %s", pkgPath)
-	r.loadPackageManifest(pkgPath)
+	r.loadPackageManifest(pkgPath, workspace)
 }
 
 // loadNodeModulesManifests loads manifests from node_modules packages
 func (r *Registry) loadNodeModulesManifests(workspace types.WorkspaceContext) error {
-	// Look for node_modules directory
 	nodeModulesPath := filepath.Join(workspace.Root(), "node_modules")
-	entries, err := os.ReadDir(nodeModulesPath)
+	entries, err := workspace.ReadDir(nodeModulesPath)
 	if err != nil {
 		return fmt.Errorf("could not read node_modules: %w", err)
 	}
@@ -557,32 +560,30 @@ func (r *Registry) loadNodeModulesManifests(workspace types.WorkspaceContext) er
 
 		pkgPath := filepath.Join(nodeModulesPath, entry.Name())
 
-		// Handle scoped packages (@scope/package)
 		if strings.HasPrefix(entry.Name(), "@") {
-			scopedEntries, err := os.ReadDir(pkgPath)
+			scopedEntries, err := workspace.ReadDir(pkgPath)
 			if err != nil {
 				continue
 			}
 			for _, scopedEntry := range scopedEntries {
 				if scopedEntry.IsDir() {
 					scopedPkgPath := filepath.Join(pkgPath, scopedEntry.Name())
-					r.loadPackageManifest(scopedPkgPath)
+					r.loadPackageManifest(scopedPkgPath, workspace)
 				}
 			}
 		} else {
-			r.loadPackageManifest(pkgPath)
+			r.loadPackageManifest(pkgPath, workspace)
 		}
 	}
 
 	return nil
 }
 
-// loadPackageManifest loads a manifest from a specific package directory
-// If the manifest file doesn't exist, it generates it in-memory
-func (r *Registry) loadPackageManifest(packagePath string) {
-	// Read package.json to find customElements field
+// loadPackageManifest loads a manifest from a specific package directory.
+// When workspace is non-nil, reads through the workspace interface.
+func (r *Registry) loadPackageManifest(packagePath string, workspace types.WorkspaceContext) {
 	packageJSONPath := filepath.Join(packagePath, "package.json")
-	packageJSON, err := r.readPackageJSON(packageJSONPath)
+	packageJSON, err := r.readPackageJSON(packageJSONPath, workspace)
 	if err != nil {
 		return
 	}
@@ -591,21 +592,25 @@ func (r *Registry) loadPackageManifest(packagePath string) {
 		return
 	}
 
-	// Resolve the manifest path
 	manifestPath := filepath.Join(packagePath, packageJSON.CustomElements)
-	if !filepath.IsAbs(manifestPath) {
-		manifestPath = filepath.Join(packagePath, packageJSON.CustomElements)
-	}
 
-	// Try to load the manifest file
-	if pkg, err := r.loadManifestFileWithPackageName(manifestPath, packageJSON.Name); err == nil {
+	if pkg, err := r.loadManifestFileWithPackageName(manifestPath, packageJSON.Name, workspace); err == nil {
 		r.addManifest(pkg, packageJSON.Name)
 		helpers.SafeDebugLog("Loaded manifest from %s (%s)", packageJSON.Name, manifestPath)
 		return
 	}
 
-	// If manifest file doesn't exist, generate it in-memory
-	if _, statErr := os.Stat(manifestPath); os.IsNotExist(statErr) {
+	// Check whether the manifest file exists to decide between generation and parse error
+	var exists bool
+	if workspace != nil {
+		_, statErr := workspace.Stat(manifestPath)
+		exists = statErr == nil
+	} else {
+		_, statErr := os.Stat(manifestPath)
+		exists = statErr == nil
+	}
+
+	if !exists {
 		helpers.SafeDebugLog("Manifest file %s doesn't exist, generating in-memory for %s", manifestPath, packageJSON.Name)
 		if pkg := r.generateInMemoryManifest(packagePath, packageJSON.Name); pkg != nil {
 			r.addManifest(pkg, packageJSON.Name)
@@ -721,9 +726,23 @@ func (r *Registry) loadAdditionalPackage(spec string) error {
 	return nil
 }
 
-// readPackageJSON reads and parses a package.json file
-func (r *Registry) readPackageJSON(path string) (*M.PackageJSON, error) {
-	data, err := os.ReadFile(path)
+// readPackageJSON reads and parses a package.json file.
+// When workspace is non-nil, reads through the workspace interface;
+// otherwise falls back to os.ReadFile for absolute paths (e.g. node_modules).
+func (r *Registry) readPackageJSON(path string, workspace types.WorkspaceContext) (*M.PackageJSON, error) {
+	var data []byte
+	var err error
+
+	if workspace != nil {
+		rc, readErr := workspace.ReadFile(path)
+		if readErr != nil {
+			return nil, readErr
+		}
+		defer func() { _ = rc.Close() }()
+		data, err = io.ReadAll(rc)
+	} else {
+		data, err = os.ReadFile(path)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -733,7 +752,6 @@ func (r *Registry) readPackageJSON(path string) (*M.PackageJSON, error) {
 		return nil, err
 	}
 
-	// If this package.json references a custom elements manifest, track it for watching
 	if pkg.CustomElements != "" {
 		r.addManifestPath(path)
 	}
@@ -741,9 +759,22 @@ func (r *Registry) readPackageJSON(path string) (*M.PackageJSON, error) {
 	return &pkg, nil
 }
 
-// loadManifestFileWithPackageName loads a custom elements manifest from a file with package name
-func (r *Registry) loadManifestFileWithPackageName(path string, packageName string) (*M.Package, error) {
-	data, err := os.ReadFile(path)
+// loadManifestFileWithPackageName loads a custom elements manifest from a file with package name.
+// When workspace is non-nil, reads through the workspace interface.
+func (r *Registry) loadManifestFileWithPackageName(path string, packageName string, workspace types.WorkspaceContext) (*M.Package, error) {
+	var data []byte
+	var err error
+
+	if workspace != nil {
+		rc, readErr := workspace.ReadFile(path)
+		if readErr != nil {
+			return nil, readErr
+		}
+		defer func() { _ = rc.Close() }()
+		data, err = io.ReadAll(rc)
+	} else {
+		data, err = os.ReadFile(path)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -753,7 +784,6 @@ func (r *Registry) loadManifestFileWithPackageName(path string, packageName stri
 		return nil, err
 	}
 
-	// Track this file path for watching with package name
 	r.addManifestPathWithPackageName(path, packageName)
 
 	return &pkg, nil

--- a/lsp/registry.go
+++ b/lsp/registry.go
@@ -739,6 +739,11 @@ func (r *Registry) readPackageJSON(path string, workspace types.WorkspaceContext
 		return nil, err
 	}
 
+	// Track package.json for file watching so customElements field changes trigger reload.
+	// NOTE: ManifestPaths is also iterated by ReloadManifestsDirectly, which parses each
+	// entry as a CEM manifest. package.json entries fail to parse and are skipped (logged
+	// as warnings). Separating watch paths from manifest paths would fix this, but requires
+	// splitting ManifestPaths into two collections.
 	if pkg.CustomElements != "" {
 		r.addManifestPath(path)
 	}

--- a/lsp/registry_workspace_test.go
+++ b/lsp/registry_workspace_test.go
@@ -17,11 +17,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package lsp_test
 
 import (
-	"path/filepath"
 	"testing"
 
 	"bennypowers.dev/cem/lsp"
-	"bennypowers.dev/cem/internal/workspace"
+	testworkspace "bennypowers.dev/cem/internal/platform/testutil/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,10 +31,7 @@ import (
 
 // TestWorkspaceManifestLoading_npm tests that npm workspace packages are loaded into the registry
 func TestWorkspaceManifestLoading_npm(t *testing.T) {
-	fixturePath := filepath.Join("testdata", "integration", "workspace-npm")
-
-	// Create workspace context
-	wsCtx := workspace.NewFileSystemWorkspaceContext(fixturePath)
+	wsCtx := testworkspace.NewMapWorkspaceContext(t, "testdata/integration/workspace-npm")
 
 	// Create registry and load from workspace
 	registry, err := lsp.NewRegistryWithDefaults()
@@ -74,10 +70,7 @@ func TestWorkspaceManifestLoading_npm(t *testing.T) {
 
 // TestWorkspaceManifestLoading_yarn tests that yarn workspace packages are loaded into the registry
 func TestWorkspaceManifestLoading_yarn(t *testing.T) {
-	fixturePath := filepath.Join("testdata", "integration", "workspace-yarn")
-
-	// Create workspace context
-	wsCtx := workspace.NewFileSystemWorkspaceContext(fixturePath)
+	wsCtx := testworkspace.NewMapWorkspaceContext(t, "testdata/integration/workspace-yarn")
 
 	// Create registry and load from workspace
 	registry, err := lsp.NewRegistryWithDefaults()
@@ -112,10 +105,7 @@ func TestWorkspaceManifestLoading_yarn(t *testing.T) {
 
 // TestWorkspaceManifestLoading_pnpm tests that pnpm workspace packages are loaded into the registry
 func TestWorkspaceManifestLoading_pnpm(t *testing.T) {
-	fixturePath := filepath.Join("testdata", "integration", "workspace-pnpm")
-
-	// Create workspace context
-	wsCtx := workspace.NewFileSystemWorkspaceContext(fixturePath)
+	wsCtx := testworkspace.NewMapWorkspaceContext(t, "testdata/integration/workspace-pnpm")
 
 	// Create registry and load from workspace
 	registry, err := lsp.NewRegistryWithDefaults()

--- a/lsp/workspace_diagnostics_test.go
+++ b/lsp/workspace_diagnostics_test.go
@@ -17,15 +17,14 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package lsp_test
 
 import (
-	"os"
-	"path/filepath"
+	"io"
 	"strings"
 	"testing"
 
 	"bennypowers.dev/cem/lsp"
 	"bennypowers.dev/cem/lsp/document"
 	"bennypowers.dev/cem/lsp/methods/textDocument/publishDiagnostics"
-	"bennypowers.dev/cem/internal/workspace"
+	testworkspace "bennypowers.dev/cem/internal/platform/testutil/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -37,32 +36,27 @@ import (
 // TestWorkspaceDiagnostics_NoFalsePositives_npm tests that workspace sibling elements
 // do NOT produce "unknown element" diagnostics when properly imported
 func TestWorkspaceDiagnostics_NoFalsePositives_npm(t *testing.T) {
-	fixturePath, err := filepath.Abs(filepath.Join("testdata", "integration", "workspace-npm"))
-	require.NoError(t, err, "Failed to get absolute path")
+	wsCtx := testworkspace.NewMapWorkspaceContext(t, "testdata/integration/workspace-npm")
 
-	// Create workspace context
-	wsCtx := workspace.NewFileSystemWorkspaceContext(fixturePath)
-
-	// Create LSP server
 	server, err := lsp.NewServer(wsCtx, lsp.TransportStdio)
 	require.NoError(t, err, "Failed to create server")
 	defer func() {
 		_ = server.Close()
 	}()
 
-	// Initialize server (this loads manifests)
 	err = server.InitializeForTesting()
 	require.NoError(t, err, "Failed to initialize server")
 
-	// Create DocumentManager
 	dm, err := document.NewDocumentManager()
 	require.NoError(t, err, "Failed to create DocumentManager")
 	defer dm.Close()
 
-	// Read the test HTML file
-	htmlPath := filepath.Join(fixturePath, "packages", "component-b", "test.html")
-	content, err := os.ReadFile(htmlPath)
+	htmlRC, err := wsCtx.ReadFile("/packages/component-b/test.html")
 	require.NoError(t, err, "Failed to read test HTML file")
+	content, err := io.ReadAll(htmlRC)
+	_ = htmlRC.Close()
+	require.NoError(t, err)
+	htmlPath := "/packages/component-b/test.html"
 
 	// Open document
 	doc := dm.OpenDocument("file://"+htmlPath, string(content), 1)
@@ -92,32 +86,27 @@ func TestWorkspaceDiagnostics_NoFalsePositives_npm(t *testing.T) {
 
 // TestWorkspaceDiagnostics_NoFalsePositives_yarn tests yarn workspace sibling elements
 func TestWorkspaceDiagnostics_NoFalsePositives_yarn(t *testing.T) {
-	fixturePath, err := filepath.Abs(filepath.Join("testdata", "integration", "workspace-yarn"))
-	require.NoError(t, err, "Failed to get absolute path")
+	wsCtx := testworkspace.NewMapWorkspaceContext(t, "testdata/integration/workspace-yarn")
 
-	// Create workspace context
-	wsCtx := workspace.NewFileSystemWorkspaceContext(fixturePath)
-
-	// Create LSP server
 	server, err := lsp.NewServer(wsCtx, lsp.TransportStdio)
 	require.NoError(t, err, "Failed to create server")
 	defer func() {
 		_ = server.Close()
 	}()
 
-	// Initialize server
 	err = server.InitializeForTesting()
 	require.NoError(t, err, "Failed to initialize server")
 
-	// Create DocumentManager
 	dm, err := document.NewDocumentManager()
 	require.NoError(t, err, "Failed to create DocumentManager")
 	defer dm.Close()
 
-	// Read the test HTML file
-	htmlPath := filepath.Join(fixturePath, "packages", "component-b", "test.html")
-	content, err := os.ReadFile(htmlPath)
+	htmlRC, err := wsCtx.ReadFile("/packages/component-b/test.html")
 	require.NoError(t, err, "Failed to read test HTML file")
+	content, err := io.ReadAll(htmlRC)
+	_ = htmlRC.Close()
+	require.NoError(t, err)
+	htmlPath := "/packages/component-b/test.html"
 
 	// Open document
 	doc := dm.OpenDocument("file://"+htmlPath, string(content), 1)
@@ -146,32 +135,27 @@ func TestWorkspaceDiagnostics_NoFalsePositives_yarn(t *testing.T) {
 
 // TestWorkspaceDiagnostics_NoFalsePositives_pnpm tests pnpm workspace sibling elements
 func TestWorkspaceDiagnostics_NoFalsePositives_pnpm(t *testing.T) {
-	fixturePath, err := filepath.Abs(filepath.Join("testdata", "integration", "workspace-pnpm"))
-	require.NoError(t, err, "Failed to get absolute path")
+	wsCtx := testworkspace.NewMapWorkspaceContext(t, "testdata/integration/workspace-pnpm")
 
-	// Create workspace context
-	wsCtx := workspace.NewFileSystemWorkspaceContext(fixturePath)
-
-	// Create LSP server
 	server, err := lsp.NewServer(wsCtx, lsp.TransportStdio)
 	require.NoError(t, err, "Failed to create server")
 	defer func() {
 		_ = server.Close()
 	}()
 
-	// Initialize server
 	err = server.InitializeForTesting()
 	require.NoError(t, err, "Failed to initialize server")
 
-	// Create DocumentManager
 	dm, err := document.NewDocumentManager()
 	require.NoError(t, err, "Failed to create DocumentManager")
 	defer dm.Close()
 
-	// Read the test HTML file
-	htmlPath := filepath.Join(fixturePath, "packages", "component-b", "test.html")
-	content, err := os.ReadFile(htmlPath)
+	htmlRC, err := wsCtx.ReadFile("/packages/component-b/test.html")
 	require.NoError(t, err, "Failed to read test HTML file")
+	content, err := io.ReadAll(htmlRC)
+	_ = htmlRC.Close()
+	require.NoError(t, err)
+	htmlPath := "/packages/component-b/test.html"
 
 	// Open document
 	doc := dm.OpenDocument("file://"+htmlPath, string(content), 1)

--- a/lsp/workspace_patterns_test.go
+++ b/lsp/workspace_patterns_test.go
@@ -17,11 +17,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package lsp_test
 
 import (
-	"path/filepath"
 	"testing"
 
 	"bennypowers.dev/cem/lsp"
-	"bennypowers.dev/cem/internal/workspace"
+	testworkspace "bennypowers.dev/cem/internal/platform/testutil/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,10 +32,7 @@ import (
 // TestWorkspacePatterns_NestedDoublestar tests that "**" doublestar patterns
 // find deeply nested workspace packages
 func TestWorkspacePatterns_NestedDoublestar(t *testing.T) {
-	fixturePath := filepath.Join("testdata", "integration", "workspace-nested")
-
-	// Create workspace context
-	wsCtx := workspace.NewFileSystemWorkspaceContext(fixturePath)
+	wsCtx := testworkspace.NewMapWorkspaceContext(t, "testdata/integration/workspace-nested")
 
 	// Create registry and load from workspace
 	registry, err := lsp.NewRegistryWithDefaults()
@@ -86,10 +82,7 @@ func TestWorkspacePatterns_NestedDoublestar(t *testing.T) {
 // TestWorkspacePatterns_Negation tests that "!" negation patterns
 // exclude matching packages from being loaded
 func TestWorkspacePatterns_Negation(t *testing.T) {
-	fixturePath := filepath.Join("testdata", "integration", "workspace-negation")
-
-	// Create workspace context
-	wsCtx := workspace.NewFileSystemWorkspaceContext(fixturePath)
+	wsCtx := testworkspace.NewMapWorkspaceContext(t, "testdata/integration/workspace-negation")
 
 	// Create registry and load from workspace
 	registry, err := lsp.NewRegistryWithDefaults()
@@ -134,9 +127,7 @@ func TestWorkspacePatterns_Negation(t *testing.T) {
 func TestWorkspacePatterns_EdgeCases(t *testing.T) {
 	t.Run("empty workspace patterns", func(t *testing.T) {
 		// Create a temporary fixture without workspaces
-		fixturePath := filepath.Join("testdata", "integration", "workspace-npm")
-
-		wsCtx := workspace.NewFileSystemWorkspaceContext(fixturePath)
+		wsCtx := testworkspace.NewMapWorkspaceContext(t, "testdata/integration/workspace-npm")
 		registry, err := lsp.NewRegistryWithDefaults()
 		require.NoError(t, err, "Failed to create registry")
 

--- a/mcp/context_race_test.go
+++ b/mcp/context_race_test.go
@@ -22,11 +22,11 @@ import (
 	"testing"
 	"time"
 
-	W "bennypowers.dev/cem/internal/workspace"
+	testworkspace "bennypowers.dev/cem/internal/platform/testutil/workspace"
 )
 
 func TestMCPContext_ConcurrentCacheAccess(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("./testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	if err != nil {
 		t.Fatalf("Failed to initialize workspace: %v", err)
@@ -85,7 +85,7 @@ func TestMCPContext_ConcurrentCacheAccess(t *testing.T) {
 }
 
 func TestMCPContext_ConcurrentLoadManifestsAndCacheAccess(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("./testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	if err != nil {
 		t.Fatalf("Failed to initialize workspace: %v", err)
@@ -161,7 +161,7 @@ func TestMCPContext_ConcurrentLoadManifestsAndCacheAccess(t *testing.T) {
 }
 
 func TestMCPContext_SnapshotConsistency(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("./testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	if err != nil {
 		t.Fatalf("Failed to initialize workspace: %v", err)
@@ -209,7 +209,7 @@ func TestMCPContext_SnapshotConsistency(t *testing.T) {
 }
 
 func TestMCPContext_CacheInvalidationRace(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("./testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	if err != nil {
 		t.Fatalf("Failed to initialize workspace: %v", err)

--- a/mcp/context_test.go
+++ b/mcp/context_test.go
@@ -20,16 +20,16 @@ import (
 	"strings"
 	"testing"
 
+	testworkspace "bennypowers.dev/cem/internal/platform/testutil/workspace"
 	"bennypowers.dev/cem/manifest"
 	"bennypowers.dev/cem/mcp"
 	"bennypowers.dev/cem/mcp/types"
-	W "bennypowers.dev/cem/internal/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMCPContext_NewRegistry(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("./testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/multiple-elements-integration")
 
 	registry, err := mcp.NewMCPContext(workspace)
 	require.NoError(t, err, "Failed to create registry")
@@ -37,7 +37,7 @@ func TestMCPContext_NewRegistry(t *testing.T) {
 }
 
 func TestMCPContext_LoadManifests(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("./testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 
@@ -49,7 +49,7 @@ func TestMCPContext_LoadManifests(t *testing.T) {
 }
 
 func TestMCPContext_GetElementInfo(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("./testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 
@@ -208,7 +208,7 @@ func TestMCPContext_GetElementInfo(t *testing.T) {
 }
 
 func TestMCPContext_GetAllElements(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("./testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 
@@ -235,7 +235,7 @@ func TestMCPContext_GetAllElements(t *testing.T) {
 }
 
 func TestMCPContext_GetManifestSchema(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("./testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 
@@ -295,7 +295,7 @@ func TestMCPContext_GetManifestSchema(t *testing.T) {
 // Table-driven tests for detailed data conversion testing
 
 func TestMCPContext_AttributeConversion(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("./testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 
@@ -384,7 +384,7 @@ func TestMCPContext_AttributeConversion(t *testing.T) {
 }
 
 func TestMCPContext_SlotConversion(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("./testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 
@@ -453,7 +453,7 @@ func TestMCPContext_SlotConversion(t *testing.T) {
 }
 
 func TestMCPContext_CssPropertyConversion(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("./testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 
@@ -523,7 +523,7 @@ func TestMCPContext_CssPropertyConversion(t *testing.T) {
 }
 
 func TestMCPContext_CssPartConversion(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("./testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 

--- a/mcp/integration_test.go
+++ b/mcp/integration_test.go
@@ -23,18 +23,17 @@ import (
 	"strings"
 	"testing"
 
+	"bennypowers.dev/cem/internal/platform/testutil"
+	testworkspace "bennypowers.dev/cem/internal/platform/testutil/workspace"
 	"bennypowers.dev/cem/mcp"
 	"bennypowers.dev/cem/mcp/resources"
-	"bennypowers.dev/cem/internal/platform/testutil"
-	W "bennypowers.dev/cem/internal/workspace"
 	mcpSDK "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// getTestRegistry creates a registry using the test fixtures following the existing pattern
 func getTestRegistry(t *testing.T) *mcp.MCPContext {
-	workspace := W.NewFileSystemWorkspaceContext("./testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 

--- a/mcp/malicious_manifest_test.go
+++ b/mcp/malicious_manifest_test.go
@@ -20,11 +20,11 @@ import (
 	"strings"
 	"testing"
 
+	testworkspace "bennypowers.dev/cem/internal/platform/testutil/workspace"
 	"bennypowers.dev/cem/mcp"
 	"bennypowers.dev/cem/mcp/security"
 	"bennypowers.dev/cem/mcp/templates"
 	"bennypowers.dev/cem/mcp/tools"
-	"bennypowers.dev/cem/internal/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,7 +33,7 @@ import (
 
 func TestMaliciousManifestMitigation(t *testing.T) {
 	// Use the malicious manifest fixture
-	wctx := workspace.NewFileSystemWorkspaceContext("testdata/fixtures/malicious-manifest-security")
+	wctx := testworkspace.NewMapWorkspaceContext(t, "testdata/fixtures/malicious-manifest-security")
 	require.NoError(t, wctx.Init())
 
 	registry, err := mcp.NewMCPContext(wctx)
@@ -135,7 +135,7 @@ func TestTemplateRenderingWithMaliciousData(t *testing.T) {
 	// by using the malicious manifest fixture
 
 	// Use the malicious manifest fixture
-	wctx := workspace.NewFileSystemWorkspaceContext("testdata/fixtures/malicious-manifest-security")
+	wctx := testworkspace.NewMapWorkspaceContext(t, "testdata/fixtures/malicious-manifest-security")
 	require.NoError(t, wctx.Init())
 
 	registry, err := mcp.NewMCPContext(wctx)

--- a/mcp/resources/embed_test.go
+++ b/mcp/resources/embed_test.go
@@ -19,9 +19,9 @@ package resources_test
 import (
 	"testing"
 
+	testworkspace "bennypowers.dev/cem/internal/platform/testutil/workspace"
 	"bennypowers.dev/cem/mcp"
 	"bennypowers.dev/cem/mcp/resources"
-	W "bennypowers.dev/cem/internal/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,7 +34,7 @@ import (
 // find .md files on disk, which failed for distributed binaries.
 // See: https://github.com/anthropics/cem/issues/XXX
 func TestResourceDefinitions_Embedded(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("../testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "../testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 

--- a/mcp/resources/resources_test.go
+++ b/mcp/resources/resources_test.go
@@ -24,20 +24,19 @@ import (
 	"strings"
 	"testing"
 
+	"bennypowers.dev/cem/internal/platform/testutil"
+	testworkspace "bennypowers.dev/cem/internal/platform/testutil/workspace"
 	"bennypowers.dev/cem/mcp"
 	"bennypowers.dev/cem/mcp/resources"
 	"bennypowers.dev/cem/mcp/types"
-	"bennypowers.dev/cem/internal/platform/testutil"
 	V "bennypowers.dev/cem/validate"
-	W "bennypowers.dev/cem/internal/workspace"
 	mcpSDK "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// getTestRegistry creates a registry using the test fixtures following the existing pattern
 func getTestRegistry(t *testing.T) *mcp.MCPContext {
-	workspace := W.NewFileSystemWorkspaceContext("../testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "../testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -20,10 +20,10 @@ import (
 	"context"
 	"testing"
 
+	testworkspace "bennypowers.dev/cem/internal/platform/testutil/workspace"
 	"bennypowers.dev/cem/internal/version"
 	"bennypowers.dev/cem/mcp/resources"
 	"bennypowers.dev/cem/mcp/types"
-	W "bennypowers.dev/cem/internal/workspace"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,7 +32,7 @@ import (
 // Inline: integration test, scalar assertions
 
 func TestNewServer(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("./testdata/fixtures/basic-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/basic-integration")
 
 	server, err := NewServer(workspace)
 	require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestNewServer(t *testing.T) {
 }
 
 func TestServer_GetInfo(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("./testdata/fixtures/basic-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/basic-integration")
 	server, err := NewServer(workspace)
 	require.NoError(t, err)
 
@@ -56,7 +56,7 @@ func TestServer_GetInfo(t *testing.T) {
 }
 
 func TestServer_VersionConsistency(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("./testdata/fixtures/basic-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/basic-integration")
 	server, err := NewServer(workspace)
 	require.NoError(t, err)
 
@@ -67,7 +67,7 @@ func TestServer_VersionConsistency(t *testing.T) {
 }
 
 func TestDynamicSchemaVersionDetection(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("./testdata/fixtures/basic-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/basic-integration")
 
 	// Initialize workspace
 	err := workspace.Init()

--- a/mcp/stdout_test.go
+++ b/mcp/stdout_test.go
@@ -26,8 +26,8 @@ import (
 	"time"
 
 	"bennypowers.dev/cem/internal/logging"
+	testworkspace "bennypowers.dev/cem/internal/platform/testutil/workspace"
 	"bennypowers.dev/cem/mcp"
-	W "bennypowers.dev/cem/internal/workspace"
 	"github.com/pterm/pterm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -126,7 +126,7 @@ func TestMCPServerStdoutCleanWithQuietMode(t *testing.T) {
 	}()
 
 	// Create workspace and MCP server
-	workspace := W.NewFileSystemWorkspaceContext("./testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/multiple-elements-integration")
 	err = workspace.Init()
 	require.NoError(t, err)
 
@@ -184,7 +184,7 @@ func TestMCPServerStderrAllowed(t *testing.T) {
 	}()
 
 	// Create workspace with basic integration
-	workspace := W.NewFileSystemWorkspaceContext("./testdata/fixtures/basic-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/basic-integration")
 	err = workspace.Init()
 	require.NoError(t, err)
 

--- a/mcp/tools/embed_test.go
+++ b/mcp/tools/embed_test.go
@@ -19,9 +19,9 @@ package tools_test
 import (
 	"testing"
 
+	testworkspace "bennypowers.dev/cem/internal/platform/testutil/workspace"
 	"bennypowers.dev/cem/mcp"
 	"bennypowers.dev/cem/mcp/tools"
-	W "bennypowers.dev/cem/internal/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,7 +34,7 @@ import (
 // find .md files on disk, which failed for distributed binaries.
 // See: https://github.com/anthropics/cem/issues/XXX
 func TestToolDefinitions_Embedded(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("../testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "../testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 

--- a/mcp/tools/tools_test.go
+++ b/mcp/tools/tools_test.go
@@ -22,19 +22,18 @@ import (
 	"path/filepath"
 	"testing"
 
+	"bennypowers.dev/cem/internal/platform/testutil"
+	testworkspace "bennypowers.dev/cem/internal/platform/testutil/workspace"
 	"bennypowers.dev/cem/mcp"
 	"bennypowers.dev/cem/mcp/templates"
 	"bennypowers.dev/cem/mcp/tools"
-	"bennypowers.dev/cem/internal/platform/testutil"
-	W "bennypowers.dev/cem/internal/workspace"
 	mcpSDK "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// getTestRegistry creates a registry using the test fixtures following the existing pattern
 func getTestRegistry(t *testing.T) *mcp.MCPContextAdapter {
-	workspace := W.NewFileSystemWorkspaceContext("../testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "../testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 

--- a/mcp/tools/validate_html_test.go
+++ b/mcp/tools/validate_html_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	"bennypowers.dev/cem/internal/platform/testutil"
-	W "bennypowers.dev/cem/internal/workspace"
+	testworkspace "bennypowers.dev/cem/internal/platform/testutil/workspace"
 	"bennypowers.dev/cem/mcp"
 	"bennypowers.dev/cem/mcp/tools"
 	mcpSDK "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -150,7 +150,7 @@ func TestValidateHtmlArgs_Parsing(t *testing.T) {
 }
 
 func TestValidationTemplateData_WithFixtures(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("../testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "../testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 
@@ -183,7 +183,7 @@ func TestValidationTemplateData_WithFixtures(t *testing.T) {
 }
 
 func TestValidateHtml_UnknownAttributeDetection(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("../testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "../testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 
@@ -238,7 +238,7 @@ func TestValidateHtml_UnknownAttributeDetection(t *testing.T) {
 }
 
 func TestValidateHtml_ValidAttributes(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("../testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "../testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 
@@ -280,7 +280,7 @@ func TestValidateHtml_ValidAttributes(t *testing.T) {
 }
 
 func TestValidateHtml_InvalidAttributeValue(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("../testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "../testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 
@@ -326,7 +326,7 @@ func TestValidateHtml_InvalidAttributeValue(t *testing.T) {
 func TestValidateHtml_AttributeValueParsing_Regression(t *testing.T) {
 	// Regression test for attribute value parsing bug where boolean attributes
 	// cause misaligned indices between attr.name and attr.value arrays
-	workspace := W.NewFileSystemWorkspaceContext("../testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "../testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 
@@ -386,7 +386,7 @@ func TestValidateHtml_AttributeValueParsing_Regression(t *testing.T) {
 }
 
 func TestValidateHtml_UnknownElement(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("../testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "../testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 
@@ -428,7 +428,7 @@ func TestValidateHtml_UnknownElement(t *testing.T) {
 }
 
 func TestValidateHtml_MultipleIssues(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("../testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "../testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 
@@ -473,7 +473,7 @@ func TestValidateHtml_MultipleIssues(t *testing.T) {
 }
 
 func TestValidateHtml_GlobalAttributesAllowed(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("../testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "../testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 
@@ -551,7 +551,7 @@ func TestValidateHtml_GlobalAttributesAllowed(t *testing.T) {
 }
 
 func TestValidateHtml_GlobalAttributesWithUnknownCustomAttribute(t *testing.T) {
-	workspace := W.NewFileSystemWorkspaceContext("../testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "../testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 
@@ -606,7 +606,7 @@ func TestValidateHtml_GlobalAttributesWithUnknownCustomAttribute(t *testing.T) {
 func testValidateHtmlWithGolden(t *testing.T, fixtureFile, contextStr, goldenFile string) {
 	t.Helper()
 
-	workspace := W.NewFileSystemWorkspaceContext("../testdata/fixtures/multiple-elements-integration")
+	workspace := testworkspace.NewMapWorkspaceContext(t, "../testdata/fixtures/multiple-elements-integration")
 	err := workspace.Init()
 	require.NoError(t, err)
 

--- a/types/workspace.go
+++ b/types/workspace.go
@@ -19,6 +19,7 @@ package types
 
 import (
 	"io"
+	"io/fs"
 
 	C "bennypowers.dev/cem/cmd/config"
 	M "bennypowers.dev/cem/manifest"
@@ -40,6 +41,10 @@ type WorkspaceContext interface {
 	CustomElementsManifestPath() string
 	// ReadFile returns an io.ReadCloser for a file within the package.
 	ReadFile(path string) (io.ReadCloser, error)
+	// Stat returns file info for the given path.
+	Stat(path string) (fs.FileInfo, error)
+	// ReadDir returns directory entries for the given path.
+	ReadDir(path string) ([]fs.DirEntry, error)
 	// Glob returns a list of file paths matching the given pattern (e.g., *.ts).
 	Glob(pattern string) ([]string, error)
 	// Writes outputs to paths


### PR DESCRIPTION
## Summary

- Add `Stat(path) (fs.FileInfo, error)` and `ReadDir(path) ([]fs.DirEntry, error)` to `WorkspaceContext` interface
- Refactor `lsp.Registry` to route file operations through workspace abstraction instead of raw `os.*` calls (13 call sites across 8 functions)
- Create `MapWorkspaceContext` (`testutil/workspace` package) backed by `platform.MapFileSystem` for zero-disk-IO test workspaces
- Convert 14 MCP and LSP test files from `FileSystemWorkspaceContext` to `MapWorkspaceContext`
- Extract `readFileViaWorkspace` helper to centralize workspace/os.ReadFile branching

Follows #334 (Phase 1: MapFS for fixture/golden reads). This is Phase 2 of the MapFS test infrastructure work.

## Test plan

- [ ] `make test` passes (3945 tests, 0 failures)
- [ ] `make lint` passes (0 issues)
- [ ] Workspace manifest loading tests (npm, yarn, pnpm) pass with MapFS
- [ ] Workspace pattern tests (doublestar, negation) pass with MapFS
- [ ] Workspace diagnostics tests pass with MapFS
- [ ] New Stat/ReadDir tests cover existing file, missing file, directory, root, subdirectory cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Substantially improved testing infrastructure with new in-memory workspace utilities, strengthening test coverage for workspace detection, manifest loading, and integration scenarios across LSP and MCP components.

* **Chores**
  * Extended workspace context interfaces with filesystem inspection capabilities, improving consistency and maintainability across different workspace types while enhancing code abstraction layers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bennypowers/cem/pull/335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->