### PR TITLE
fix(lsp): split ManifestPaths into WatchPaths + ManifestPaths

### DIFF
--- a/lsp/registry.go
+++ b/lsp/registry.go
@@ -1106,14 +1106,12 @@ func (r *Registry) handleFileChange(event platform.FileWatchEvent) {
 		return
 	}
 
-	// Check if this is a manifest file we care about
-	isManifestFile := slices.Contains(r.WatchPaths, event.Name)
-
-	if !isManifestFile {
+	isWatchedPath := slices.Contains(r.WatchPaths, event.Name)
+	if !isWatchedPath {
 		return
 	}
 
-	helpers.SafeDebugLog("Manifest file changed: %s", event.Name)
+	helpers.SafeDebugLog("Watched file changed: %s", event.Name)
 
 	// Trigger reload callback if available (with proper synchronization)
 	r.watcherMu.RLock()

--- a/lsp/registry.go
+++ b/lsp/registry.go
@@ -102,8 +102,10 @@ type Registry struct {
 	attributes map[string]map[string]*M.Attribute
 	// Manifests stores all loaded manifest packages
 	Manifests []*M.Package
-	// ManifestPaths tracks the file paths of loaded manifests for file watching
+	// ManifestPaths tracks the file paths of loaded CEM manifests for reload
 	ManifestPaths []string
+	// WatchPaths tracks all file paths watched for changes (manifests + package.json)
+	WatchPaths []string
 	// ManifestPackageNames tracks the package name for each manifest path
 	ManifestPackageNames map[string]string
 	// File watching
@@ -139,6 +141,7 @@ func NewRegistry(fileWatcher platform.FileWatcher) *Registry {
 		attributes:           make(map[string]map[string]*M.Attribute),
 		Manifests:            make([]*M.Package, 0),
 		ManifestPaths:        make([]string, 0),
+		WatchPaths:           make([]string, 0),
 		ManifestPackageNames: make(map[string]string),
 		fileWatcher:          fileWatcher,
 		moduleGraph:          moduleGraph,
@@ -200,6 +203,7 @@ func (r *Registry) clear() {
 	r.attributes = make(map[string]map[string]*M.Attribute)
 	r.Manifests = r.Manifests[:0]
 	r.ManifestPaths = r.ManifestPaths[:0]
+	r.WatchPaths = r.WatchPaths[:0]
 	r.ManifestPackageNames = make(map[string]string)
 	// Get QueryManager for dependency injection
 	queryManager, err := treesitter.GetGlobalQueryManager()
@@ -739,13 +743,8 @@ func (r *Registry) readPackageJSON(path string, workspace types.WorkspaceContext
 		return nil, err
 	}
 
-	// Track package.json for file watching so customElements field changes trigger reload.
-	// NOTE: ManifestPaths is also iterated by ReloadManifestsDirectly, which parses each
-	// entry as a CEM manifest. package.json entries fail to parse and are skipped (logged
-	// as warnings). Separating watch paths from manifest paths would fix this, but requires
-	// splitting ManifestPaths into two collections.
 	if pkg.CustomElements != "" {
-		r.addManifestPath(path)
+		r.addWatchPath(path)
 	}
 
 	return &pkg, nil
@@ -1011,8 +1010,7 @@ func (r *Registry) StartFileWatching(onReload func()) error {
 	// PROTECTED BY LOCK: Channel initialization is thread-safe with StopFileWatching
 	r.watcherDone = make(chan struct{})
 
-	// Add all known manifest paths to the watcher
-	for _, path := range r.ManifestPaths {
+	for _, path := range r.WatchPaths {
 		if err := r.fileWatcher.Add(path); err != nil {
 			helpers.SafeDebugLog("Warning: Could not watch manifest file %s: %v", path, err)
 		} else {
@@ -1109,7 +1107,7 @@ func (r *Registry) handleFileChange(event platform.FileWatchEvent) {
 	}
 
 	// Check if this is a manifest file we care about
-	isManifestFile := slices.Contains(r.ManifestPaths, event.Name)
+	isManifestFile := slices.Contains(r.WatchPaths, event.Name)
 
 	if !isManifestFile {
 		return
@@ -1285,18 +1283,40 @@ func (r *Registry) StopGenerateWatcher() error {
 	return nil
 }
 
-// addManifestPathWithPackageName tracks a manifest file path with its package name for watching
+// addWatchPath tracks a file path for watching without adding it to ManifestPaths.
+// Used for package.json files that should trigger reload but aren't CEM manifests.
+func (r *Registry) addWatchPath(path string) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		helpers.SafeDebugLog("Warning: Could not resolve watch path %s: %v", path, err)
+		return
+	}
+
+	if slices.Contains(r.WatchPaths, absPath) {
+		return
+	}
+
+	r.WatchPaths = append(r.WatchPaths, absPath)
+	helpers.SafeDebugLog("Watching file: %s", absPath)
+
+	r.watcherMu.RLock()
+	if r.fileWatcher != nil {
+		if err := r.fileWatcher.Add(absPath); err != nil {
+			helpers.SafeDebugLog("Warning: Could not watch file %s: %v", absPath, err)
+		}
+	}
+	r.watcherMu.RUnlock()
+}
+
+// addManifestPathWithPackageName tracks a CEM manifest path with its package name.
 func (r *Registry) addManifestPathWithPackageName(path string, packageName string) {
-	// Resolve to absolute path
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		helpers.SafeDebugLog("Warning: Could not resolve manifest path %s: %v", path, err)
 		return
 	}
 
-	// Check if already tracked
 	if slices.Contains(r.ManifestPaths, absPath) {
-		// Update package name if already exists
 		r.ManifestPackageNames[absPath] = packageName
 		return
 	}
@@ -1305,28 +1325,17 @@ func (r *Registry) addManifestPathWithPackageName(path string, packageName strin
 	r.ManifestPackageNames[absPath] = packageName
 	helpers.SafeDebugLog("Tracking manifest file: %s with package: %s", absPath, packageName)
 
-	// If watcher is active, add this path
-	r.watcherMu.RLock()
-	if r.fileWatcher != nil {
-		if err := r.fileWatcher.Add(absPath); err != nil {
-			helpers.SafeDebugLog("Warning: Could not watch manifest file %s: %v", absPath, err)
-		} else {
-			helpers.SafeDebugLog("Now watching manifest file: %s", absPath)
-		}
-	}
-	r.watcherMu.RUnlock()
+	r.addWatchPath(path)
 }
 
-// addManifestPath tracks a manifest file path for watching
+// addManifestPath tracks a CEM manifest path for reload and watching.
 func (r *Registry) addManifestPath(path string) {
-	// Resolve to absolute path
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		helpers.SafeDebugLog("Warning: Could not resolve manifest path %s: %v", path, err)
 		return
 	}
 
-	// Check if already tracked
 	if slices.Contains(r.ManifestPaths, absPath) {
 		return
 	}
@@ -1334,16 +1343,7 @@ func (r *Registry) addManifestPath(path string) {
 	r.ManifestPaths = append(r.ManifestPaths, absPath)
 	helpers.SafeDebugLog("Tracking manifest file: %s", absPath)
 
-	// If watcher is active, add this path
-	r.watcherMu.RLock()
-	if r.fileWatcher != nil {
-		if err := r.fileWatcher.Add(absPath); err != nil {
-			helpers.SafeDebugLog("Warning: Could not watch manifest file %s: %v", absPath, err)
-		} else {
-			helpers.SafeDebugLog("Now watching manifest file: %s", absPath)
-		}
-	}
-	r.watcherMu.RUnlock()
+	r.addWatchPath(path)
 }
 
 // GetModuleGraph returns the module graph for re-export analysis

--- a/lsp/registry.go
+++ b/lsp/registry.go
@@ -1325,7 +1325,7 @@ func (r *Registry) addManifestPathWithPackageName(path string, packageName strin
 	r.ManifestPackageNames[absPath] = packageName
 	helpers.SafeDebugLog("Tracking manifest file: %s with package: %s", absPath, packageName)
 
-	r.addWatchPath(path)
+	r.addWatchPath(absPath)
 }
 
 // addManifestPath tracks a CEM manifest path for reload and watching.
@@ -1343,7 +1343,7 @@ func (r *Registry) addManifestPath(path string) {
 	r.ManifestPaths = append(r.ManifestPaths, absPath)
 	helpers.SafeDebugLog("Tracking manifest file: %s", absPath)
 
-	r.addWatchPath(path)
+	r.addWatchPath(absPath)
 }
 
 // GetModuleGraph returns the module graph for re-export analysis

--- a/lsp/server_integration_file_watch_test.go
+++ b/lsp/server_integration_file_watch_test.go
@@ -288,16 +288,16 @@ func TestPackageJSONWatching(t *testing.T) {
 			t.Fatalf("Failed to load from workspace: %v", err)
 		}
 
-		// Verify package.json is tracked for watching
+		// Verify package.json is tracked in WatchPaths (not ManifestPaths)
 		found := false
-		for _, path := range registry.ManifestPaths {
+		for _, path := range registry.WatchPaths {
 			if filepath.Base(path) == "package.json" {
 				found = true
 				break
 			}
 		}
 		if !found {
-			t.Error("Expected package.json to be tracked for watching")
+			t.Error("Expected package.json to be tracked in WatchPaths")
 		}
 	})
 
@@ -372,6 +372,81 @@ func TestPackageJSONWatching(t *testing.T) {
 			t.Fatal("package.json change should have triggered reload")
 		}
 	})
+}
+
+func TestManifestPaths_NoPackageJSON(t *testing.T) {
+	// Inline: regression test for #336 — ManifestPaths must not contain package.json
+	tempDir := t.TempDir()
+
+	// Create node_modules/test-pkg with package.json pointing to custom-elements.json
+	pkgDir := filepath.Join(tempDir, "node_modules", "test-pkg")
+	err := os.MkdirAll(pkgDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create node_modules: %v", err)
+	}
+
+	packageJSON := map[string]string{
+		"name":           "test-pkg",
+		"version":        "1.0.0",
+		"customElements": "custom-elements.json",
+	}
+	packageData, _ := json.MarshalIndent(packageJSON, "", "  ")
+	err = os.WriteFile(filepath.Join(pkgDir, "package.json"), packageData, 0644)
+	if err != nil {
+		t.Fatalf("Failed to write package.json: %v", err)
+	}
+
+	manifest := map[string]any{
+		"schemaVersion": "2.1.0",
+		"modules":       []any{},
+	}
+	manifestData, _ := json.MarshalIndent(manifest, "", "  ")
+	err = os.WriteFile(filepath.Join(pkgDir, "custom-elements.json"), manifestData, 0644)
+	if err != nil {
+		t.Fatalf("Failed to write manifest: %v", err)
+	}
+
+	// Root package.json (no customElements — just a container)
+	rootPkg := map[string]string{"name": "root", "version": "1.0.0"}
+	rootData, _ := json.MarshalIndent(rootPkg, "", "  ")
+	err = os.WriteFile(filepath.Join(tempDir, "package.json"), rootData, 0644)
+	if err != nil {
+		t.Fatalf("Failed to write root package.json: %v", err)
+	}
+
+	registry, err := lsp.NewRegistryWithDefaults()
+	if err != nil {
+		t.Fatalf("Failed to create registry: %v", err)
+	}
+
+	workspace := W.NewFileSystemWorkspaceContext(tempDir)
+	err = workspace.Init()
+	if err != nil {
+		t.Fatalf("Failed to init workspace: %v", err)
+	}
+
+	err = registry.LoadFromWorkspace(workspace)
+	if err != nil {
+		t.Fatalf("Failed to load from workspace: %v", err)
+	}
+
+	for _, path := range registry.ManifestPaths {
+		if filepath.Base(path) == "package.json" {
+			t.Errorf("ManifestPaths should not contain package.json, got: %s", path)
+		}
+	}
+
+	// package.json should be in WatchPaths for file watching
+	found := false
+	for _, path := range registry.WatchPaths {
+		if filepath.Base(path) == "package.json" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Expected package.json in WatchPaths for file watching")
+	}
 }
 
 func TestFileWatchingErrorHandling(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `WatchPaths` field to Registry for all file-watched paths (manifests + package.json)
- `ManifestPaths` now contains only CEM manifest file paths
- `ReloadManifestsDirectly` iterates `ManifestPaths` only, no longer attempts to parse package.json as CEM manifests
- File watcher setup and event handling use `WatchPaths`
- New `addWatchPath` method for watch-only tracking (used by `readPackageJSON`)
- `addManifestPath`/`addManifestPathWithPackageName` add to both collections

Closes #336

## Test plan

- [ ] `make test` passes
- [ ] `make lint` passes (0 issues)
- [ ] `TestManifestPaths_NoPackageJSON` verifies package.json NOT in ManifestPaths, IS in WatchPaths
- [ ] `TestPackageJSONWatching` passes with WatchPaths
- [ ] `TestManifestFileWatchingIntegration` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-watching system to properly distinguish between manifest files and workspace configuration files
  * Enhanced change detection accuracy for workspaces with multiple file types
  * Refined file tracking to prevent unintended manifest interference during workspace reloads

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bennypowers/cem/pull/338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->