### PR TITLE
fix(ci): derive zed extension version from release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,8 @@ jobs:
     name: Build and publish Zed extension
     runs-on: ubuntu-latest
     needs: npm  # Wait for npm packages to be published
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -113,8 +115,7 @@ jobs:
       - name: Get extension version
         id: version
         run: |
-          VERSION="${{ github.event.release.tag_name }}"
-          VERSION="${VERSION#v}"
+          VERSION="${RELEASE_TAG#v}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Extension version: $VERSION"
 
@@ -138,17 +139,30 @@ jobs:
           git reset --hard upstream/main
           git push origin main --force
 
+      - name: Check for existing PR
+        id: check_pr
+        working-directory: zed-extensions
+        env:
+          GH_TOKEN: ${{ secrets.ZED_COMMITTER_TOKEN }}
+        run: |
+          BRANCH="update-cem-${{ steps.version.outputs.version }}"
+          existing_pr=$(gh pr list --repo zed-industries/extensions --head "bennypowers:$BRANCH" --state all --json number --jq '.[0].number')
+          if [ -n "$existing_pr" ]; then
+            echo "PR #$existing_pr already exists for branch $BRANCH"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Update Zed Extension
+        if: steps.check_pr.outputs.skip != 'true'
         working-directory: zed-extensions
         run: |
-          # Initialize only the cem submodule
           git submodule update --init extensions/cem
-          # Update submodule to latest release tag
           cd extensions/cem
           git fetch origin --tags
-          git checkout ${{ github.event.release.tag_name }}
+          git checkout "$RELEASE_TAG"
           cd ../..
-          # Update version in extensions.toml for cem section only
           sed -i '/^\[cem\]/,/^\[/ s/^version = .*/version = "${{ steps.version.outputs.version }}"/' extensions.toml
           git add extensions/cem extensions.toml
           BRANCH="update-cem-${{ steps.version.outputs.version }}"
@@ -157,17 +171,11 @@ jobs:
           git push -f -u origin "$BRANCH"
 
       - name: Create Pull Request
+        if: steps.check_pr.outputs.skip != 'true'
         working-directory: zed-extensions
         env:
           GH_TOKEN: ${{ secrets.ZED_COMMITTER_TOKEN }}
         run: |
-          BRANCH="update-cem-${{ steps.version.outputs.version }}"
-          # Check if PR already exists (open or merged)
-          existing_pr=$(gh pr list --repo zed-industries/extensions --head "bennypowers:$BRANCH" --state all --json number --jq '.[0].number')
-          if [ -n "$existing_pr" ]; then
-            echo "PR #$existing_pr already exists for branch $BRANCH"
-            exit 0
-          fi
           gh pr create \
             --repo zed-industries/extensions \
             --title "Update cem to v${{ steps.version.outputs.version }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,8 @@ jobs:
       - name: Get extension version
         id: version
         run: |
-          VERSION=$(grep '^version = ' extensions/zed/extension.toml | cut -d'"' -f2)
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Extension version: $VERSION"
 
@@ -161,8 +162,8 @@ jobs:
           GH_TOKEN: ${{ secrets.ZED_COMMITTER_TOKEN }}
         run: |
           BRANCH="update-cem-${{ steps.version.outputs.version }}"
-          # Check if PR already exists
-          existing_pr=$(gh pr list --repo zed-industries/extensions --head "bennypowers:$BRANCH" --json number --jq '.[0].number')
+          # Check if PR already exists (open or merged)
+          existing_pr=$(gh pr list --repo zed-industries/extensions --head "bennypowers:$BRANCH" --state all --json number --jq '.[0].number')
           if [ -n "$existing_pr" ]; then
             echo "PR #$existing_pr already exists for branch $BRANCH"
             exit 0


### PR DESCRIPTION
## Summary

- Derive zed extension version from the release tag instead of reading `extensions/zed/extension.toml`, which could be stale if not bumped before tagging
- Check all PR states (not just open) when guarding against duplicate PRs

## What happened

The v0.10.6 release ran but `extension.toml` still said `0.10.5`. The zed job:
1. Read `0.10.5` from `extension.toml`
2. Created branch `update-cem-0.10.5` (same as the already-merged v0.10.5 PR)
3. Force-pushed over the merged PR's branch
4. The `sed` writing `version = "0.10.5"` was a no-op (upstream already had it)
5. Only the submodule pointer changed, so `extensions.toml` was missing from the diff
6. Result: [zed-industries/extensions#6377](https://github.com/zed-industries/extensions/pull/6377) -- broken PR, closed by maintainer

## Fix

- Use `github.event.release.tag_name` (strip `v` prefix) instead of grepping `extension.toml`
- Add `--state all` to the `gh pr list` guard so merged/closed PRs also prevent duplicates

Assisted-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to derive extension version from GitHub release tags instead of reading from configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->