### PR TITLE
refactor(config): consolidate scattered config validation

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -17,7 +17,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package config
 
 import (
-	"fmt"
 	"maps"
 
 	IC "bennypowers.dev/cem/internal/config"
@@ -38,26 +37,14 @@ type URLRewrite = IC.URLRewrite
 type FrameworkExportConfig = IC.FrameworkExportConfig
 type HealthConfig = IC.HealthConfig
 
-// Validate validates the configuration and returns an error if invalid
+// Validate validates the configuration and returns an error if invalid.
 func Validate(c *CemConfig) error {
-	if c == nil {
-		return nil
-	}
+	return IC.ValidationErrors(IC.Validate(c, IC.ValidateOptions{}))
+}
 
-	// Validate demo rendering mode
-	rendering := c.Serve.Demos.Rendering
-	if rendering != "" {
-		switch rendering {
-		case "light", "shadow":
-			// Valid modes
-		case "iframe":
-			return fmt.Errorf("serve.demos.rendering: 'iframe' mode is not yet implemented - use 'light' or 'shadow'")
-		default:
-			return fmt.Errorf("serve.demos.rendering: invalid value '%s' - must be 'light', 'shadow', or 'iframe'", rendering)
-		}
-	}
-
-	return nil
+// ValidateWithOptions validates the configuration with the given options.
+func ValidateWithOptions(c *CemConfig, opts IC.ValidateOptions) error {
+	return IC.ValidationErrors(IC.Validate(c, opts))
 }
 
 func Clone(c *CemConfig) *CemConfig {

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestValidate_ValidRenderingModes(t *testing.T) {
-	validModes := []string{"", "light", "shadow"}
+	validModes := []string{"", "light", "shadow", "iframe", "chromeless"}
 
 	for _, mode := range validModes {
 		t.Run(mode, func(t *testing.T) {
@@ -75,25 +75,6 @@ func TestValidate_InvalidRenderingMode(t *testing.T) {
 	}
 }
 
-func TestValidate_IframeRenderingMode(t *testing.T) {
-	cfg := &CemConfig{
-		Serve: ServeConfig{
-			Demos: DemosConfig{
-				Rendering: "iframe",
-			},
-		},
-	}
-
-	err := Validate(cfg)
-	if err == nil {
-		t.Error("Expected 'iframe' mode to be rejected, but validation passed")
-	}
-
-	// Check error mentions it's not implemented
-	if !strings.Contains(err.Error(), "not") || !strings.Contains(err.Error(), "implemented") {
-		t.Errorf("Error should mention iframe is not implemented, got: %v", err)
-	}
-}
 
 func TestValidate_EmptyConfigValid(t *testing.T) {
 	cfg := &CemConfig{}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -22,13 +22,14 @@ import (
 	"os/exec"
 	"os/signal"
 	"runtime"
-	"slices"
+	"strings"
 	"syscall"
 	"time"
 
 	"atomicgo.dev/keyboard"
 	"atomicgo.dev/keyboard/keys"
 	"bennypowers.dev/cem/cmd/config"
+	IC "bennypowers.dev/cem/internal/config"
 	"bennypowers.dev/cem/internal/logging"
 	"bennypowers.dev/cem/serve"
 	"bennypowers.dev/cem/serve/logger"
@@ -119,11 +120,10 @@ var serveCmd = &cobra.Command{
 			targetStr = configTarget
 		}
 
-		// Validate and parse target (default to ES2022)
 		var target transform.Target
 		if targetStr != "" {
-			if !transform.IsValidTarget(targetStr) {
-				return fmt.Errorf("invalid target '%s': must be one of es2015, es2016, es2017, es2018, es2019, es2020, es2021, es2022, es2023, or esnext", targetStr)
+			if !IC.IsValidTarget(targetStr) {
+				return fmt.Errorf("invalid target %q: must be one of %s", targetStr, strings.Join(IC.ValidTargets(), ", "))
 			}
 			target = transform.Target(targetStr)
 		} else {
@@ -144,10 +144,8 @@ var serveCmd = &cobra.Command{
 		if demoRendering == "" {
 			demoRendering = "light"
 		}
-		// Validate rendering mode
-		validModes := []string{"light", "shadow", "iframe", "chromeless"}
-		if !slices.Contains(validModes, demoRendering) {
-			return fmt.Errorf("invalid demo rendering mode '%s': must be 'light', 'shadow', 'iframe', or 'chromeless'", demoRendering)
+		if !IC.IsValidRenderingMode(demoRendering) {
+			return fmt.Errorf("invalid demo rendering mode %q: must be one of %s", demoRendering, strings.Join(IC.ValidRenderingModes(), ", "))
 		}
 		// Create server config
 		config := serve.Config{

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -56,7 +56,7 @@ var validTargets = []string{
 }
 
 func IsValidTarget(target string) bool {
-	return slices.Contains(validTargets, strings.ToLower(target))
+	return slices.Contains(validTargets, target)
 }
 
 // Validate checks a CemConfig for invalid values and returns all errors found.
@@ -177,12 +177,12 @@ func ValidationErrors(errs []ValidationError) error {
 
 // ValidRenderingModes returns valid rendering mode values.
 func ValidRenderingModes() []string {
-	return validRenderingModes
+	return slices.Clone(validRenderingModes)
 }
 
 // ValidTargets returns valid ES target values.
 func ValidTargets() []string {
-	return validTargets
+	return slices.Clone(validTargets)
 }
 
 var _ error = ValidationError{}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -145,7 +146,7 @@ func validateFilesystem(cfg *CemConfig, opts ValidateOptions) []ValidationError 
 	}
 
 	if f := cfg.Generate.DesignTokens.Spec; f != "" {
-		if !strings.HasPrefix(f, "npm:") && !strings.HasPrefix(f, "jsr:") && !strings.HasPrefix(f, "http://") && !strings.HasPrefix(f, "https://") {
+		if u, err := url.Parse(f); err != nil || u.Scheme == "" {
 			path := f
 			if !filepath.IsAbs(path) && opts.Root != "" {
 				path = filepath.Join(opts.Root, path)

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,0 +1,188 @@
+package config
+
+import (
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// ValidationError describes a single config validation failure.
+type ValidationError struct {
+	Field   string
+	Message string
+	Value   string
+}
+
+func (e ValidationError) Error() string {
+	if e.Value != "" {
+		return fmt.Sprintf("%s: %s (got %q)", e.Field, e.Message, e.Value)
+	}
+	return fmt.Sprintf("%s: %s", e.Field, e.Message)
+}
+
+// ValidateOptions controls which categories of validation run.
+type ValidateOptions struct {
+	CheckFilesystem bool
+	Root            string
+	FS              interface {
+		Exists(string) bool
+	}
+	ValidateURLRewrites   func([]URLRewrite) error
+	ValidateDemoDiscovery func(*CemConfig) error
+}
+
+const (
+	RenderingLight      = "light"
+	RenderingShadow     = "shadow"
+	RenderingIframe     = "iframe"
+	RenderingChromeless = "chromeless"
+)
+
+var validRenderingModes = []string{
+	RenderingLight,
+	RenderingShadow,
+	RenderingIframe,
+	RenderingChromeless,
+}
+
+func IsValidRenderingMode(mode string) bool {
+	return slices.Contains(validRenderingModes, mode)
+}
+
+var validTargets = []string{
+	"es2015", "es2016", "es2017", "es2018", "es2019",
+	"es2020", "es2021", "es2022", "es2023", "esnext",
+}
+
+func IsValidTarget(target string) bool {
+	return slices.Contains(validTargets, strings.ToLower(target))
+}
+
+// Validate checks a CemConfig for invalid values and returns all errors found.
+func Validate(cfg *CemConfig, opts ValidateOptions) []ValidationError {
+	if cfg == nil {
+		return nil
+	}
+
+	var errs []ValidationError
+
+	if r := cfg.Serve.Demos.Rendering; r != "" && !IsValidRenderingMode(r) {
+		errs = append(errs, ValidationError{
+			Field:   "serve.demos.rendering",
+			Message: fmt.Sprintf("must be one of: %s", strings.Join(validRenderingModes, ", ")),
+			Value:   r,
+		})
+	}
+
+	if t := cfg.Serve.Transforms.TypeScript.Target; t != "" && !IsValidTarget(t) {
+		errs = append(errs, ValidationError{
+			Field:   "serve.transforms.typescript.target",
+			Message: fmt.Sprintf("must be one of: %s", strings.Join(validTargets, ", ")),
+			Value:   t,
+		})
+	}
+
+	if p := cfg.Serve.Port; p < 0 || p > 65535 {
+		errs = append(errs, ValidationError{
+			Field:   "serve.port",
+			Message: "must be between 0 and 65535",
+			Value:   fmt.Sprintf("%d", p),
+		})
+	}
+
+	if prefix := cfg.Generate.DesignTokens.Prefix; prefix != "" && strings.HasPrefix(prefix, "-") {
+		errs = append(errs, ValidationError{
+			Field:   "generate.designTokens.prefix",
+			Message: fmt.Sprintf("should not start with dashes (use %q instead)", strings.TrimLeft(prefix, "-")),
+			Value:   prefix,
+		})
+	}
+
+	if opts.ValidateURLRewrites != nil && len(cfg.Serve.URLRewrites) > 0 {
+		if err := opts.ValidateURLRewrites(cfg.Serve.URLRewrites); err != nil {
+			errs = append(errs, ValidationError{
+				Field:   "serve.urlRewrites",
+				Message: err.Error(),
+			})
+		}
+	}
+
+	if opts.ValidateDemoDiscovery != nil {
+		if err := opts.ValidateDemoDiscovery(cfg); err != nil {
+			errs = append(errs, ValidationError{
+				Field:   "generate.demoDiscovery",
+				Message: err.Error(),
+			})
+		}
+	}
+
+	if opts.CheckFilesystem && opts.FS != nil {
+		errs = append(errs, validateFilesystem(cfg, opts)...)
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+	return errs
+}
+
+func validateFilesystem(cfg *CemConfig, opts ValidateOptions) []ValidationError {
+	var errs []ValidationError
+
+	if f := cfg.Serve.ImportMap.OverrideFile; f != "" {
+		path := f
+		if !filepath.IsAbs(path) && opts.Root != "" {
+			path = filepath.Join(opts.Root, path)
+		}
+		if !opts.FS.Exists(path) {
+			errs = append(errs, ValidationError{
+				Field:   "serve.importMap.overrideFile",
+				Message: "file not found",
+				Value:   f,
+			})
+		}
+	}
+
+	if f := cfg.Generate.DesignTokens.Spec; f != "" {
+		if !strings.HasPrefix(f, "npm:") && !strings.HasPrefix(f, "jsr:") && !strings.HasPrefix(f, "http://") && !strings.HasPrefix(f, "https://") {
+			path := f
+			if !filepath.IsAbs(path) && opts.Root != "" {
+				path = filepath.Join(opts.Root, path)
+			}
+			if !opts.FS.Exists(path) {
+				errs = append(errs, ValidationError{
+					Field:   "generate.designTokens.spec",
+					Message: "file not found",
+					Value:   f,
+				})
+			}
+		}
+	}
+
+	return errs
+}
+
+// ValidationErrors converts a slice of ValidationError to a single error.
+func ValidationErrors(errs []ValidationError) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	msgs := make([]string, len(errs))
+	for i, e := range errs {
+		msgs[i] = e.Error()
+	}
+	return fmt.Errorf("config validation failed:\n  %s", strings.Join(msgs, "\n  "))
+}
+
+// ValidRenderingModes returns valid rendering mode values.
+func ValidRenderingModes() []string {
+	return validRenderingModes
+}
+
+// ValidTargets returns valid ES target values.
+func ValidTargets() []string {
+	return validTargets
+}
+
+var _ error = ValidationError{}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -7,6 +7,9 @@ import (
 	"bennypowers.dev/cem/serve/middleware/types"
 )
 
+// Tier 1 pure function tests: all validation depends on formal parameters,
+// no I/O or side effects. Inline assertions are appropriate.
+
 func TestValidate_NilConfig(t *testing.T) {
 	errs := Validate(nil, ValidateOptions{})
 	if errs != nil {
@@ -58,9 +61,8 @@ func TestValidate_ESTarget(t *testing.T) {
 	valid := []string{
 		"", "es2015", "es2016", "es2017", "es2018", "es2019",
 		"es2020", "es2021", "es2022", "es2023", "esnext",
-		"ES2022", "ESNext", "ESNEXT",
 	}
-	invalid := []string{"es2014", "es2024", "es5", "es6", "latest"}
+	invalid := []string{"es2014", "es2024", "es5", "es6", "latest", "ES2022", "ESNext", "ESNEXT"}
 
 	for _, target := range valid {
 		t.Run("valid_"+target, func(t *testing.T) {
@@ -207,6 +209,22 @@ func TestValidate_DelegatedURLRewrites(t *testing.T) {
 			t.Errorf("expected nil, got %v", errs)
 		}
 	})
+
+	t.Run("empty_rewrites_skips_validator", func(t *testing.T) {
+		called := false
+		errs := Validate(&CemConfig{}, ValidateOptions{
+			ValidateURLRewrites: func(rewrites []URLRewrite) error {
+				called = true
+				return errors.New("should not be called")
+			},
+		})
+		if called {
+			t.Error("validator should not be called for empty rewrites")
+		}
+		if errs != nil {
+			t.Errorf("expected nil, got %v", errs)
+		}
+	})
 }
 
 func TestValidate_DelegatedDemoDiscovery(t *testing.T) {
@@ -332,6 +350,38 @@ func TestValidate_FilesystemChecks(t *testing.T) {
 		errs := Validate(cfg, ValidateOptions{CheckFilesystem: true, Root: "/root", FS: fs})
 		if errs != nil {
 			t.Errorf("expected nil for https specifier, got %v", errs)
+		}
+	})
+
+	t.Run("http_specifier_skips_filesystem", func(t *testing.T) {
+		cfg := &CemConfig{Generate: GenerateConfig{
+			DesignTokens: DesignTokensConfig{Spec: "http://cdn.example.com/tokens.json"},
+		}}
+		errs := Validate(cfg, ValidateOptions{CheckFilesystem: true, Root: "/root", FS: fs})
+		if errs != nil {
+			t.Errorf("expected nil for http specifier, got %v", errs)
+		}
+	})
+
+	t.Run("absolute_importmap_path", func(t *testing.T) {
+		absFS := &mockFS{files: map[string]bool{"/abs/override.json": true}}
+		cfg := &CemConfig{Serve: ServeConfig{
+			ImportMap: types.ImportMapConfig{OverrideFile: "/abs/override.json"},
+		}}
+		errs := Validate(cfg, ValidateOptions{CheckFilesystem: true, Root: "/root", FS: absFS})
+		if errs != nil {
+			t.Errorf("expected nil for absolute path, got %v", errs)
+		}
+	})
+
+	t.Run("absolute_tokens_path", func(t *testing.T) {
+		absFS := &mockFS{files: map[string]bool{"/abs/tokens.json": true}}
+		cfg := &CemConfig{Generate: GenerateConfig{
+			DesignTokens: DesignTokensConfig{Spec: "/abs/tokens.json"},
+		}}
+		errs := Validate(cfg, ValidateOptions{CheckFilesystem: true, Root: "/root", FS: absFS})
+		if errs != nil {
+			t.Errorf("expected nil for absolute path, got %v", errs)
 		}
 	})
 }

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,0 +1,370 @@
+package config
+
+import (
+	"errors"
+	"testing"
+
+	"bennypowers.dev/cem/serve/middleware/types"
+)
+
+func TestValidate_NilConfig(t *testing.T) {
+	errs := Validate(nil, ValidateOptions{})
+	if errs != nil {
+		t.Errorf("expected nil, got %v", errs)
+	}
+}
+
+func TestValidate_EmptyConfig(t *testing.T) {
+	errs := Validate(&CemConfig{}, ValidateOptions{})
+	if errs != nil {
+		t.Errorf("expected nil, got %v", errs)
+	}
+}
+
+func TestValidate_RenderingMode(t *testing.T) {
+	tests := []struct {
+		mode    string
+		wantErr bool
+	}{
+		{"", false},
+		{"light", false},
+		{"shadow", false},
+		{"iframe", false},
+		{"chromeless", false},
+		{"dark", true},
+		{"LIGHT", true},
+		{"Light", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.mode, func(t *testing.T) {
+			cfg := &CemConfig{Serve: ServeConfig{Demos: DemosConfig{Rendering: tt.mode}}}
+			errs := Validate(cfg, ValidateOptions{})
+			if tt.wantErr && errs == nil {
+				t.Errorf("expected error for mode %q", tt.mode)
+			}
+			if !tt.wantErr && errs != nil {
+				t.Errorf("unexpected error for mode %q: %v", tt.mode, errs)
+			}
+			if tt.wantErr && errs != nil {
+				if errs[0].Field != "serve.demos.rendering" {
+					t.Errorf("expected field serve.demos.rendering, got %q", errs[0].Field)
+				}
+			}
+		})
+	}
+}
+
+func TestValidate_ESTarget(t *testing.T) {
+	valid := []string{
+		"", "es2015", "es2016", "es2017", "es2018", "es2019",
+		"es2020", "es2021", "es2022", "es2023", "esnext",
+		"ES2022", "ESNext", "ESNEXT",
+	}
+	invalid := []string{"es2014", "es2024", "es5", "es6", "latest"}
+
+	for _, target := range valid {
+		t.Run("valid_"+target, func(t *testing.T) {
+			cfg := &CemConfig{Serve: ServeConfig{
+				Transforms: TransformsConfig{
+					TypeScript: TypeScriptTransformConfig{Target: target},
+				},
+			}}
+			errs := Validate(cfg, ValidateOptions{})
+			if errs != nil {
+				t.Errorf("unexpected error for target %q: %v", target, errs)
+			}
+		})
+	}
+	for _, target := range invalid {
+		t.Run("invalid_"+target, func(t *testing.T) {
+			cfg := &CemConfig{Serve: ServeConfig{
+				Transforms: TransformsConfig{
+					TypeScript: TypeScriptTransformConfig{Target: target},
+				},
+			}}
+			errs := Validate(cfg, ValidateOptions{})
+			if errs == nil {
+				t.Errorf("expected error for target %q", target)
+			}
+			if errs != nil && errs[0].Field != "serve.transforms.typescript.target" {
+				t.Errorf("expected field serve.transforms.typescript.target, got %q", errs[0].Field)
+			}
+		})
+	}
+}
+
+func TestValidate_Port(t *testing.T) {
+	tests := []struct {
+		name    string
+		port    int
+		wantErr bool
+	}{
+		{"zero", 0, false},
+		{"one", 1, false},
+		{"common", 8000, false},
+		{"max", 65535, false},
+		{"over_max", 65536, true},
+		{"negative", -1, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &CemConfig{Serve: ServeConfig{Port: tt.port}}
+			errs := Validate(cfg, ValidateOptions{})
+			if tt.wantErr && errs == nil {
+				t.Errorf("expected error for port %d", tt.port)
+			}
+			if !tt.wantErr && errs != nil {
+				t.Errorf("unexpected error for port %d: %v", tt.port, errs)
+			}
+		})
+	}
+}
+
+func TestValidate_DesignTokensPrefix(t *testing.T) {
+	tests := []struct {
+		prefix  string
+		wantErr bool
+	}{
+		{"", false},
+		{"rh", false},
+		{"my-ds", false},
+		{"-rh", true},
+		{"--rh", true},
+		{"---", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.prefix, func(t *testing.T) {
+			cfg := &CemConfig{Generate: GenerateConfig{
+				DesignTokens: DesignTokensConfig{Prefix: tt.prefix},
+			}}
+			errs := Validate(cfg, ValidateOptions{})
+			if tt.wantErr && errs == nil {
+				t.Errorf("expected error for prefix %q", tt.prefix)
+			}
+			if !tt.wantErr && errs != nil {
+				t.Errorf("unexpected error for prefix %q: %v", tt.prefix, errs)
+			}
+		})
+	}
+}
+
+func TestValidate_MultipleErrors(t *testing.T) {
+	cfg := &CemConfig{
+		Serve: ServeConfig{
+			Port:  -1,
+			Demos: DemosConfig{Rendering: "invalid"},
+			Transforms: TransformsConfig{
+				TypeScript: TypeScriptTransformConfig{Target: "es5"},
+			},
+		},
+		Generate: GenerateConfig{
+			DesignTokens: DesignTokensConfig{Prefix: "--bad"},
+		},
+	}
+	errs := Validate(cfg, ValidateOptions{})
+	if len(errs) != 4 {
+		t.Errorf("expected 4 errors, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestValidate_DelegatedURLRewrites(t *testing.T) {
+	cfg := &CemConfig{
+		Serve: ServeConfig{
+			URLRewrites: []URLRewrite{{URLPattern: "/foo", URLTemplate: "/bar"}},
+		},
+	}
+
+	t.Run("nil_validator_skips", func(t *testing.T) {
+		errs := Validate(cfg, ValidateOptions{})
+		if errs != nil {
+			t.Errorf("expected nil with no validator, got %v", errs)
+		}
+	})
+
+	t.Run("validator_called", func(t *testing.T) {
+		called := false
+		errs := Validate(cfg, ValidateOptions{
+			ValidateURLRewrites: func(rewrites []URLRewrite) error {
+				called = true
+				return errors.New("bad pattern")
+			},
+		})
+		if !called {
+			t.Error("validator was not called")
+		}
+		if len(errs) != 1 || errs[0].Field != "serve.urlRewrites" {
+			t.Errorf("unexpected errs: %v", errs)
+		}
+	})
+
+	t.Run("validator_success", func(t *testing.T) {
+		errs := Validate(cfg, ValidateOptions{
+			ValidateURLRewrites: func(rewrites []URLRewrite) error {
+				return nil
+			},
+		})
+		if errs != nil {
+			t.Errorf("expected nil, got %v", errs)
+		}
+	})
+}
+
+func TestValidate_DelegatedDemoDiscovery(t *testing.T) {
+	cfg := &CemConfig{}
+
+	t.Run("nil_validator_skips", func(t *testing.T) {
+		errs := Validate(cfg, ValidateOptions{})
+		if errs != nil {
+			t.Errorf("expected nil, got %v", errs)
+		}
+	})
+
+	t.Run("validator_called", func(t *testing.T) {
+		errs := Validate(cfg, ValidateOptions{
+			ValidateDemoDiscovery: func(c *CemConfig) error {
+				return errors.New("bad template")
+			},
+		})
+		if len(errs) != 1 || errs[0].Field != "generate.demoDiscovery" {
+			t.Errorf("unexpected errs: %v", errs)
+		}
+	})
+}
+
+type mockFS struct {
+	files map[string]bool
+}
+
+func (m *mockFS) Exists(path string) bool {
+	return m.files[path]
+}
+
+func TestValidate_FilesystemChecks(t *testing.T) {
+	fs := &mockFS{files: map[string]bool{
+		"/root/exists.json": true,
+		"/root/tokens.json": true,
+	}}
+
+	t.Run("skipped_when_disabled", func(t *testing.T) {
+		cfg := &CemConfig{Serve: ServeConfig{
+			ImportMap: types.ImportMapConfig{OverrideFile: "missing.json"},
+		}}
+		errs := Validate(cfg, ValidateOptions{CheckFilesystem: false})
+		if errs != nil {
+			t.Errorf("expected nil when filesystem check disabled, got %v", errs)
+		}
+	})
+
+	t.Run("skipped_when_no_fs", func(t *testing.T) {
+		cfg := &CemConfig{Serve: ServeConfig{
+			ImportMap: types.ImportMapConfig{OverrideFile: "missing.json"},
+		}}
+		errs := Validate(cfg, ValidateOptions{CheckFilesystem: true})
+		if errs != nil {
+			t.Errorf("expected nil when FS is nil, got %v", errs)
+		}
+	})
+
+	t.Run("importmap_override_found", func(t *testing.T) {
+		cfg := &CemConfig{Serve: ServeConfig{
+			ImportMap: types.ImportMapConfig{OverrideFile: "exists.json"},
+		}}
+		errs := Validate(cfg, ValidateOptions{CheckFilesystem: true, Root: "/root", FS: fs})
+		if errs != nil {
+			t.Errorf("expected nil, got %v", errs)
+		}
+	})
+
+	t.Run("importmap_override_missing", func(t *testing.T) {
+		cfg := &CemConfig{Serve: ServeConfig{
+			ImportMap: types.ImportMapConfig{OverrideFile: "missing.json"},
+		}}
+		errs := Validate(cfg, ValidateOptions{CheckFilesystem: true, Root: "/root", FS: fs})
+		if len(errs) != 1 || errs[0].Field != "serve.importMap.overrideFile" {
+			t.Errorf("expected importMap error, got %v", errs)
+		}
+	})
+
+	t.Run("design_tokens_found", func(t *testing.T) {
+		cfg := &CemConfig{Generate: GenerateConfig{
+			DesignTokens: DesignTokensConfig{Spec: "tokens.json"},
+		}}
+		errs := Validate(cfg, ValidateOptions{CheckFilesystem: true, Root: "/root", FS: fs})
+		if errs != nil {
+			t.Errorf("expected nil, got %v", errs)
+		}
+	})
+
+	t.Run("design_tokens_missing", func(t *testing.T) {
+		cfg := &CemConfig{Generate: GenerateConfig{
+			DesignTokens: DesignTokensConfig{Spec: "nope.json"},
+		}}
+		errs := Validate(cfg, ValidateOptions{CheckFilesystem: true, Root: "/root", FS: fs})
+		if len(errs) != 1 || errs[0].Field != "generate.designTokens.spec" {
+			t.Errorf("expected designTokens error, got %v", errs)
+		}
+	})
+
+	t.Run("npm_specifier_skips_filesystem", func(t *testing.T) {
+		cfg := &CemConfig{Generate: GenerateConfig{
+			DesignTokens: DesignTokensConfig{Spec: "npm:@rhds/tokens/tokens.json"},
+		}}
+		errs := Validate(cfg, ValidateOptions{CheckFilesystem: true, Root: "/root", FS: fs})
+		if errs != nil {
+			t.Errorf("expected nil for npm specifier, got %v", errs)
+		}
+	})
+
+	t.Run("jsr_specifier_skips_filesystem", func(t *testing.T) {
+		cfg := &CemConfig{Generate: GenerateConfig{
+			DesignTokens: DesignTokensConfig{Spec: "jsr:@example/tokens"},
+		}}
+		errs := Validate(cfg, ValidateOptions{CheckFilesystem: true, Root: "/root", FS: fs})
+		if errs != nil {
+			t.Errorf("expected nil for jsr specifier, got %v", errs)
+		}
+	})
+
+	t.Run("https_specifier_skips_filesystem", func(t *testing.T) {
+		cfg := &CemConfig{Generate: GenerateConfig{
+			DesignTokens: DesignTokensConfig{Spec: "https://cdn.example.com/tokens.json"},
+		}}
+		errs := Validate(cfg, ValidateOptions{CheckFilesystem: true, Root: "/root", FS: fs})
+		if errs != nil {
+			t.Errorf("expected nil for https specifier, got %v", errs)
+		}
+	})
+}
+
+func TestValidationErrors(t *testing.T) {
+	t.Run("nil_for_empty", func(t *testing.T) {
+		if err := ValidationErrors(nil); err != nil {
+			t.Errorf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("formats_single", func(t *testing.T) {
+		err := ValidationErrors([]ValidationError{{Field: "f", Message: "m", Value: "v"}})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		want := "config validation failed:\n  f: m (got \"v\")"
+		if err.Error() != want {
+			t.Errorf("got %q, want %q", err.Error(), want)
+		}
+	})
+
+	t.Run("formats_multiple", func(t *testing.T) {
+		err := ValidationErrors([]ValidationError{
+			{Field: "a", Message: "bad"},
+			{Field: "b", Message: "worse", Value: "x"},
+		})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		want := "config validation failed:\n  a: bad\n  b: worse (got \"x\")"
+		if err.Error() != want {
+			t.Errorf("got %q, want %q", err.Error(), want)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Consolidate config validation from 16+ scattered callsites into a central `internal/config.Validate()` function. Fixes rendering mode discrepancy where `iframe` and `chromeless` were accepted by `cmd/serve` but rejected by `cmd/config`.

Closes #340

## Changes

- Add `internal/config/validate.go` with `Validate()`, enum constants, port/prefix validation, delegated validators for domain-specific checks, and opt-in filesystem checks
- Add exhaustive Tier 1 table-driven tests (38 test cases)
- Wire `cmd/config.Validate()` as thin wrapper delegating to `internal/config.Validate()`
- Migrate `cmd/serve.go` to use centralized `IsValidTarget()` and `IsValidRenderingMode()`
- Remove duplicate rendering mode validation (was in both `cmd/config` and `cmd/serve`)

## Design decisions

- **Delegation pattern**: Domain-specific validation (URL rewrites, demo discovery) stays in domain packages. `Validate()` accepts optional validator functions to avoid `internal/config` importing `go-urlpattern`/`text/template`/`gosimple/slug`.
- **Filesystem checks opt-in**: `ValidateOptions.CheckFilesystem` gates file existence checks. Uses structural `interface{ Exists(string) bool }` for wasm compatibility.
- **Case-sensitive target validation**: `transform.Target` is compared case-sensitively by esbuild's transform switch. Accepting mixed-case would cause silent fallthrough to a wrong default target.
- **Slice getters return clones**: `ValidRenderingModes()`/`ValidTargets()` return `slices.Clone()` to prevent callers from mutating canonical lists.
- **`ValidateWithOptions` exported for #345**: `cem config validate` command will wire up delegated validators and filesystem checks through this API.

## Test plan

- [x] `golangci-lint run ./...` -- 0 issues
- [x] `go test ./internal/config/...` -- 38 tests pass
- [x] `go test ./cmd/config/...` -- all tests pass (iframe/chromeless now valid)
- [x] `go test ./...` -- all Go tests pass

Assisted-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new demo rendering mode: chromeless; iframe is now treated as a valid mode.

* **Improvements**
  * Centralized and standardized configuration validation with clearer, aggregated error messages and optional filesystem/validator checks.

* **Tests**
  * Expanded validation unit tests covering rendering modes, targets, ports, design tokens, filesystem checks, and delegated validators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->