### PR TITLE
feat(cli): add cem config command group

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,10 @@ Run `go vet` to surface gopls suggestions. Common examples:
 - replace `m[k]=v` loop with `maps.Copy` [mapsloop]
 - Loop can be simplified using slices.Contains [slicescontains]
 
+### CLI commands
+
+In cobra command `RunE` handlers, use `cmd.Println` / `cmd.PrintErrln` instead of `fmt.Println` / `fmt.Fprintln(os.Stderr, ...)`. This respects cobra's configured output streams and makes commands testable.
+
 ## Debugging
 
 When debugging Go code, always use the logger `logger.Debug`, etc. Don't use `fmt.Printf`, which pollutes stdio, breaking the LSP and MCP commands.

--- a/cmd/config_cmd.go
+++ b/cmd/config_cmd.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"fmt"
+
+	W "bennypowers.dev/cem/internal/workspace"
+	"github.com/spf13/cobra"
+)
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Manage CEM configuration",
+	Long:  "Commands for creating, validating, and inspecting CEM configuration files.",
+}
+
+var configInitCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Create a CEM configuration file",
+	Long:  "Interactive wizard that detects project settings and generates .config/cem.yaml.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return fmt.Errorf("not yet implemented")
+	},
+}
+
+var configValidateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: "Validate the configuration file",
+	Long:  "Check the config file for invalid values, unreachable patterns, and missing files.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return fmt.Errorf("not yet implemented")
+	},
+}
+
+var configShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Print the resolved configuration",
+	Long:  "Print the fully resolved and merged config, showing workspace inheritance.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return fmt.Errorf("not yet implemented")
+	},
+}
+
+var configMCPCmd = &cobra.Command{
+	Use:   "mcp",
+	Short: "Generate MCP client configuration",
+	Long:  "Generate configuration snippets for AI tools (Claude Code, Claude Desktop, Cursor, etc.).",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return fmt.Errorf("not yet implemented")
+	},
+}
+
+var configPathCmd = &cobra.Command{
+	Use:   "path",
+	Short: "Print the config file path",
+	Long:  "Print the resolved config file path. Useful for scripting: $EDITOR $(cem config path)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, err := W.GetWorkspaceContext(cmd)
+		if err != nil {
+			return fmt.Errorf("project context not initialized: %w", err)
+		}
+		cfgFile := ctx.ConfigFile()
+		if cfgFile == "" {
+			root := ctx.Root()
+			return fmt.Errorf("no config file found (searched %s)", root)
+		}
+		fmt.Println(cfgFile)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(configCmd)
+	configCmd.AddCommand(configInitCmd)
+	configCmd.AddCommand(configValidateCmd)
+	configCmd.AddCommand(configShowCmd)
+	configCmd.AddCommand(configMCPCmd)
+	configCmd.AddCommand(configPathCmd)
+}

--- a/cmd/config_cmd.go
+++ b/cmd/config_cmd.go
@@ -63,7 +63,7 @@ var configPathCmd = &cobra.Command{
 			root := ctx.Root()
 			return fmt.Errorf("no config file found (searched %s)", root)
 		}
-		fmt.Println(cfgFile)
+		cmd.Println(cfgFile)
 		return nil
 	},
 }


### PR DESCRIPTION
## Summary

Add `cem config` parent command with stub subcommands for init, validate, show, and mcp. Implement `cem config path` which prints the resolved config file path.

Closes #342, closes #343

## Commands

| Command | Status |
|---------|--------|
| `cem config` | Parent -- lists subcommands |
| `cem config path` | Implemented -- prints resolved config file path |
| `cem config init` | Stub -- returns "not yet implemented" |
| `cem config validate` | Stub -- returns "not yet implemented" |
| `cem config show` | Stub -- returns "not yet implemented" |
| `cem config mcp` | Stub -- returns "not yet implemented" |

## Test plan

- [x] `cem config --help` shows all subcommands
- [x] `cem config path -p examples/kitchen-sink` prints config path
- [x] `cem config path -p /tmp` errors with "no config file found"
- [x] `cem config init` errors with "not yet implemented"
- [x] `golangci-lint run ./cmd/...` -- 0 issues
- [x] `go test ./cmd/...` -- all pass

Assisted-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `config` command group to the CLI with subcommands: `init`, `validate`, `show`, `mcp`, and `path`
  * The `config path` subcommand displays the current configuration file location

<!-- end of auto-generated comment: release notes by coderabbit.ai -->