### PR TITLE
fix(generate): surface clear errors when glob patterns match files outside project root

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -75,18 +75,20 @@ var generateCmd = &cobra.Command{
 		}
 
 		files, err := expand(ctx, uniqueGlobs)
-		if err != nil {
-			errs = errors.Join(errs, err)
-		}
-
 		if len(files) == 0 {
+			if err != nil {
+				return err
+			}
 			return errors.New("pass at least one file to generate")
+		}
+		if err != nil {
+			logging.Warning("%v", err)
 		}
 
 		excludeGlobs := append(viper.GetStringSlice("generate.exclude"), cfg.Generate.Exclude...)
-		exclude, err := expand(ctx, excludeGlobs)
-		if err != nil {
-			errs = errors.Join(errs, err)
+		exclude, expandErr := expand(ctx, excludeGlobs)
+		if expandErr != nil {
+			logging.Warning("%v", expandErr)
 		}
 
 		// Validate demo discovery configuration at startup to fail fast
@@ -192,15 +194,18 @@ var generateCmd = &cobra.Command{
 	},
 }
 
-// Use WorkspaceContext to expand globs
+// expand resolves glob patterns via the workspace context.
+// Always use returned files even when err != nil (io.Reader pattern):
+//   - ([], err)      → fatal, no usable results
+//   - (files, err)   → files are valid, err is a warning
+//   - (files, nil)   → clean success
 func expand(ctx types.WorkspaceContext, globs []string) (files []string, errs error) {
 	for _, pattern := range globs {
 		matches, err := ctx.Glob(pattern)
+		files = append(files, matches...)
 		if err != nil {
 			errs = errors.Join(errs, err)
-			continue
 		}
-		files = append(files, matches...)
 	}
 	return files, errs
 }

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -26,12 +26,12 @@ import (
 
 	DT "bennypowers.dev/cem/internal/designtokens"
 	DD "bennypowers.dev/cem/generate/demodiscovery"
+	"bennypowers.dev/cem/internal/logging"
 	M "bennypowers.dev/cem/manifest"
 	Q "bennypowers.dev/cem/internal/treesitter"
 	"bennypowers.dev/cem/types"
 
 	DS "github.com/bmatcuk/doublestar"
-	"github.com/pterm/pterm"
 	ts "github.com/tree-sitter/go-tree-sitter"
 )
 
@@ -85,7 +85,7 @@ func preprocess(ctx types.WorkspaceContext) (r preprocessResult, errs error) {
 		demoFiles, err := ctx.Glob(cfg.Generate.DemoDiscovery.FileGlob)
 		r.demoFiles = demoFiles
 		if err != nil {
-			pterm.Debug.Printfln("demo discovery glob: %v", err)
+			logging.Debug("demo discovery glob: %v", err)
 		}
 	}
 	for _, filePattern := range cfg.Generate.Files {

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -81,25 +81,18 @@ func preprocess(ctx types.WorkspaceContext) (r preprocessResult, errs error) {
 		}
 	}
 	if cfg.Generate.DemoDiscovery.FileGlob != "" {
-		demoFiles, err := ctx.Glob(cfg.Generate.DemoDiscovery.FileGlob)
+		demoFiles, _ := ctx.Glob(cfg.Generate.DemoDiscovery.FileGlob)
 		r.demoFiles = demoFiles
-		if err != nil {
-			errs = errors.Join(errs, err)
-		}
 	}
 	for _, filePattern := range cfg.Generate.Files {
-		// Expand glob patterns to actual file paths
 		expandedFiles, err := ctx.Glob(filePattern)
-		if err != nil {
-			errs = errors.Join(errs, fmt.Errorf("failed to expand glob pattern %s: %w", filePattern, err))
-			continue
-		}
-
-		// Add expanded files that don't match exclude patterns
 		for _, file := range expandedFiles {
 			if !matchesAnyPattern(file, r.excludePatterns) {
 				r.includedFiles = append(r.includedFiles, file)
 			}
+		}
+		if err != nil {
+			errs = errors.Join(errs, fmt.Errorf("expanding glob %s: %w", filePattern, err))
 		}
 	}
 	return r, errs

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -31,6 +31,7 @@ import (
 	"bennypowers.dev/cem/types"
 
 	DS "github.com/bmatcuk/doublestar"
+	"github.com/pterm/pterm"
 	ts "github.com/tree-sitter/go-tree-sitter"
 )
 
@@ -81,8 +82,11 @@ func preprocess(ctx types.WorkspaceContext) (r preprocessResult, errs error) {
 		}
 	}
 	if cfg.Generate.DemoDiscovery.FileGlob != "" {
-		demoFiles, _ := ctx.Glob(cfg.Generate.DemoDiscovery.FileGlob)
+		demoFiles, err := ctx.Glob(cfg.Generate.DemoDiscovery.FileGlob)
 		r.demoFiles = demoFiles
+		if err != nil {
+			pterm.Debug.Printfln("demo discovery glob: %v", err)
+		}
 	}
 	for _, filePattern := range cfg.Generate.Files {
 		expandedFiles, err := ctx.Glob(filePattern)

--- a/generate/session_watch.go
+++ b/generate/session_watch.go
@@ -132,10 +132,7 @@ func (ws *WatchSession) setupWatcher() (*fsnotify.Watcher, error) {
 
 	// Expand globs to get current files and their directories
 	for _, glob := range ws.globs {
-		files, err := ws.ctx.Glob(glob)
-		if err != nil {
-			continue
-		}
+		files, _ := ws.ctx.Glob(glob)
 		for _, file := range files {
 			dir := filepath.Dir(file)
 			if !filepath.IsAbs(dir) {
@@ -148,15 +145,13 @@ func (ws *WatchSession) setupWatcher() (*fsnotify.Watcher, error) {
 	// Add demo discovery directories if configured
 	cfg, err := ws.ctx.Config()
 	if err == nil && cfg.Generate.DemoDiscovery.FileGlob != "" {
-		demoFiles, err := ws.ctx.Glob(cfg.Generate.DemoDiscovery.FileGlob)
-		if err == nil {
-			for _, file := range demoFiles {
-				dir := filepath.Dir(file)
-				if !filepath.IsAbs(dir) {
-					dir = filepath.Join(ws.ctx.Root(), dir)
-				}
-				dirs[dir] = true
+		demoFiles, _ := ws.ctx.Glob(cfg.Generate.DemoDiscovery.FileGlob)
+		for _, file := range demoFiles {
+			dir := filepath.Dir(file)
+			if !filepath.IsAbs(dir) {
+				dir = filepath.Join(ws.ctx.Root(), dir)
 			}
+			dirs[dir] = true
 		}
 	}
 

--- a/generate/session_watch.go
+++ b/generate/session_watch.go
@@ -145,7 +145,10 @@ func (ws *WatchSession) setupWatcher() (*fsnotify.Watcher, error) {
 	// Add demo discovery directories if configured
 	cfg, err := ws.ctx.Config()
 	if err == nil && cfg.Generate.DemoDiscovery.FileGlob != "" {
-		demoFiles, _ := ws.ctx.Glob(cfg.Generate.DemoDiscovery.FileGlob)
+		demoFiles, err := ws.ctx.Glob(cfg.Generate.DemoDiscovery.FileGlob)
+		if err != nil {
+			pterm.Debug.Printfln("demo discovery glob: %v", err)
+		}
 		for _, file := range demoFiles {
 			dir := filepath.Dir(file)
 			if !filepath.IsAbs(dir) {

--- a/generate/session_watch.go
+++ b/generate/session_watch.go
@@ -147,7 +147,7 @@ func (ws *WatchSession) setupWatcher() (*fsnotify.Watcher, error) {
 	if err == nil && cfg.Generate.DemoDiscovery.FileGlob != "" {
 		demoFiles, err := ws.ctx.Glob(cfg.Generate.DemoDiscovery.FileGlob)
 		if err != nil {
-			pterm.Debug.Printfln("demo discovery glob: %v", err)
+			logging.Debug("demo discovery glob: %v", err)
 		}
 		for _, file := range demoFiles {
 			dir := filepath.Dir(file)

--- a/internal/workspace/glob_test.go
+++ b/internal/workspace/glob_test.go
@@ -17,6 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package workspace
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -179,6 +180,92 @@ func TestMakeRelativeToRoot_CrossPlatform(t *testing.T) {
 				t.Errorf("Expected %q, got %q", expected, actual)
 			}
 		})
+	}
+}
+
+// Inline assertions: testing error sentinel types via errors.Is; goldens cannot capture this.
+// Real filesystem: doublestar.Glob requires actual disk paths, not MapFS.
+
+func TestGlob_AllOutsideRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	siblingFiles := []string{
+		"packages/components/button/src/button.ts",
+		"packages/components/card/src/card.ts",
+	}
+	for _, file := range siblingFiles {
+		fullPath := filepath.Join(tmpDir, file)
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+			t.Fatalf("Failed to create directory: %v", err)
+		}
+		if err := os.WriteFile(fullPath, []byte("export class Foo {}"), 0644); err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+	}
+
+	projectRoot := filepath.Join(tmpDir, "website")
+	if err := os.MkdirAll(projectRoot, 0755); err != nil {
+		t.Fatalf("Failed to create project dir: %v", err)
+	}
+
+	ctx := NewFileSystemWorkspaceContext(projectRoot)
+
+	result, err := ctx.Glob("../packages/components/**/*.ts")
+
+	if len(result) != 0 {
+		t.Errorf("Expected empty result, got %v", result)
+	}
+	if !errors.Is(err, ErrGlobAllOutsideRoot) {
+		t.Errorf("Expected ErrGlobAllOutsideRoot, got %v", err)
+	}
+}
+
+func TestGlob_SomeOutsideRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Files both inside and outside project root
+	allFiles := []string{
+		"packages/components/button/src/button.ts", // outside website/
+		"website/src/local.ts",                     // inside website/
+	}
+	for _, file := range allFiles {
+		fullPath := filepath.Join(tmpDir, file)
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+			t.Fatalf("Failed to create directory: %v", err)
+		}
+		if err := os.WriteFile(fullPath, []byte("export class Foo {}"), 0644); err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+	}
+
+	projectRoot := filepath.Join(tmpDir, "website")
+	ctx := NewFileSystemWorkspaceContext(projectRoot)
+
+	// Pattern that matches both inside and outside root
+	result, err := ctx.Glob("../**/*.ts")
+
+	if len(result) != 1 {
+		t.Fatalf("Expected 1 result (local file only), got %d: %v", len(result), result)
+	}
+	if result[0] != filepath.Join("src", "local.ts") {
+		t.Errorf("Expected src/local.ts, got %s", result[0])
+	}
+	if !errors.Is(err, ErrGlobSomeOutsideRoot) {
+		t.Errorf("Expected ErrGlobSomeOutsideRoot, got %v", err)
+	}
+}
+
+func TestGlob_NoneMatched(t *testing.T) {
+	tmpDir := t.TempDir()
+	ctx := NewFileSystemWorkspaceContext(tmpDir)
+
+	result, err := ctx.Glob("nonexistent/**/*.ts")
+
+	if len(result) != 0 {
+		t.Errorf("Expected empty result, got %v", result)
+	}
+	if !errors.Is(err, ErrGlobNoneMatched) {
+		t.Errorf("Expected ErrGlobNoneMatched, got %v", err)
 	}
 }
 

--- a/internal/workspace/local.go
+++ b/internal/workspace/local.go
@@ -242,19 +242,29 @@ func (c *FileSystemWorkspaceContext) Glob(pattern string) ([]string, error) {
 			return nil, fmt.Errorf("glob pattern %q failed: %w", pattern, err)
 		}
 
-		// Convert absolute paths back to relative paths within base directory
 		relativeResult := make([]string, 0, len(result))
+		skippedOutsideRoot := 0
 		for _, absPath := range result {
 			rel, err := filepath.Rel(baseDir, absPath)
 			if err != nil {
-				// Skip files that can't be made relative
 				continue
 			}
-			// Skip files outside base directory
 			if strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+				skippedOutsideRoot++
 				continue
 			}
 			relativeResult = append(relativeResult, rel)
+		}
+		if skippedOutsideRoot > 0 && len(relativeResult) == 0 {
+			return relativeResult, fmt.Errorf("pattern %q matched %d files outside project root %q: %w",
+				pattern, skippedOutsideRoot, baseDir, ErrGlobAllOutsideRoot)
+		}
+		if skippedOutsideRoot > 0 {
+			return relativeResult, fmt.Errorf("pattern %q: %d of %d matched files are outside project root %q: %w",
+				pattern, skippedOutsideRoot, len(result), baseDir, ErrGlobSomeOutsideRoot)
+		}
+		if len(result) == 0 {
+			return relativeResult, fmt.Errorf("pattern %q: %w", pattern, ErrGlobNoneMatched)
 		}
 		return relativeResult, nil
 	}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -37,6 +37,9 @@ var ErrRemoteUnsupported = fmt.Errorf("remote workspace context is not yet suppo
 var ErrNoPackageCustomElements = errors.New("package does not specify a custom elements manifest")
 var ErrManifestNotFound = errors.New("manifest not found")
 var ErrPackageNotFound = errors.New("package not found")
+var ErrGlobAllOutsideRoot = errors.New("all matched files are outside project root")
+var ErrGlobSomeOutsideRoot = errors.New("some matched files are outside project root")
+var ErrGlobNoneMatched = errors.New("no files matched glob pattern")
 
 // designTokensCacheImpl implements DesignTokensCache
 type designTokensCacheImpl struct {

--- a/lsp/registry.go
+++ b/lsp/registry.go
@@ -477,9 +477,10 @@ func (r *Registry) parseNpmYarnWorkspaces(path string, workspace types.Workspace
 
 // expandWorkspacePattern expands a glob pattern to actual directories using workspace.Glob
 func (r *Registry) expandWorkspacePattern(workspace types.WorkspaceContext, pattern string) ([]string, error) {
-	// Use workspace.Glob which supports ** doublestar patterns
+	// Glob follows the io.Reader pattern: always use matches even when err != nil.
+	// ([], err) is fatal; (matches, err) means matches are valid and err is a warning.
 	matches, err := workspace.Glob(pattern)
-	if err != nil {
+	if len(matches) == 0 && err != nil {
 		return nil, fmt.Errorf("failed to expand pattern %s: %w", pattern, err)
 	}
 
@@ -517,13 +518,7 @@ func (r *Registry) filterNegatedPackages(workspace types.WorkspaceContext, packa
 
 		excluded := false
 		for _, negPattern := range negativePatterns {
-			// Try to match the negation pattern
-			matches, err := workspace.Glob(negPattern)
-			if err != nil {
-				continue
-			}
-
-			// Check if this package matches any negation pattern
+			matches, _ := workspace.Glob(negPattern)
 			for _, match := range matches {
 				if filepath.Clean(match) == filepath.Clean(relPath) {
 					excluded = true

--- a/lsp/registry.go
+++ b/lsp/registry.go
@@ -518,7 +518,11 @@ func (r *Registry) filterNegatedPackages(workspace types.WorkspaceContext, packa
 
 		excluded := false
 		for _, negPattern := range negativePatterns {
-			matches, _ := workspace.Glob(negPattern)
+			matches, err := workspace.Glob(negPattern)
+			if len(matches) == 0 && err != nil {
+				helpers.SafeDebugLog("Warning: negation pattern %s failed: %v", negPattern, err)
+				continue
+			}
 			for _, match := range matches {
 				if filepath.Clean(match) == filepath.Clean(relPath) {
 					excluded = true


### PR DESCRIPTION
## Summary

- `Glob()` now returns sentinel errors for three distinct cases when glob patterns reference files outside the project root, instead of silently returning empty results
- All `Glob()` callers updated to follow the io.Reader pattern: always process returned matches even when error is non-nil
- Fixes the confusing "pass at least one file to generate" error when config file glob patterns legitimately match files but they're all outside the project root

## Context

When a config file specifies glob patterns like `../packages/components/**/*.ts`, `Glob()` correctly expanded them via `doublestar.Glob` but then silently dropped all results because they resolved outside the project root. Users saw only "pass at least one file to generate" with no indication of what went wrong.

The `../` filter is an intentional security boundary and is preserved. This PR surfaces clear errors so users understand what happened:

- `ErrGlobAllOutsideRoot` -- all matched files are outside project root (fatal, exit 1)
- `ErrGlobSomeOutsideRoot` -- some matched files are outside project root (warning, valid results returned)
- `ErrGlobNoneMatched` -- glob pattern matched no files at all (fatal, exit 1)

The return contract follows the `io.Reader` pattern:
- `([], err)` -- fatal, no usable results
- `(files, err)` -- files are valid, err is a warning
- `(files, nil)` -- clean success

## Test plan

- [x] Three new unit tests covering all sentinel error cases
- [x] All 4070 existing tests pass
- [x] Manual test against sl-design-system monorepo confirms clear error message
- [x] `golangci-lint run` clean

Closes #359

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved glob handling across generation, watching, and LSP: glob expansion errors no longer fail the operation when there are valid matches.
  * Demo discovery and negated package patterns now proceed with any returned matches while logging warnings/debug output as needed.
  * Glob results are now more accurate relative to the project root, with clearer outcomes for “none matched” and “matches outside root”.
* **Tests**
  * Added new coverage for glob edge cases, including sentinel error behavior verified with `errors.Is`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->