### PR TITLE
fix(lsp): prevent double-unlock panic in UpdateDocumentWithChanges

### DIFF
--- a/lsp/document/manager.go
+++ b/lsp/document/manager.go
@@ -142,20 +142,20 @@ func (dm *documentManager) UpdateDocumentWithChanges(uri, content string, versio
 	// Serialize all tree-sitter operations for this URI to prevent concurrent access
 	uriLock := dm.getURILock(uri)
 	uriLock.Lock()
-	defer uriLock.Unlock()
+
+	dm.mu.Lock()
+	doc, exists := dm.documents[uri]
+	dm.mu.Unlock()
+
+	if !exists {
+		uriLock.Unlock()
+		helpers.SafeDebugLog("[DOCUMENT] Document not found, creating new one: %s", uri)
+		return dm.OpenDocument(uri, content, version)
+	}
 
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
-
-	doc, exists := dm.documents[uri]
-	if !exists {
-		helpers.SafeDebugLog("[DOCUMENT] Document not found, creating new one: %s", uri)
-		// Note: We already hold the URI lock, OpenDocument will try to acquire it again
-		// Need to unlock before calling OpenDocument to avoid deadlock
-		dm.mu.Unlock()
-		uriLock.Unlock()
-		return dm.OpenDocument(uri, content, version)
-	}
+	defer uriLock.Unlock()
 
 	// Get the language handler for this document
 	language := getLanguageFromURI(uri)

--- a/lsp/document/manager_test.go
+++ b/lsp/document/manager_test.go
@@ -128,7 +128,18 @@ func TestDocumentManager_UpdateDocument(t *testing.T) {
 }
 
 func TestDocumentManager_UpdateCreatesIfMissing(t *testing.T) {
-	t.Skip("UpdateDocumentWithChanges has lock ordering bug when document doesn't exist (pre-existing)")
+	dm, err := document.NewDocumentManager()
+	require.NoError(t, err)
+	defer dm.Close()
+
+	doc := dm.UpdateDocument("file:///new.html", "<p>created</p>", 1)
+	require.NotNil(t, doc, "UpdateDocument on missing document should create it")
+	assert.Equal(t, "<p>created</p>", getContent(t, doc))
+	assert.Equal(t, int32(1), doc.Version())
+
+	retrieved := dm.Document("file:///new.html")
+	require.NotNil(t, retrieved, "created document should be retrievable")
+	assert.Equal(t, doc.URI(), retrieved.URI())
 }
 
 func TestDocumentManager_ReopenReplacesExisting(t *testing.T) {


### PR DESCRIPTION
## Summary

- `UpdateDocumentWithChanges` acquired two locks with deferred unlocks, then manually unlocked both before calling `OpenDocument` when the document didn't exist -- the deferred unlocks fired again on return, causing a `sync.Mutex` panic
- Restructure lock acquisition: check document existence under a brief `dm.mu` hold, release it, then either delegate to `OpenDocument` (releasing `uriLock` first) or re-acquire `dm.mu` with deferred unlocks for the update path
- Unskip `TestDocumentManager_UpdateCreatesIfMissing` which was disabled due to this bug

Fixes #362

## Test plan

- [x] `TestDocumentManager_UpdateCreatesIfMissing` unskipped and passing (previously panicked with `sync: Unlock of unlocked RWMutex`)
- [x] Full `lsp/document/...` test suite passes with `-race`
- [x] Lint clean
- [x] No regressions in existing document manager tests (open, close, update, incremental edit)