### PR TITLE
fix(serve): inject import map before any script tags

### DIFF
--- a/serve/middleware/importmap/importmap.go
+++ b/serve/middleware/importmap/importmap.go
@@ -18,12 +18,14 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package importmap
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
-	"regexp"
 	"strings"
 
 	"bennypowers.dev/cem/serve/middleware"
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
 )
 
 // MiddlewareConfig holds configuration for the import map injection middleware
@@ -113,57 +115,121 @@ func New(config MiddlewareConfig) middleware.Middleware {
 	}
 }
 
-// injectImportMap injects or replaces an import map script in HTML
-// If an import map already exists, it replaces it; otherwise it injects a new one
+// injectImportMap injects or replaces an import map in HTML using DOM parsing.
+// The import map is placed before the first <script> in <head>, or as the last
+// child of <head> if no scripts exist. Any existing import map is removed first.
 func injectImportMap(htmlStr string, importMapJSON string) string {
-	// Regex pattern to match <script type="importmap">...</script>
-	// Handles both single and double quotes, and content with newlines
-	importMapPattern := regexp.MustCompile(`(?s)<script\s+type=["']importmap["'][^>]*>.*?</script>`)
-
-	// Check if an import map already exists
-	if importMapPattern.MatchString(htmlStr) {
-		// Replace existing import map with new content
-		replacement := `<script type="importmap">
-` + importMapJSON + `
-  </script>`
-		return importMapPattern.ReplaceAllString(htmlStr, replacement)
+	doc, err := html.Parse(strings.NewReader(htmlStr))
+	if err != nil {
+		return injectImportMapFallback(htmlStr, importMapJSON)
 	}
 
-	// No existing import map found, inject a new one before </head>
-	return injectImportMapFallback(htmlStr, importMapJSON)
+	head := findElement(doc, "head")
+	if head == nil {
+		return injectImportMapFallback(htmlStr, importMapJSON)
+	}
+
+	removeExistingImportMaps(doc)
+
+	scriptTag := `<script type="importmap">` + "\n" + importMapJSON + "\n</script>"
+	newNodes, err := html.ParseFragment(strings.NewReader(scriptTag), &html.Node{
+		Type:     html.ElementNode,
+		Data:     "head",
+		DataAtom: atom.Head,
+	})
+	if err != nil || len(newNodes) == 0 {
+		return injectImportMapFallback(htmlStr, importMapJSON)
+	}
+
+	firstScript := findFirstScript(head)
+	for _, node := range newNodes {
+		if firstScript != nil {
+			head.InsertBefore(node, firstScript)
+		} else {
+			head.AppendChild(node)
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := html.Render(&buf, doc); err != nil {
+		return injectImportMapFallback(htmlStr, importMapJSON)
+	}
+	return buf.String()
 }
 
-// injectImportMapFallback uses string replacement to inject import map
-// Used when HTML parsing fails or when injecting (not replacing)
-func injectImportMapFallback(html string, importMapJSON string) string {
-	importMapScript := "<script type=\"importmap\">\n  " + importMapJSON + "\n  </script>"
+func findElement(n *html.Node, tag string) *html.Node {
+	if n.Type == html.ElementNode && n.Data == tag {
+		return n
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if result := findElement(c, tag); result != nil {
+			return result
+		}
+	}
+	return nil
+}
 
-	// Try to inject before </head>
-	if idx := strings.Index(html, "</head>"); idx != -1 {
-		return html[:idx] + importMapScript + "\n" + html[idx:]
+func isImportMapScript(n *html.Node) bool {
+	if n.Type != html.ElementNode || n.Data != "script" {
+		return false
+	}
+	for _, attr := range n.Attr {
+		if attr.Key == "type" && attr.Val == "importmap" {
+			return true
+		}
+	}
+	return false
+}
+
+func removeExistingImportMaps(root *html.Node) {
+	var toRemove []*html.Node
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			if isImportMapScript(c) {
+				toRemove = append(toRemove, c)
+			} else {
+				walk(c)
+			}
+		}
+	}
+	walk(root)
+	for _, n := range toRemove {
+		n.Parent.RemoveChild(n)
+	}
+}
+
+func findFirstScript(head *html.Node) *html.Node {
+	for c := head.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type == html.ElementNode && c.Data == "script" {
+			return c
+		}
+	}
+	return nil
+}
+
+// injectImportMapFallback uses string replacement when DOM parsing fails.
+// Inserts before the first <script> in the document, or before </head>.
+func injectImportMapFallback(htmlStr string, importMapJSON string) string {
+	importMapScript := "<script type=\"importmap\">\n" + importMapJSON + "\n</script>"
+
+	if idx := strings.Index(htmlStr, "<script"); idx != -1 {
+		return htmlStr[:idx] + importMapScript + "\n" + htmlStr[idx:]
 	}
 
-	// Fall back to start of <body>
-	if idx := strings.Index(html, "<body"); idx != -1 {
-		// Find the end of the <body> tag
-		closeIdx := strings.Index(html[idx:], ">")
+	if idx := strings.Index(htmlStr, "</head>"); idx != -1 {
+		return htmlStr[:idx] + importMapScript + "\n" + htmlStr[idx:]
+	}
+
+	if idx := strings.Index(htmlStr, "<body"); idx != -1 {
+		closeIdx := strings.Index(htmlStr[idx:], ">")
 		if closeIdx != -1 {
 			insertPos := idx + closeIdx + 1
-			return html[:insertPos] + "\n" + importMapScript + html[insertPos:]
+			return htmlStr[:insertPos] + "\n" + importMapScript + htmlStr[insertPos:]
 		}
 	}
 
-	// Last resort: inject at start of HTML
-	if idx := strings.Index(html, "<html"); idx != -1 {
-		closeIdx := strings.Index(html[idx:], ">")
-		if closeIdx != -1 {
-			insertPos := idx + closeIdx + 1
-			return html[:insertPos] + "\n" + importMapScript + html[insertPos:]
-		}
-	}
-
-	// Can't find a good place, return unchanged
-	return html
+	return htmlStr
 }
 
 // writeResponse writes the recorded response to the ResponseWriter

--- a/serve/middleware/importmap/types_test.go
+++ b/serve/middleware/importmap/types_test.go
@@ -17,6 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package importmap
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,42 +65,66 @@ func TestDependencyGraph_Dependents(t *testing.T) {
 
 func TestInjectImportMap(t *testing.T) {
 	t.Run("replaces existing import map", func(t *testing.T) {
-		html := `<head><script type="importmap">{"imports":{}}</script></head>`
-		result := injectImportMap(html, `{"imports":{"lit":"/lit.js"}}`)
+		input := `<html><head><script type="importmap">{"imports":{}}</script></head><body></body></html>`
+		result := injectImportMap(input, `{"imports":{"lit":"/lit.js"}}`)
 		assert.Contains(t, result, `{"imports":{"lit":"/lit.js"}}`)
 		assert.NotContains(t, result, `{"imports":{}}`)
 	})
 
-	t.Run("injects before head close", func(t *testing.T) {
-		html := `<html><head><title>Test</title></head><body></body></html>`
-		result := injectImportMap(html, `{"imports":{}}`)
+	t.Run("injects before existing scripts", func(t *testing.T) {
+		input := `<html><head><title>Test</title><script type="module" src="/app.js"></script></head><body></body></html>`
+		result := injectImportMap(input, `{"imports":{}}`)
+		importMapIdx := strings.Index(result, `<script type="importmap">`)
+		scriptIdx := strings.Index(result, `<script type="module"`)
+		assert.Greater(t, importMapIdx, -1, "import map should be present")
+		assert.Greater(t, scriptIdx, -1, "module script should be present")
+		assert.Less(t, importMapIdx, scriptIdx, "import map must appear before module script")
+	})
+
+	t.Run("appends to head when no scripts", func(t *testing.T) {
+		input := `<html><head><title>Test</title><link rel="stylesheet" href="/style.css"></head><body></body></html>`
+		result := injectImportMap(input, `{"imports":{}}`)
 		assert.Contains(t, result, `<script type="importmap">`)
-		assert.Contains(t, result, `</head>`)
+		importMapIdx := strings.Index(result, `<script type="importmap">`)
+		headCloseIdx := strings.Index(result, `</head>`)
+		assert.Less(t, importMapIdx, headCloseIdx, "import map should be inside head")
+	})
+
+	t.Run("replaces existing and keeps before scripts", func(t *testing.T) {
+		input := `<html><head><script type="module" src="/a.js"></script><script type="importmap">{"old":true}</script></head><body></body></html>`
+		result := injectImportMap(input, `{"imports":{"new":"/new.js"}}`)
+		importMapIdx := strings.Index(result, `<script type="importmap">`)
+		scriptIdx := strings.Index(result, `<script type="module"`)
+		assert.Less(t, importMapIdx, scriptIdx, "import map must appear before module script even after replacement")
+		assert.NotContains(t, result, `"old"`)
 	})
 }
 
 func TestInjectImportMapFallback(t *testing.T) {
-	t.Run("injects before head close", func(t *testing.T) {
-		html := `<html><head></head><body></body></html>`
-		result := injectImportMapFallback(html, `{}`)
+	t.Run("injects before first script in head", func(t *testing.T) {
+		input := `<html><head><script src="/app.js"></script></head><body></body></html>`
+		result := injectImportMapFallback(input, `{}`)
+		importMapIdx := strings.Index(result, `<script type="importmap">`)
+		scriptIdx := strings.Index(result, `<script src="/app.js">`)
+		assert.Greater(t, importMapIdx, -1)
+		assert.Less(t, importMapIdx, scriptIdx)
+	})
+
+	t.Run("injects before head close when no scripts", func(t *testing.T) {
+		input := `<html><head><title>T</title></head><body></body></html>`
+		result := injectImportMapFallback(input, `{}`)
 		assert.Contains(t, result, `<script type="importmap">`)
 	})
 
 	t.Run("falls back to body", func(t *testing.T) {
-		html := `<html><body>content</body></html>`
-		result := injectImportMapFallback(html, `{}`)
-		assert.Contains(t, result, `<script type="importmap">`)
-	})
-
-	t.Run("falls back to html tag", func(t *testing.T) {
-		html := `<html>content</html>`
-		result := injectImportMapFallback(html, `{}`)
+		input := `<html><body>content</body></html>`
+		result := injectImportMapFallback(input, `{}`)
 		assert.Contains(t, result, `<script type="importmap">`)
 	})
 
 	t.Run("no suitable location returns unchanged", func(t *testing.T) {
-		html := `just text`
-		result := injectImportMapFallback(html, `{}`)
-		assert.Equal(t, html, result)
+		input := `just text`
+		result := injectImportMapFallback(input, `{}`)
+		assert.Equal(t, input, result)
 	})
 }


### PR DESCRIPTION
## Summary

Closes #356

Browsers require `<script type="importmap">` to appear before any `<script>` tags. The middleware was using regex to inject/replace import maps, which could place them after existing scripts.

- Rewrite `injectImportMap` to use `golang.org/x/net/html` DOM parser (matches pattern in `inject/html.go`)
- Remove any existing import map scripts, then insert new one before the first `<script>` in `<head>` (or as last child of `<head>` if no scripts exist)
- Fix string-based fallback to also insert before first `<script>` instead of before `</head>`
- Replace regexp-based HTML manipulation with proper DOM parser per CLAUDE.md

## Test plan

- [x] `make test-unit` -- 4125 tests pass
- [x] `make test-e2e` -- 105 tests pass  
- [x] `make lint` -- 0 issues
- [x] New tests verify ordering: import map before module scripts, replacement preserves ordering, fallback inserts before scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved import-map injection reliability through enhanced HTML processing with fallback mechanisms for edge cases.

* **Tests**
  * Updated validation to confirm correct import-map placement relative to existing scripts and improved fallback behavior coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->