### PR TITLE
feat(serve): warn when CSS imported without import attributes

### DIFF
--- a/serve/middleware/transform/css.go
+++ b/serve/middleware/transform/css.go
@@ -158,7 +158,7 @@ func NewCSS(config CSSConfig) middleware.Middleware {
 			if !hasImportAttrs && r.Header.Get("Sec-Fetch-Dest") == "empty" {
 				cssPathNorm := strings.TrimPrefix(requestPath, "/")
 				if !shouldTransformCSS(cssPathNorm, config.Include, config.Exclude, nil, nil, "") {
-					if _, alreadyWarned := warnedPaths.LoadOrStore(requestPath, true); !alreadyWarned && config.Logger != nil {
+					if _, alreadyWarned := warnedPaths.LoadOrStore(cssPathNorm, true); !alreadyWarned && config.Logger != nil {
 						config.Logger.Warning("%s: CSS imported without `with { type: 'css' }` import attribute", requestPath)
 					}
 				}

--- a/serve/middleware/transform/css.go
+++ b/serve/middleware/transform/css.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"bennypowers.dev/cem/internal/platform"
 	"bennypowers.dev/cem/serve/middleware"
@@ -128,6 +129,8 @@ func NewCSS(config CSSConfig) middleware.Middleware {
 		fs = platform.NewOSFileSystem()
 	}
 
+	var warnedPaths sync.Map
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			requestPath := r.URL.Path
@@ -146,6 +149,18 @@ func NewCSS(config CSSConfig) middleware.Middleware {
 				if strings.HasPrefix(key, "__cem-import-attrs[") {
 					hasImportAttrs = true
 					break
+				}
+			}
+
+			// Warn when CSS is imported from JS without import attributes
+			// and not covered by serve.transforms.css include patterns.
+			// Sec-Fetch-Dest: "empty" indicates a JS module import (not <link> or @import).
+			if !hasImportAttrs && r.Header.Get("Sec-Fetch-Dest") == "empty" {
+				cssPathNorm := strings.TrimPrefix(requestPath, "/")
+				if !shouldTransformCSS(cssPathNorm, config.Include, config.Exclude, nil, nil, "") {
+					if _, alreadyWarned := warnedPaths.LoadOrStore(requestPath, true); !alreadyWarned && config.Logger != nil {
+						config.Logger.Warning("%s: CSS imported without `with { type: 'css' }` import attribute", requestPath)
+					}
 				}
 			}
 

--- a/serve/middleware/transform/css_glob_test.go
+++ b/serve/middleware/transform/css_glob_test.go
@@ -317,3 +317,134 @@ func TestCSSGlobFiltering_E2E(t *testing.T) {
 		})
 	}
 }
+
+func TestCSS_WarnsWithoutImportAttributes(t *testing.T) {
+	mfs := platform.NewMapFileSystem(nil)
+	mfs.AddFile("/test-root/elements/button.css", ":host { color: red; }", 0644)
+
+	var warnings []string
+	logger := &mockLogger{
+		warningFunc: func(msg string, args ...any) {
+			warnings = append(warnings, msg)
+		},
+	}
+
+	mw := transform.NewCSS(transform.CSSConfig{
+		WatchDirFunc:     func() string { return "/test-root" },
+		Logger:           logger,
+		ErrorBroadcaster: &mockErrorBroadcaster{},
+		Enabled:          true,
+		Include:          nil,
+		FS:               mfs,
+	})
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/css")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(":host { color: red; }"))
+	})
+
+	handler := mw(next)
+
+	t.Run("warns on JS module import without import attributes", func(t *testing.T) {
+		warnings = nil
+		req := httptest.NewRequest("GET", "/elements/button.css", nil)
+		req.Header.Set("Sec-Fetch-Dest", "empty")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if len(warnings) == 0 {
+			t.Error("Expected warning for CSS import without import attributes")
+		}
+	})
+
+	t.Run("no warning on stylesheet request", func(t *testing.T) {
+		warnings = nil
+		req := httptest.NewRequest("GET", "/elements/button.css", nil)
+		req.Header.Set("Sec-Fetch-Dest", "style")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if len(warnings) > 0 {
+			t.Errorf("Should not warn on <link> stylesheet request, got: %v", warnings)
+		}
+	})
+
+	t.Run("no warning when import attributes present", func(t *testing.T) {
+		warnings = nil
+		req := httptest.NewRequest("GET", "/elements/button.css?__cem-import-attrs%5Btype%5D=css", nil)
+		req.Header.Set("Sec-Fetch-Dest", "empty")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if len(warnings) > 0 {
+			t.Errorf("Should not warn when import attributes present, got: %v", warnings)
+		}
+	})
+
+	t.Run("no warning when covered by CSS transform include patterns", func(t *testing.T) {
+		mfs2 := platform.NewMapFileSystem(nil)
+		mfs2.AddFile("/test-root/elements/button.css", ":host { color: red; }", 0644)
+
+		var warnings2 []string
+		logger2 := &mockLogger{
+			warningFunc: func(msg string, args ...any) {
+				warnings2 = append(warnings2, msg)
+			},
+		}
+
+		mw2 := transform.NewCSS(transform.CSSConfig{
+			WatchDirFunc:     func() string { return "/test-root" },
+			Logger:           logger2,
+			ErrorBroadcaster: &mockErrorBroadcaster{},
+			Enabled:          true,
+			Include:          []string{"elements/**/*.css"},
+			FS:               mfs2,
+		})
+
+		handler2 := mw2(next)
+
+		req := httptest.NewRequest("GET", "/elements/button.css", nil)
+		req.Header.Set("Sec-Fetch-Dest", "empty")
+		rec := httptest.NewRecorder()
+		handler2.ServeHTTP(rec, req)
+
+		if len(warnings2) > 0 {
+			t.Errorf("Should not warn when file covered by CSS transform include, got: %v", warnings2)
+		}
+	})
+
+	t.Run("warns only once per file", func(t *testing.T) {
+		mfs3 := platform.NewMapFileSystem(nil)
+		mfs3.AddFile("/test-root/elements/card.css", ":host { display: block; }", 0644)
+
+		var warnings3 []string
+		logger3 := &mockLogger{
+			warningFunc: func(msg string, args ...any) {
+				warnings3 = append(warnings3, msg)
+			},
+		}
+
+		mw3 := transform.NewCSS(transform.CSSConfig{
+			WatchDirFunc:     func() string { return "/test-root" },
+			Logger:           logger3,
+			ErrorBroadcaster: &mockErrorBroadcaster{},
+			Enabled:          true,
+			Include:          nil,
+			FS:               mfs3,
+		})
+
+		handler3 := mw3(next)
+
+		for range 3 {
+			req := httptest.NewRequest("GET", "/elements/card.css", nil)
+			req.Header.Set("Sec-Fetch-Dest", "empty")
+			rec := httptest.NewRecorder()
+			handler3.ServeHTTP(rec, req)
+		}
+
+		if len(warnings3) != 1 {
+			t.Errorf("Expected exactly 1 warning (deduped), got %d", len(warnings3))
+		}
+	})
+}

--- a/serve/middleware/transform/css_glob_test.go
+++ b/serve/middleware/transform/css_glob_test.go
@@ -318,6 +318,7 @@ func TestCSSGlobFiltering_E2E(t *testing.T) {
 	}
 }
 
+// Inline: testing middleware warning side effects (logger callback counts), not output content
 func TestCSS_WarnsWithoutImportAttributes(t *testing.T) {
 	mfs := platform.NewMapFileSystem(nil)
 	mfs.AddFile("/test-root/elements/button.css", ":host { color: red; }", 0644)

--- a/serve/serve_transform_test.go
+++ b/serve/serve_transform_test.go
@@ -260,13 +260,6 @@ func TestServeCSS_TransformsToModule(t *testing.T) {
 	}
 }
 
-// TestServeCSS_WarnsWithoutImportAttribute tests warning for CSS imports without 'with { type: "css" }'
-func TestServeCSS_WarnsWithoutImportAttribute(t *testing.T) {
-	t.Skip("Warning implementation TBD - need to detect import context")
-	// This test verifies that when CSS is imported without `with { type: 'css' }`,
-	// the server logs a warning. Implementation requires examining the referrer
-	// to detect how the CSS is being imported.
-}
 
 // TestServeCSS_RejectsPathTraversal tests that path traversal attacks are blocked
 func TestServeCSS_RejectsPathTraversal(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #363

When a `.css` file is requested via JS module import without `with { type: 'css' }` import attributes, the dev server now emits a warning. This catches cases where CSS works in the dev server (which handles the transform) but would fail in production browsers.

The warning is suppressed when:
- Import attributes are present (`__cem-import-attrs` query param)
- The file is covered by `serve.transforms.css` include patterns (intentionally bare-imported)
- The request is a stylesheet fetch (`Sec-Fetch-Dest: style`), not a JS import
- The file was already warned about (`sync.Map` dedup, zero cost on repeat requests)

Also removes the skipped test stub (`TestServeCSS_WarnsWithoutImportAttribute`) in favor of unit tests.

## Test plan

- [x] `make test-unit` -- 4130 tests, 0 skipped
- [x] `make test-e2e` -- 105 tests pass
- [x] `make lint` -- 0 issues
- [x] Tests verify: warn on bare JS import, no warn on stylesheet, no warn with attrs, no warn when covered by CSS transform include, dedup (warn once)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSS files imported as JavaScript modules without proper import attributes now emit warnings to guide developers toward correct syntax. Warnings are deduplicated per file path.

* **Tests**
  * Added comprehensive test coverage for CSS import attribute validation, including warning deduplication scenarios and various import contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->