### PR TITLE
feat(mcp): add config resources and tools

### DIFF
--- a/cmd/config_cmd.go
+++ b/cmd/config_cmd.go
@@ -72,7 +72,7 @@ var configValidateCmd = &cobra.Command{
 			},
 		})
 
-		allErrs := deduplicateErrors(schemaErrs, semanticErrs)
+		allErrs := IC.DeduplicateErrors(schemaErrs, semanticErrs)
 
 		if len(allErrs) > 0 {
 			enrichPositions(allErrs, rawData, cfgFormat)
@@ -86,35 +86,6 @@ var configValidateCmd = &cobra.Command{
 			return printConfigValidationText(cmd, cfgFile, rawData, allErrs)
 		}
 	},
-}
-
-// deduplicateErrors removes redundant schema errors when a semantic error
-// covers the same field with the same severity. Multiple errors on the same
-// field are preserved when they differ in severity or message substance.
-// Schema errors (first half of the slice) are identified by lacking a Value
-// field; semantic errors (second half) provide richer context.
-func deduplicateErrors(schemaErrs, semanticErrs []IC.ValidationError) []IC.ValidationError {
-	type key struct {
-		field    string
-		severity IC.ValidationSeverity
-	}
-	normalize := func(s IC.ValidationSeverity) IC.ValidationSeverity {
-		if s == "" {
-			return IC.SeverityError
-		}
-		return s
-	}
-	semanticFields := make(map[key]bool, len(semanticErrs))
-	for _, e := range semanticErrs {
-		semanticFields[key{e.Field, normalize(e.Severity)}] = true
-	}
-	var result []IC.ValidationError
-	for _, e := range schemaErrs {
-		if !semanticFields[key{e.Field, normalize(e.Severity)}] {
-			result = append(result, e)
-		}
-	}
-	return append(result, semanticErrs...)
 }
 
 func splitBySeverity(errs []IC.ValidationError) (errors, warnings []IC.ValidationError) {

--- a/cmd/config_validate_unit_test.go
+++ b/cmd/config_validate_unit_test.go
@@ -10,7 +10,7 @@ import (
 // pure logic with no I/O dependencies.
 
 func TestDeduplicateErrors_BothEmpty(t *testing.T) {
-	result := deduplicateErrors(nil, nil)
+	result := IC.DeduplicateErrors(nil, nil)
 	if len(result) != 0 {
 		t.Errorf("expected empty, got %v", result)
 	}
@@ -21,7 +21,7 @@ func TestDeduplicateErrors_SchemaOnly(t *testing.T) {
 		{Field: "a", Message: "type error"},
 		{Field: "b", Message: "enum error"},
 	}
-	result := deduplicateErrors(schema, nil)
+	result := IC.DeduplicateErrors(schema, nil)
 	if len(result) != 2 {
 		t.Fatalf("expected 2, got %d", len(result))
 	}
@@ -34,7 +34,7 @@ func TestDeduplicateErrors_SemanticReplacesSchema(t *testing.T) {
 	semantic := []IC.ValidationError{
 		{Field: "serve.port", Message: "must be between 0 and 65535", Value: "99999", Severity: IC.SeverityError},
 	}
-	result := deduplicateErrors(schema, semantic)
+	result := IC.DeduplicateErrors(schema, semantic)
 	if len(result) != 1 {
 		t.Fatalf("expected 1 after dedup, got %d", len(result))
 	}
@@ -48,7 +48,7 @@ func TestDeduplicateErrors_PreservesMultipleSchemaOnSameField(t *testing.T) {
 		{Field: "serve.port", Message: "type error", Severity: IC.SeverityError},
 		{Field: "serve.port", Message: "range warning", Severity: IC.SeverityWarning},
 	}
-	result := deduplicateErrors(schema, nil)
+	result := IC.DeduplicateErrors(schema, nil)
 	if len(result) != 2 {
 		t.Fatalf("expected 2 (different severities preserved), got %d", len(result))
 	}
@@ -61,7 +61,7 @@ func TestDeduplicateErrors_PreservesDifferentSeverities(t *testing.T) {
 	semantic := []IC.ValidationError{
 		{Field: "serve.port", Message: "semantic warning", Severity: IC.SeverityWarning},
 	}
-	result := deduplicateErrors(schema, semantic)
+	result := IC.DeduplicateErrors(schema, semantic)
 	if len(result) != 2 {
 		t.Fatalf("expected 2 (error + warning preserved), got %d", len(result))
 	}
@@ -74,7 +74,7 @@ func TestDeduplicateErrors_PreservesRootErrors(t *testing.T) {
 	semantic := []IC.ValidationError{
 		{Field: "(root)", Message: "another root error"},
 	}
-	result := deduplicateErrors(schema, semantic)
+	result := IC.DeduplicateErrors(schema, semantic)
 	if len(result) != 1 {
 		t.Fatalf("expected 1 (same field+severity deduped), got %d", len(result))
 	}
@@ -87,7 +87,7 @@ func TestDeduplicateErrors_NormalizesEmptySeverity(t *testing.T) {
 	semantic := []IC.ValidationError{
 		{Field: "serve.port", Message: "must be between 0 and 65535", Value: "99999"},
 	}
-	result := deduplicateErrors(schema, semantic)
+	result := IC.DeduplicateErrors(schema, semantic)
 	if len(result) != 1 {
 		t.Fatalf("expected 1 after dedup with empty severity, got %d", len(result))
 	}

--- a/internal/config/cem-config.schema.json
+++ b/internal/config/cem-config.schema.json
@@ -8,20 +8,20 @@
   "properties": {
     "projectDir": {
       "type": "string",
-      "description": "Root directory of the project"
+      "description": "Root directory of the project. Resolved automatically from the config file location when not set."
     },
     "configFile": {
       "type": "string",
-      "description": "Path to the config file"
+      "description": "Path to the config file. Normally resolved automatically; set only when overriding via CLI."
     },
     "packageName": {
       "type": "string",
-      "description": "Package name override"
+      "description": "Override the package name used in the generated manifest. Defaults to the name field in package.json."
     },
     "sourceControlRootUrl": {
       "type": "string",
       "format": "uri",
-      "description": "Root URL for source control links"
+      "description": "Base URL for linking manifest entries to source code (e.g. https://github.com/org/repo/blob/main)."
     },
     "verbose": {
       "type": "boolean",
@@ -31,17 +31,17 @@
     "logLevel": {
       "type": "string",
       "enum": ["error", "warn", "success", "info", "debug", "trace"],
-      "description": "Set the minimum log level. Overrides verbose if both are set."
+      "description": "Minimum log level. Overrides verbose if both are set."
     },
     "additionalPackages": {
       "type": "array",
       "items": { "type": "string" },
-      "description": "Additional packages to analyze"
+      "description": "Extra packages to load manifests from (npm:, jsr:, or URL specifiers). Useful for consuming design system elements without local source."
     },
     "generate": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Manifest generation settings",
+      "description": "Controls how cem generates custom-elements.json manifests from source files.",
       "properties": {
         "files": {
           "type": "array",
@@ -49,7 +49,7 @@
             "type": "string",
             "format": "x-glob-pattern"
           },
-          "description": "Glob patterns for source files to analyze"
+          "description": "Glob patterns for source files cem scans for custom element definitions. At least one pattern is required for generation."
         },
         "exclude": {
           "type": "array",
@@ -57,50 +57,50 @@
             "type": "string",
             "format": "x-glob-pattern"
           },
-          "description": "Glob patterns for files to exclude"
+          "description": "Glob patterns for files to skip during generation. By default, **/*.d.ts files are excluded."
         },
         "noDefaultExcludes": {
           "type": "boolean",
-          "description": "Disable default exclusion patterns"
+          "description": "When true, disables the default **/*.d.ts exclusion pattern, so declaration files are also scanned."
         },
         "output": {
           "type": "string",
-          "description": "Output file path for the manifest"
+          "description": "Output path for the generated manifest. Falls back to the customElements field in package.json, or stdout if neither is set."
         },
         "designTokens": {
           "type": "object",
           "additionalProperties": false,
-          "description": "Design tokens configuration",
+          "description": "Merges DTCG design token metadata (descriptions, syntax, defaults) into matching CSS custom properties in the manifest.",
           "properties": {
             "spec": {
               "type": "string",
-              "description": "Path or URL to design tokens specification"
+              "description": "Path or specifier (npm:, jsr:, URL) to a DTCG design tokens JSON file. Token names are matched to CSS custom property names in the manifest."
             },
             "prefix": {
               "type": "string",
-              "description": "Prefix for generated CSS custom properties"
+              "description": "Prefix prepended to token names when matching against CSS custom properties (e.g. 'rh' matches token 'color-brand' to '--rh-color-brand')."
             }
           }
         },
         "demoDiscovery": {
           "type": "object",
           "additionalProperties": false,
-          "description": "Demo file discovery settings",
+          "description": "Discovers demo HTML files and associates them with elements in the manifest. Demos can declare associations via frontmatter, URL pattern matching, or content-based tag detection.",
           "properties": {
             "fileGlob": {
               "type": "string",
               "format": "x-glob-pattern",
-              "description": "Glob pattern for demo files"
+              "description": "Glob pattern for finding demo HTML files. When empty, demo discovery is skipped entirely."
             },
             "urlPattern": {
               "type": "string",
               "format": "x-url-pattern",
-              "description": "URL pattern for matching demo URLs"
+              "description": "WHATWG URLPattern for extracting parameters from demo file paths. Parameter values are matched against element tag names to infer associations."
             },
             "urlTemplate": {
               "type": "string",
               "format": "x-go-template",
-              "description": "Go template for generating demo URLs"
+              "description": "Go template for generating demo URLs from matched parameters (e.g. '/demos/{{.tagName}}/')."
             }
           }
         }
@@ -109,40 +109,40 @@
     "serve": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Dev server settings",
+      "description": "Configures the cem dev server for previewing components with live reload, import maps, and source transforms.",
       "properties": {
         "port": {
           "type": "integer",
           "minimum": 0,
           "maximum": 65535,
-          "description": "Server port number"
+          "description": "Port the dev server listens on. Use 0 for automatic port assignment."
         },
         "openBrowser": {
           "type": "boolean",
-          "description": "Open browser on startup"
+          "description": "Automatically open a browser tab when the dev server starts."
         },
         "importMap": {
           "type": "object",
           "additionalProperties": false,
-          "description": "Import map configuration",
+          "description": "Controls the import map injected into served HTML pages, enabling bare specifier resolution (e.g. import 'lit').",
           "properties": {
             "generate": {
               "type": "boolean",
-              "description": "Auto-generate import map"
+              "description": "When true, auto-generates an import map from node_modules package.json exports. Generated entries are merged with overrides, where overrides take precedence."
             },
             "overrideFile": {
               "type": "string",
-              "description": "Path to import map override file"
+              "description": "Path to a JSON file with manual import map overrides (standard { imports: {}, scopes: {} } format). Merged with auto-generated map."
             },
             "override": {
               "type": "object",
               "additionalProperties": false,
-              "description": "Inline import map overrides",
+              "description": "Inline import map overrides. Same format and merge behavior as overrideFile, but specified directly in config.",
               "properties": {
                 "imports": {
                   "type": "object",
                   "additionalProperties": { "type": "string" },
-                  "description": "Import specifier mappings"
+                  "description": "Bare specifier to URL mappings (e.g. { \"lit\": \"/node_modules/lit/index.js\" })."
                 },
                 "scopes": {
                   "type": "object",
@@ -150,7 +150,7 @@
                     "type": "object",
                     "additionalProperties": { "type": "string" }
                   },
-                  "description": "Scoped import specifier mappings"
+                  "description": "Scope-specific import overrides, keyed by URL prefix."
                 }
               }
             }
@@ -159,16 +159,16 @@
         "transforms": {
           "type": "object",
           "additionalProperties": false,
-          "description": "Source transform settings",
+          "description": "On-the-fly source transforms applied when the dev server serves files.",
           "properties": {
             "typescript": {
               "type": "object",
               "additionalProperties": false,
-              "description": "TypeScript transform settings",
+              "description": "Transforms .ts files to JavaScript on-the-fly. Uses tsconfig.json for compiler options when available.",
               "properties": {
                 "enabled": {
                   "type": "boolean",
-                  "description": "Enable TypeScript transformation"
+                  "description": "Enable TypeScript-to-JavaScript transformation for served .ts files."
                 },
                 "target": {
                   "type": "string",
@@ -176,18 +176,18 @@
                     "es2015", "es2016", "es2017", "es2018", "es2019",
                     "es2020", "es2021", "es2022", "es2023", "esnext"
                   ],
-                  "description": "ES target version"
+                  "description": "ECMAScript target version for TypeScript output. Defaults to es2022."
                 }
               }
             },
             "css": {
               "type": "object",
               "additionalProperties": false,
-              "description": "CSS transform settings",
+              "description": "Transforms CSS files into JavaScript modules for import with import attributes. Only files matching include patterns are transformed.",
               "properties": {
                 "enabled": {
                   "type": "boolean",
-                  "description": "Enable CSS transformation"
+                  "description": "Enable CSS-to-JS module transformation. Files must also match include patterns to be transformed."
                 },
                 "include": {
                   "type": "array",
@@ -195,7 +195,7 @@
                     "type": "string",
                     "format": "x-glob-pattern"
                   },
-                  "description": "Glob patterns for CSS files to include"
+                  "description": "Glob patterns for CSS files to transform. No files are transformed unless at least one include pattern is specified."
                 },
                 "exclude": {
                   "type": "array",
@@ -203,7 +203,7 @@
                     "type": "string",
                     "format": "x-glob-pattern"
                   },
-                  "description": "Glob patterns for CSS files to exclude"
+                  "description": "Glob patterns for CSS files to skip. Excludes take precedence over includes."
                 }
               }
             }
@@ -211,7 +211,7 @@
         },
         "urlRewrites": {
           "type": "array",
-          "description": "URL rewrite rules for the dev server",
+          "description": "Maps request URLs to different file paths. Uses WHATWG URLPattern for matching and Go templates for rewriting. First match wins.",
           "items": {
             "type": "object",
             "additionalProperties": false,
@@ -219,12 +219,12 @@
               "urlPattern": {
                 "type": "string",
                 "format": "x-url-pattern",
-                "description": "URL pattern to match"
+                "description": "WHATWG URLPattern with named parameters (e.g. '/dist/:path*')."
               },
               "urlTemplate": {
                 "type": "string",
                 "format": "x-go-template",
-                "description": "Go template for the rewritten URL"
+                "description": "Go template producing the rewritten path (e.g. '/src/{{.path}}')."
               }
             }
           }
@@ -232,12 +232,12 @@
         "demos": {
           "type": "object",
           "additionalProperties": false,
-          "description": "Demo rendering configuration",
+          "description": "Controls how component demos are rendered in the dev server UI.",
           "properties": {
             "rendering": {
               "type": "string",
               "enum": ["light", "shadow", "iframe", "chromeless"],
-              "description": "Demo rendering mode"
+              "description": "Demo rendering mode: light (default, no encapsulation), shadow (Shadow DOM boundary), iframe (full isolation), chromeless (no dev server chrome)."
             }
           }
         }
@@ -246,55 +246,55 @@
     "mcp": {
       "type": "object",
       "additionalProperties": false,
-      "description": "MCP server settings",
+      "description": "Settings for the MCP (Model Context Protocol) server that provides custom element context to AI tools.",
       "properties": {
         "maxDescriptionLength": {
           "type": "integer",
           "minimum": 0,
-          "description": "Maximum description length for MCP resources"
+          "description": "Truncate element descriptions to this many characters in MCP responses. Defaults to 2000."
         }
       }
     },
     "health": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Health check settings",
+      "description": "Configures cem health checks that score manifest completeness and documentation quality.",
       "properties": {
         "failBelow": {
           "type": "integer",
           "minimum": 0,
           "maximum": 100,
-          "description": "Health score threshold (percentage)"
+          "description": "Minimum health score percentage. The health command exits with an error if the score falls below this threshold."
         },
         "disable": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "List of health checks to disable"
+          "description": "Health check rule IDs to skip. Available rules: description, attributes, slots, css, events, demos."
         }
       }
     },
     "export": {
       "type": "object",
-      "description": "Framework export configurations",
+      "description": "Named framework export configurations. Each key is an export name, and its value defines how to generate framework-specific wrappers from the manifest.",
       "additionalProperties": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
           "output": {
             "type": "string",
-            "description": "Output directory"
+            "description": "Directory where generated framework wrapper files are written."
           },
           "stripPrefix": {
             "type": "string",
-            "description": "Prefix to strip from paths"
+            "description": "Prefix to remove from element tag names when generating wrapper names."
           },
           "packageName": {
             "type": "string",
-            "description": "Package name for the export"
+            "description": "Package name used in generated import statements."
           },
           "moduleName": {
             "type": "string",
-            "description": "Module name for the export"
+            "description": "Module name used in generated wrapper code."
           }
         }
       }

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"cmp"
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"slices"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -18,6 +20,43 @@ import (
 
 //go:embed cem-config.schema.json
 var configSchemaJSON []byte
+
+func SchemaJSON() []byte { return configSchemaJSON }
+
+// SchemaSection describes a top-level property in the config schema.
+type SchemaSection struct {
+	Key         string
+	Description string
+}
+
+var schemaSections []SchemaSection
+var schemaSectionSet map[string]bool
+
+func init() {
+	var schema struct {
+		Properties map[string]struct {
+			Description string `json:"description"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(configSchemaJSON, &schema); err != nil {
+		return
+	}
+	keys := make([]string, 0, len(schema.Properties))
+	for k := range schema.Properties {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	schemaSections = make([]SchemaSection, len(keys))
+	schemaSectionSet = make(map[string]bool, len(keys))
+	for i, k := range keys {
+		schemaSections[i] = SchemaSection{Key: k, Description: schema.Properties[k].Description}
+		schemaSectionSet[k] = true
+	}
+}
+
+func SchemaSections() []SchemaSection { return schemaSections }
+
+func IsSchemaSection(name string) bool { return schemaSectionSet[name] }
 
 var englishPrinter = message.NewPrinter(language.English)
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -39,7 +39,7 @@ func init() {
 		} `json:"properties"`
 	}
 	if err := json.Unmarshal(configSchemaJSON, &schema); err != nil {
-		return
+		panic(fmt.Sprintf("embedded config schema is invalid JSON: %v", err))
 	}
 	keys := make([]string, 0, len(schema.Properties))
 	for k := range schema.Properties {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -411,3 +411,29 @@ func validateOutputMismatch(cfg *CemConfig, opts ValidateOptions) []ValidationEr
 }
 
 var _ error = ValidationError{}
+
+// DeduplicateErrors removes redundant schema errors when a semantic error
+// covers the same field with the same severity.
+func DeduplicateErrors(schemaErrs, semanticErrs []ValidationError) []ValidationError {
+	type key struct {
+		field    string
+		severity ValidationSeverity
+	}
+	normalize := func(s ValidationSeverity) ValidationSeverity {
+		if s == "" {
+			return SeverityError
+		}
+		return s
+	}
+	semanticFields := make(map[key]bool, len(semanticErrs))
+	for _, e := range semanticErrs {
+		semanticFields[key{e.Field, normalize(e.Severity)}] = true
+	}
+	var result []ValidationError
+	for _, e := range schemaErrs {
+		if !semanticFields[key{e.Field, normalize(e.Severity)}] {
+			result = append(result, e)
+		}
+	}
+	return append(result, semanticErrs...)
+}

--- a/internal/workspace/local.go
+++ b/internal/workspace/local.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	C "bennypowers.dev/cem/cmd/config"
 	DT "bennypowers.dev/cem/internal/designtokens"
@@ -44,11 +45,12 @@ type FileSystemWorkspaceContext struct {
 	root                       string
 	configFilePath             string
 	config                     *C.CemConfig
+	configErr                  error
+	configMu                   sync.RWMutex
 	customElementsManifestPath string
-	// Cache parsed results if desired
-	manifest          *M.Package
-	packageJSON       *M.PackageJSON
-	designTokensCache types.DesignTokensCache
+	manifest                   *M.Package
+	packageJSON                *M.PackageJSON
+	designTokensCache          types.DesignTokensCache
 }
 
 func (c *FileSystemWorkspaceContext) initConfig() (*C.CemConfig, error) {
@@ -155,7 +157,33 @@ func (c *FileSystemWorkspaceContext) PackageJSON() (*M.PackageJSON, error) {
 }
 
 func (c *FileSystemWorkspaceContext) Config() (*C.CemConfig, error) {
-	return c.config, nil
+	c.configMu.RLock()
+	if c.config != nil || c.configErr != nil {
+		cfg, err := c.config, c.configErr
+		c.configMu.RUnlock()
+		return cfg, err
+	}
+	c.configMu.RUnlock()
+
+	c.configMu.Lock()
+	defer c.configMu.Unlock()
+	if c.config != nil || c.configErr != nil {
+		return c.config, c.configErr
+	}
+	cfg, err := c.initConfig()
+	if err != nil {
+		c.configErr = err
+		return nil, err
+	}
+	c.config = cfg
+	return cfg, nil
+}
+
+func (c *FileSystemWorkspaceContext) InvalidateConfig() {
+	c.configMu.Lock()
+	c.config = nil
+	c.configErr = nil
+	c.configMu.Unlock()
 }
 
 func (c *FileSystemWorkspaceContext) CustomElementsManifestPath() string {

--- a/lsp/registry.go
+++ b/lsp/registry.go
@@ -1128,6 +1128,11 @@ func (r *Registry) AddManifestPath(path string) {
 	r.addManifestPath(path)
 }
 
+// AddWatchPath adds a file path to the watch list without treating it as a manifest.
+func (r *Registry) AddWatchPath(path string) {
+	r.addWatchPath(path)
+}
+
 // ReloadManifestsDirectly bypasses workspace caching by directly reading manifest files from disk
 // This is used when manifest files change and we need to force a fresh read
 func (r *Registry) ReloadManifestsDirectly() error {

--- a/mcp/context.go
+++ b/mcp/context.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 
+	IC "bennypowers.dev/cem/internal/config"
 	LSP "bennypowers.dev/cem/lsp"
 	"bennypowers.dev/cem/lsp/document"
 	"bennypowers.dev/cem/lsp/helpers"
@@ -138,6 +139,10 @@ func (ctx *MCPContext) LoadManifests() error {
 
 	if err := ctx.lspRegistry.LoadFromWorkspace(ctx.workspace); err != nil {
 		return fmt.Errorf("failed to load manifests from workspace %q: %w", ctx.workspace.Root(), err)
+	}
+
+	if cfgFile := ctx.workspace.ConfigFile(); cfgFile != "" {
+		ctx.lspRegistry.AddWatchPath(cfgFile)
 	}
 
 	// Build relationship detector with all elements
@@ -367,6 +372,31 @@ func (ctx *MCPContext) LSPRegistry() *LSP.Registry {
 	return ctx.lspRegistry
 }
 
+func (ctx *MCPContext) Config() (*IC.CemConfig, error) {
+	return ctx.workspace.Config()
+}
+
+func (ctx *MCPContext) ConfigFile() string {
+	return ctx.workspace.ConfigFile()
+}
+
+func (ctx *MCPContext) ConfigSchemaJSON() []byte {
+	return IC.SchemaJSON()
+}
+
+func (ctx *MCPContext) Root() string {
+	return ctx.workspace.Root()
+}
+
+func (ctx *MCPContext) InvalidateConfig() {
+	type invalidatable interface {
+		InvalidateConfig()
+	}
+	if ws, ok := ctx.workspace.(invalidatable); ok {
+		ws.InvalidateConfig()
+	}
+}
+
 // GetElementInfo returns enhanced element information for MCP context
 func (ctx *MCPContext) GetElementInfo(tagName string) (MCPTypes.ElementInfo, error) {
 	ctx.mu.RLock()
@@ -578,6 +608,22 @@ func (ctx *MCPContextAdapter) GetManifestSchemaVersions() []string {
 // DocumentManager implements MCPTypes.MCPContext interface
 func (ctx *MCPContextAdapter) DocumentManager() lspTypes.DocumentManager {
 	return ctx.MCPContext.DocumentManager()
+}
+
+func (ctx *MCPContextAdapter) Config() (*IC.CemConfig, error) {
+	return ctx.MCPContext.Config()
+}
+
+func (ctx *MCPContextAdapter) ConfigFile() string {
+	return ctx.MCPContext.ConfigFile()
+}
+
+func (ctx *MCPContextAdapter) ConfigSchemaJSON() []byte {
+	return ctx.MCPContext.ConfigSchemaJSON()
+}
+
+func (ctx *MCPContextAdapter) Root() string {
+	return ctx.MCPContext.Root()
 }
 
 // ElementInfoAdapter implements MCPTypes.ElementInfo interface

--- a/mcp/context_config_reload_test.go
+++ b/mcp/context_config_reload_test.go
@@ -1,0 +1,89 @@
+package mcp_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"bennypowers.dev/cem/internal/workspace"
+	"bennypowers.dev/cem/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Inline assertions justified: testing cache invalidation behavior,
+// values are single scalars compared before/after mutation.
+
+func TestWorkspace_InvalidateConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".config", "cem.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(cfgPath), 0o755))
+	require.NoError(t, os.WriteFile(cfgPath, []byte("serve:\n  port: 5000\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"test"}`), 0o644))
+
+	ws := workspace.NewFileSystemWorkspaceContext(dir)
+	require.NoError(t, ws.Init())
+
+	cfg, err := ws.Config()
+	require.NoError(t, err)
+	assert.Equal(t, 5000, cfg.Serve.Port)
+
+	require.NoError(t, os.WriteFile(cfgPath, []byte("serve:\n  port: 6000\n"), 0o644))
+
+	ws.InvalidateConfig()
+
+	cfg2, err := ws.Config()
+	require.NoError(t, err)
+	assert.Equal(t, 6000, cfg2.Serve.Port)
+}
+
+func TestWorkspace_ConcurrentConfigAccess(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".config", "cem.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(cfgPath), 0o755))
+	require.NoError(t, os.WriteFile(cfgPath, []byte("serve:\n  port: 9000\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"test"}`), 0o644))
+
+	ws := workspace.NewFileSystemWorkspaceContext(dir)
+	require.NoError(t, ws.Init())
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 100 {
+			ws.InvalidateConfig()
+		}
+	}()
+
+	for range 100 {
+		_, _ = ws.Config()
+	}
+	<-done
+}
+
+func TestMCPContext_InvalidateConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".config", "cem.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(cfgPath), 0o755))
+	require.NoError(t, os.WriteFile(cfgPath, []byte("serve:\n  port: 7000\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"test"}`), 0o644))
+
+	ws := workspace.NewFileSystemWorkspaceContext(dir)
+	require.NoError(t, ws.Init())
+
+	ctx, err := mcp.NewMCPContext(ws)
+	require.NoError(t, err)
+	require.NoError(t, ctx.LoadManifests())
+
+	cfg, err := ctx.Config()
+	require.NoError(t, err)
+	assert.Equal(t, 7000, cfg.Serve.Port)
+
+	require.NoError(t, os.WriteFile(cfgPath, []byte("serve:\n  port: 8000\n"), 0o644))
+
+	ctx.InvalidateConfig()
+
+	cfg2, err := ctx.Config()
+	require.NoError(t, err)
+	assert.Equal(t, 8000, cfg2.Serve.Port)
+}

--- a/mcp/context_config_test.go
+++ b/mcp/context_config_test.go
@@ -1,0 +1,119 @@
+package mcp_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	testworkspace "bennypowers.dev/cem/internal/platform/testutil/workspace"
+	"bennypowers.dev/cem/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Inline assertions justified: testing interface compliance on thin getters/delegates
+// with no complex output to snapshot. Values are single scalars or byte slices.
+
+func TestMCPContext_Config(t *testing.T) {
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/multiple-elements-integration")
+	err := workspace.Init()
+	require.NoError(t, err)
+
+	registry, err := mcp.NewMCPContext(workspace)
+	require.NoError(t, err)
+
+	cfg, err := registry.Config()
+	require.NoError(t, err)
+	assert.NotNil(t, cfg)
+	assert.Equal(t, workspace.Root(), cfg.ProjectDir)
+}
+
+func TestMCPContext_ConfigFile(t *testing.T) {
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/multiple-elements-integration")
+	err := workspace.Init()
+	require.NoError(t, err)
+
+	registry, err := mcp.NewMCPContext(workspace)
+	require.NoError(t, err)
+
+	// MapWorkspaceContext returns empty string for ConfigFile
+	assert.Equal(t, "", registry.ConfigFile())
+}
+
+func TestMCPContext_ConfigSchemaJSON(t *testing.T) {
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/multiple-elements-integration")
+	err := workspace.Init()
+	require.NoError(t, err)
+
+	registry, err := mcp.NewMCPContext(workspace)
+	require.NoError(t, err)
+
+	schemaBytes := registry.ConfigSchemaJSON()
+	require.NotEmpty(t, schemaBytes)
+
+	var schema map[string]any
+	err = json.Unmarshal(schemaBytes, &schema)
+	require.NoError(t, err)
+	assert.Equal(t, "CEM Configuration", schema["title"])
+}
+
+func TestMCPContext_Root(t *testing.T) {
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/multiple-elements-integration")
+	err := workspace.Init()
+	require.NoError(t, err)
+
+	registry, err := mcp.NewMCPContext(workspace)
+	require.NoError(t, err)
+
+	assert.Equal(t, workspace.Root(), registry.Root())
+}
+
+func TestMCPContextAdapter_ImplementsConfigInterface(t *testing.T) {
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/multiple-elements-integration")
+	err := workspace.Init()
+	require.NoError(t, err)
+
+	registry, err := mcp.NewMCPContext(workspace)
+	require.NoError(t, err)
+
+	adapter := mcp.NewMCPContextAdapter(registry)
+
+	cfg, err := adapter.Config()
+	require.NoError(t, err)
+	assert.NotNil(t, cfg)
+
+	assert.Equal(t, workspace.Root(), adapter.Root())
+
+	schemaBytes := adapter.ConfigSchemaJSON()
+	assert.NotEmpty(t, schemaBytes)
+
+	_ = adapter.ConfigFile()
+}
+
+func TestMCPContextAdapter_ConfigSchemaIsValidJSON(t *testing.T) {
+	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/multiple-elements-integration")
+	err := workspace.Init()
+	require.NoError(t, err)
+
+	registry, err := mcp.NewMCPContext(workspace)
+	require.NoError(t, err)
+
+	adapter := mcp.NewMCPContextAdapter(registry)
+	schemaBytes := adapter.ConfigSchemaJSON()
+
+	var schema map[string]any
+	err = json.Unmarshal(schemaBytes, &schema)
+	require.NoError(t, err)
+
+	props, ok := schema["properties"].(map[string]any)
+	require.True(t, ok)
+
+	expectedSections := []string{"generate", "serve", "health", "mcp", "export"}
+	for _, section := range expectedSections {
+		_, exists := props[section]
+		assert.True(t, exists, "schema should have %s section", section)
+	}
+}
+
+// TestMCPContextAdapter_SatisfiesInterface verifies compile-time interface compliance.
+// The actual check is that the test file compiles -- adapter.Config() etc. calls above
+// would fail to compile if the interface wasn't satisfied.

--- a/mcp/resources/config-schema-section.md
+++ b/mcp/resources/config-schema-section.md
@@ -1,0 +1,12 @@
+---
+uri: cem://config/schema/{section}
+name: config-schema-section
+mimeType: application/json
+uriTemplate: true
+---
+
+Detailed JSON Schema for a specific CEM config section.
+
+Valid sections: generate, serve, health, mcp, export.
+
+Returns the full JSON Schema object for the requested section, including property types, descriptions, enum constraints, and format validators. Use this to understand available fields and valid values when configuring that section.

--- a/mcp/resources/config-schema.md
+++ b/mcp/resources/config-schema.md
@@ -1,0 +1,13 @@
+---
+uri: cem://config/schema
+name: config-schema
+mimeType: text/markdown
+---
+
+Overview of the CEM configuration schema with section summaries and drill-down URIs.
+
+Lists each config section (generate, serve, health, mcp, export) with a one-line description and a link to its detailed schema at `cem://config/schema/{section}`.
+
+Also lists top-level fields (projectDir, packageName, sourceControlRootUrl, additionalPackages) with descriptions.
+
+Use this to discover available config options before reading or writing config.

--- a/mcp/resources/config.md
+++ b/mcp/resources/config.md
@@ -1,0 +1,26 @@
+---
+uri: cem://config
+name: config
+mimeType: application/json
+dataFetchers:
+  - name: config
+    source: config
+    path: ""
+    required: true
+responseType: json
+---
+
+Resolved CEM project configuration as JSON.
+
+Includes all config sections:
+- **generate**: source file globs, output path, design tokens, demo discovery
+- **serve**: dev server port, import map (auto-generation and overrides), TypeScript/CSS transforms, URL rewrites, demo rendering mode
+- **health**: score threshold, disabled checks
+- **mcp**: MCP server settings (description length limits)
+- **export**: framework-specific wrapper generation
+
+Also includes top-level fields: projectDir, packageName, sourceControlRootUrl, additionalPackages.
+
+Use `cem://config/schema` for field descriptions, valid values, and defaults.
+Use the `validate_config` tool to check config for errors.
+Use the `generate_config` tool for guidance on creating or updating config.

--- a/mcp/resources/config_resources_test.go
+++ b/mcp/resources/config_resources_test.go
@@ -1,0 +1,152 @@
+package resources_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	IC "bennypowers.dev/cem/internal/config"
+	"bennypowers.dev/cem/mcp"
+	"bennypowers.dev/cem/mcp/resources"
+	"bennypowers.dev/cem/mcp/types"
+	mcpSDK "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Inline assertions justified: testing resource handler wiring and output structure,
+// not fixed content. Checking for key presence in dynamic schema-derived output.
+
+func findResource(t *testing.T, defs []types.ResourceDefinition, name string) *types.ResourceDefinition {
+	t.Helper()
+	for _, def := range defs {
+		if def.Name == name {
+			return &def
+		}
+	}
+	t.Fatalf("resource %q not found", name)
+	return nil
+}
+
+func TestConfigResource_Registered(t *testing.T) {
+	registry := getTestRegistry(t)
+	adapter := mcp.NewMCPContextAdapter(registry)
+
+	defs, err := resources.Resources(adapter)
+	require.NoError(t, err)
+
+	names := make(map[string]bool)
+	for _, d := range defs {
+		names[d.Name] = true
+	}
+
+	assert.True(t, names["config"], "should register cem://config resource")
+	assert.True(t, names["config-schema"], "should register cem://config/schema resource")
+	assert.True(t, names["config-schema-section"], "should register cem://config/schema/{section} resource")
+}
+
+func TestConfigResource_ReturnsResolvedConfig(t *testing.T) {
+	registry := getTestRegistry(t)
+	adapter := mcp.NewMCPContextAdapter(registry)
+
+	defs, err := resources.Resources(adapter)
+	require.NoError(t, err)
+
+	res := findResource(t, defs, "config")
+	require.Equal(t, "cem://config", res.URI)
+	require.Equal(t, "application/json", res.MimeType)
+
+	result, err := res.Handler(context.Background(), &mcpSDK.ReadResourceRequest{
+		Params: &mcpSDK.ReadResourceParams{URI: "cem://config"},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Contents, 1)
+
+	var cfg IC.CemConfig
+	err = json.Unmarshal([]byte(result.Contents[0].Text), &cfg)
+	require.NoError(t, err, "should return valid CemConfig JSON")
+	assert.NotEmpty(t, cfg.ProjectDir)
+}
+
+func TestConfigSchemaResource_ReturnsOverview(t *testing.T) {
+	registry := getTestRegistry(t)
+	adapter := mcp.NewMCPContextAdapter(registry)
+
+	defs, err := resources.Resources(adapter)
+	require.NoError(t, err)
+
+	res := findResource(t, defs, "config-schema")
+	require.Equal(t, "cem://config/schema", res.URI)
+
+	result, err := res.Handler(context.Background(), &mcpSDK.ReadResourceRequest{
+		Params: &mcpSDK.ReadResourceParams{URI: "cem://config/schema"},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Contents, 1)
+
+	text := result.Contents[0].Text
+	assert.Contains(t, text, "generate")
+	assert.Contains(t, text, "serve")
+	assert.Contains(t, text, "health")
+	assert.Contains(t, text, "cem://config/schema/generate")
+	assert.Contains(t, text, "cem://config/schema/serve")
+}
+
+func TestConfigSchemaSectionResource_ReturnsSection(t *testing.T) {
+	registry := getTestRegistry(t)
+	adapter := mcp.NewMCPContextAdapter(registry)
+
+	defs, err := resources.Resources(adapter)
+	require.NoError(t, err)
+
+	res := findResource(t, defs, "config-schema-section")
+	require.True(t, res.URITemplate)
+
+	tests := []struct {
+		section  string
+		contains string
+	}{
+		{"generate", "files"},
+		{"serve", "port"},
+		{"health", "failBelow"},
+		{"mcp", "maxDescriptionLength"},
+		{"export", "output"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.section, func(t *testing.T) {
+			result, err := res.Handler(context.Background(), &mcpSDK.ReadResourceRequest{
+				Params: &mcpSDK.ReadResourceParams{URI: "cem://config/schema/" + tc.section},
+			})
+			require.NoError(t, err)
+			require.Len(t, result.Contents, 1)
+
+			var section map[string]any
+			err = json.Unmarshal([]byte(result.Contents[0].Text), &section)
+			require.NoError(t, err, "section should be valid JSON")
+
+			props, ok := section["properties"].(map[string]any)
+			if ok {
+				assert.Contains(t, props, tc.contains)
+			} else {
+				// export uses additionalProperties
+				assert.Contains(t, result.Contents[0].Text, tc.contains)
+			}
+		})
+	}
+}
+
+func TestConfigSchemaSectionResource_UnknownSection(t *testing.T) {
+	registry := getTestRegistry(t)
+	adapter := mcp.NewMCPContextAdapter(registry)
+
+	defs, err := resources.Resources(adapter)
+	require.NoError(t, err)
+
+	res := findResource(t, defs, "config-schema-section")
+
+	_, err = res.Handler(context.Background(), &mcpSDK.ReadResourceRequest{
+		Params: &mcpSDK.ReadResourceParams{URI: "cem://config/schema/nonexistent"},
+	})
+	assert.Error(t, err)
+}

--- a/mcp/resources/data_sources.go
+++ b/mcp/resources/data_sources.go
@@ -63,6 +63,13 @@ func (p *DataSourceProvider) CreateDataSources(args map[string]any) (map[string]
 	}
 	sources["schema"] = schemaData
 
+	// Config data sources
+	if cfg, err := p.registry.Config(); err == nil && cfg != nil {
+		sources["config"] = cfg
+	}
+	sources["configFile"] = p.registry.ConfigFile()
+	sources["configSchema"] = p.registry.ConfigSchemaJSON()
+
 	// Add direct element access if tagName is provided
 	if tagName, ok := args["tagName"].(string); ok && tagName != "" {
 		elementInfo, err := p.registry.ElementInfo(tagName)

--- a/mcp/resources/embed_test.go
+++ b/mcp/resources/embed_test.go
@@ -50,7 +50,7 @@ func TestResourceDefinitions_Embedded(t *testing.T) {
 	require.NoError(t, err, "Resources() should succeed with embedded definitions")
 
 	// Verify expected number of resources (14 total)
-	assert.Len(t, resourceDefs, 14, "Should have exactly 14 embedded resource definitions")
+	assert.Len(t, resourceDefs, 17, "Should have exactly 17 embedded resource definitions")
 
 	// Verify expected resource names are present
 	resourceNames := make(map[string]bool)

--- a/mcp/resources/resources.go
+++ b/mcp/resources/resources.go
@@ -160,7 +160,12 @@ func makeConfigSchemaSectionHandler(_ types.MCPContext) mcp.ResourceHandler {
 		}
 	}
 
-	props, _ := schema["properties"].(map[string]any)
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		return func(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+			return nil, fmt.Errorf("config schema has no properties object")
+		}
+	}
 
 	return func(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
 		uri := req.Params.URI

--- a/mcp/resources/resources.go
+++ b/mcp/resources/resources.go
@@ -17,12 +17,15 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package resources
 
 import (
+	"context"
 	"embed"
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 
+	IC "bennypowers.dev/cem/internal/config"
 	"bennypowers.dev/cem/mcp/types"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -104,7 +107,13 @@ func parseResourceDefinition(filename string, registry types.MCPContext) (types.
 
 // getResourceHandler returns the appropriate handler function for a resource
 func getResourceHandler(resourceDef types.ResourceDefinition, registry types.MCPContext) (mcp.ResourceHandler, error) {
-	// All resources are now declarative and must have data fetchers
+	switch resourceDef.Name {
+	case "config-schema":
+		return makeConfigSchemaOverviewHandler(registry), nil
+	case "config-schema-section":
+		return makeConfigSchemaSectionHandler(registry), nil
+	}
+
 	if len(resourceDef.DataFetchers) == 0 {
 		return nil, fmt.Errorf("resource %s is missing data fetchers configuration", resourceDef.Name)
 	}
@@ -119,4 +128,63 @@ func getResourceHandler(resourceDef types.ResourceDefinition, registry types.MCP
 		ResponseType: resourceDef.ResponseType,
 	}
 	return MakeDeclarativeResourceHandler(registry, config), nil
+}
+
+func makeConfigSchemaOverviewHandler(_ types.MCPContext) mcp.ResourceHandler {
+	var b strings.Builder
+	b.WriteString("# CEM Configuration Schema\n\n")
+	b.WriteString("## Fields\n\n")
+	for _, s := range IC.SchemaSections() {
+		fmt.Fprintf(&b, "- **%s** -- %s\n  `cem://config/schema/%s`\n", s.Key, s.Description, s.Key)
+	}
+
+	text := b.String()
+
+	return func(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		return &mcp.ReadResourceResult{
+			Contents: []*mcp.ResourceContents{{
+				URI:      req.Params.URI,
+				MIMEType: "text/markdown",
+				Text:     text,
+			}},
+		}, nil
+	}
+}
+
+func makeConfigSchemaSectionHandler(_ types.MCPContext) mcp.ResourceHandler {
+	schemaBytes := IC.SchemaJSON()
+	var schema map[string]any
+	if err := json.Unmarshal(schemaBytes, &schema); err != nil {
+		return func(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+			return nil, fmt.Errorf("failed to parse config schema: %w", err)
+		}
+	}
+
+	props, _ := schema["properties"].(map[string]any)
+
+	return func(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		uri := req.Params.URI
+		section := strings.TrimPrefix(uri, "cem://config/schema/")
+		if !IC.IsSchemaSection(section) {
+			return nil, fmt.Errorf("unknown config section %q", section)
+		}
+
+		sectionSchema, ok := props[section]
+		if !ok {
+			return nil, fmt.Errorf("section %q not found in config schema", section)
+		}
+
+		data, err := json.MarshalIndent(sectionSchema, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal section schema: %w", err)
+		}
+
+		return &mcp.ReadResourceResult{
+			Contents: []*mcp.ResourceContents{{
+				URI:      uri,
+				MIMEType: "application/json",
+				Text:     string(data),
+			}},
+		}, nil
+	}
 }

--- a/mcp/resources/resources_test.go
+++ b/mcp/resources/resources_test.go
@@ -58,7 +58,7 @@ func TestResources_LoadingAndParsing(t *testing.T) {
 	require.NotEmpty(t, resourceDefs, "Should load resource definitions")
 
 	// Verify all expected resources are loaded
-	expectedResources := []string{"schema", "packages", "elements", "element", "guidelines", "accessibility"}
+	expectedResources := []string{"schema", "packages", "elements", "element", "guidelines", "accessibility", "config", "config-schema", "config-schema-section"}
 	resourceNames := make(map[string]bool)
 	for _, def := range resourceDefs {
 		resourceNames[def.Name] = true
@@ -503,8 +503,9 @@ func TestAllResourcesWithFixtures(t *testing.T) {
 			if resource.Name == "element" {
 				testURI = "cem://element/button-element" // Use known fixture element
 			} else if strings.Contains(resource.URI, "{tagName}") {
-				// For all declarative resources that require tagName, use button-element
 				testURI = strings.Replace(resource.URI, "{tagName}", "button-element", 1)
+			} else if strings.Contains(resource.URI, "{section}") {
+				testURI = strings.Replace(resource.URI, "{section}", "generate", 1)
 			}
 
 			req := &mcpSDK.ReadResourceRequest{

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -71,7 +71,7 @@ func NewServerWithConfig(workspace types.WorkspaceContext, config ServerConfig) 
 	// Create MCP server
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "cem",
-		Version: "1.0.0",
+		Version: version.GetVersion(),
 	}, nil)
 
 	cemServer := &Server{
@@ -125,6 +125,17 @@ func (s *Server) Run(ctx context.Context) error {
 		if err := s.registry.LSPRegistry().LoadAdditionalPackages(s.config.AdditionalPackages); err != nil {
 			helpers.SafeDebugLog("Warning: Error loading additional packages: %v", err)
 		}
+	}
+
+	// Start file watching for manifest and config changes
+	if err := s.registry.LSPRegistry().StartFileWatching(func() {
+		helpers.SafeDebugLog("File change detected, reloading manifests and config")
+		s.registry.InvalidateConfig()
+		if err := s.registry.LoadManifests(); err != nil {
+			helpers.SafeDebugLog("Warning: Failed to reload manifests: %v", err)
+		}
+	}); err != nil {
+		helpers.SafeDebugLog("Warning: Could not start file watching: %v", err)
 	}
 
 	// Run the MCP server

--- a/mcp/tools/config_tools_test.go
+++ b/mcp/tools/config_tools_test.go
@@ -1,0 +1,103 @@
+package tools_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"bennypowers.dev/cem/mcp/tools"
+	mcpSDK "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Inline assertions justified: testing tool handler wiring and output structure,
+// not fixed content. Checking for key presence in dynamic schema-derived output.
+
+func TestGenerateConfig_Registered(t *testing.T) {
+	registry := getTestRegistry(t)
+
+	toolDefs, err := tools.Tools(registry)
+	require.NoError(t, err)
+
+	names := make(map[string]bool)
+	for _, d := range toolDefs {
+		names[d.Name] = true
+	}
+	assert.True(t, names["generate_config"], "should register generate_config tool")
+	assert.True(t, names["validate_config"], "should register validate_config tool")
+}
+
+func TestGenerateConfig_ReturnsSchemaAndGuidance(t *testing.T) {
+	registry := getTestRegistry(t)
+
+	handler := tools.MakeGenerateConfigHandler(registry)
+	require.NotNil(t, handler)
+
+	result, err := handler(context.Background(), &mcpSDK.CallToolRequest{
+		Params: &mcpSDK.CallToolParamsRaw{
+			Name:      "generate_config",
+			Arguments: json.RawMessage(`{}`),
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Content)
+
+	text := result.Content[0].(*mcpSDK.TextContent).Text
+	assert.Contains(t, text, "generate")
+	assert.Contains(t, text, "serve")
+	assert.Contains(t, text, "schema")
+}
+
+func TestGenerateConfig_WithFocus(t *testing.T) {
+	registry := getTestRegistry(t)
+
+	handler := tools.MakeGenerateConfigHandler(registry)
+
+	result, err := handler(context.Background(), &mcpSDK.CallToolRequest{
+		Params: &mcpSDK.CallToolParamsRaw{
+			Name:      "generate_config",
+			Arguments: json.RawMessage(`{"focus": "serve"}`),
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Content)
+
+	text := result.Content[0].(*mcpSDK.TextContent).Text
+	assert.Contains(t, text, "serve")
+	assert.Contains(t, text, "import")
+}
+
+func TestGenerateConfig_InvalidFocus(t *testing.T) {
+	registry := getTestRegistry(t)
+
+	handler := tools.MakeGenerateConfigHandler(registry)
+
+	_, err := handler(context.Background(), &mcpSDK.CallToolRequest{
+		Params: &mcpSDK.CallToolParamsRaw{
+			Name:      "generate_config",
+			Arguments: json.RawMessage(`{"focus": "nonexistent"}`),
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown config section")
+}
+
+func TestValidateConfig_NoConfigFile(t *testing.T) {
+	registry := getTestRegistry(t)
+
+	handler := tools.MakeValidateConfigHandler(registry)
+	require.NotNil(t, handler)
+
+	result, err := handler(context.Background(), &mcpSDK.CallToolRequest{
+		Params: &mcpSDK.CallToolParamsRaw{
+			Name:      "validate_config",
+			Arguments: json.RawMessage(`{}`),
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Content)
+
+	text := result.Content[0].(*mcpSDK.TextContent).Text
+	assert.Contains(t, text, "no config file")
+}

--- a/mcp/tools/embed_test.go
+++ b/mcp/tools/embed_test.go
@@ -50,7 +50,7 @@ func TestToolDefinitions_Embedded(t *testing.T) {
 	require.NoError(t, err, "Tools() should succeed with embedded definitions")
 
 	// Verify expected number of tools
-	assert.Len(t, toolDefs, 2, "Should have exactly 2 embedded tool definitions")
+	assert.Len(t, toolDefs, 4, "Should have exactly 4 embedded tool definitions")
 
 	// Verify expected tool names are present
 	toolNames := make(map[string]bool)

--- a/mcp/tools/generate-config.md
+++ b/mcp/tools/generate-config.md
@@ -12,6 +12,6 @@ Generate or update CEM configuration for a project.
 
 Returns the current config (if any), the config file path, the full JSON schema, and guidance prompts for what to investigate in the project. The agent should use its own tools to scan the project (check for TypeScript files, demo HTML files, package.json dependencies, etc.) and then write or update the config file based on its findings.
 
-Use `cem://config` to read the current resolved config.
-Use `cem://config/schema/{section}` for detailed schema of a specific section.
-Use `validate_config` after writing config to check for errors.
+Read current resolved config via `cem://config`.
+For detailed schema of a specific section, see `cem://config/schema/{section}`.
+After writing config, run `validate_config` to check for errors.

--- a/mcp/tools/generate-config.md
+++ b/mcp/tools/generate-config.md
@@ -1,0 +1,17 @@
+---
+name: generate_config
+inputSchema:
+  type: object
+  properties:
+    focus:
+      type: string
+      description: "Optional config section to focus guidance on (generate, serve, health, mcp, export). When omitted, returns guidance for all sections."
+---
+
+Generate or update CEM configuration for a project.
+
+Returns the current config (if any), the config file path, the full JSON schema, and guidance prompts for what to investigate in the project. The agent should use its own tools to scan the project (check for TypeScript files, demo HTML files, package.json dependencies, etc.) and then write or update the config file based on its findings.
+
+Use `cem://config` to read the current resolved config.
+Use `cem://config/schema/{section}` for detailed schema of a specific section.
+Use `validate_config` after writing config to check for errors.

--- a/mcp/tools/generate_config.go
+++ b/mcp/tools/generate_config.go
@@ -1,0 +1,130 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	IC "bennypowers.dev/cem/internal/config"
+	mcpTypes "bennypowers.dev/cem/mcp/types"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type GenerateConfigArgs struct {
+	Focus string `json:"focus,omitempty"`
+}
+
+func handleGenerateConfig(
+	_ context.Context,
+	req *mcp.CallToolRequest,
+	registry mcpTypes.MCPContext,
+) (*mcp.CallToolResult, error) {
+	var args GenerateConfigArgs
+	if req.Params.Arguments != nil {
+		if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+			return nil, fmt.Errorf("failed to parse args: %w", err)
+		}
+	}
+
+	if args.Focus != "" && !IC.IsSchemaSection(args.Focus) {
+		return nil, fmt.Errorf("unknown config section %q", args.Focus)
+	}
+
+	var b strings.Builder
+
+	cfg, err := registry.Config()
+	if err != nil || cfg == nil {
+		b.WriteString("## Current config\n\nNo config file found.\n\n")
+	} else {
+		cfgJSON, _ := json.MarshalIndent(cfg, "", "  ")
+		fmt.Fprintf(&b, "## Current config\n\nFile: `%s`\n\n```json\n%s\n```\n\n", registry.ConfigFile(), string(cfgJSON))
+	}
+
+	schemaBytes := registry.ConfigSchemaJSON()
+	var schema map[string]any
+	if err := json.Unmarshal(schemaBytes, &schema); err == nil {
+		if args.Focus != "" {
+			if props, ok := schema["properties"].(map[string]any); ok {
+				if section, ok := props[args.Focus]; ok {
+					sectionJSON, _ := json.MarshalIndent(section, "", "  ")
+					fmt.Fprintf(&b, "## Schema: %s\n\n```json\n%s\n```\n\n", args.Focus, string(sectionJSON))
+				}
+			}
+		} else {
+			schemaJSON, _ := json.MarshalIndent(schema, "", "  ")
+			fmt.Fprintf(&b, "## Schema\n\n```json\n%s\n```\n\n", string(schemaJSON))
+		}
+	}
+
+	b.WriteString("## Guidance\n\n")
+	writeGuidance(&b, args.Focus)
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: b.String()},
+		},
+	}, nil
+}
+
+var configGuidance = map[string][]string{
+	"generate": {
+		"Look for source files containing custom element definitions (classes extending HTMLElement, LitElement, etc.) to set `generate.files` globs.",
+		"Check if `**/*.d.ts` files should be included (unusual); if so, set `generate.noDefaultExcludes: true`.",
+		"Check package.json for a `customElements` field pointing to the manifest output path, or set `generate.output` explicitly.",
+		"If the project uses design tokens (DTCG JSON format), set `generate.designTokens.spec` to the token file path.",
+		"Look for demo HTML files to configure `generate.demoDiscovery.fileGlob` and URL patterns.",
+	},
+	"serve": {
+		"If the project has bare import specifiers (e.g. `import 'lit'`), enable `serve.importMap.generate: true` to auto-resolve from node_modules.",
+		"For dependencies not in node_modules or needing custom resolution, add entries to `serve.importMap.override.imports`.",
+		"Check for .ts source files to enable `serve.transforms.typescript.enabled: true`.",
+		"If components import CSS files as modules, enable `serve.transforms.css.enabled: true` and set include globs.",
+		"Check if the project needs URL rewrites (e.g. mapping `/dist/` paths to `/src/`).",
+		"Choose a demo rendering mode: light (default), shadow (encapsulated), iframe (isolated), or chromeless (no dev server UI).",
+	},
+	"health": {
+		"Set `health.failBelow` to enforce a minimum documentation quality score (0-100).",
+		"Disable checks not relevant to the project with `health.disable` (available: description, attributes, slots, css, events, demos).",
+	},
+	"mcp": {
+		"Adjust `mcp.maxDescriptionLength` if element descriptions are being truncated (default: 2000 chars).",
+	},
+	"export": {
+		"Configure framework exports (React, Vue, etc.) with output directory, package name, and prefix stripping.",
+	},
+}
+
+func writeGuidance(b *strings.Builder, focus string) {
+	if focus != "" {
+		if prompts, ok := configGuidance[focus]; ok {
+			fmt.Fprintf(b, "### %s\n\n", focus)
+			for _, p := range prompts {
+				fmt.Fprintf(b, "- %s\n", p)
+			}
+			b.WriteString("\n")
+		} else {
+			fmt.Fprintf(b, "No specific guidance for `%s`. See `cem://config/schema/%s` for available fields.\n\n", focus, focus)
+		}
+		return
+	}
+	for _, s := range IC.SchemaSections() {
+		if prompts, ok := configGuidance[s.Key]; ok {
+			fmt.Fprintf(b, "### %s\n\n", s.Key)
+			for _, p := range prompts {
+				fmt.Fprintf(b, "- %s\n", p)
+			}
+			b.WriteString("\n")
+		}
+	}
+}
+
+func makeGenerateConfigHandler(registry mcpTypes.MCPContext) mcp.ToolHandler {
+	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleGenerateConfig(ctx, req, registry)
+	}
+}
+
+func MakeGenerateConfigHandler(registry mcpTypes.MCPContext) mcp.ToolHandler {
+	return makeGenerateConfigHandler(registry)
+}

--- a/mcp/tools/generate_config.go
+++ b/mcp/tools/generate_config.go
@@ -37,24 +37,34 @@ func handleGenerateConfig(
 	if err != nil || cfg == nil {
 		b.WriteString("## Current config\n\nNo config file found.\n\n")
 	} else {
-		cfgJSON, _ := json.MarshalIndent(cfg, "", "  ")
+		cfgJSON, err := json.MarshalIndent(cfg, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal config: %w", err)
+		}
 		fmt.Fprintf(&b, "## Current config\n\nFile: `%s`\n\n```json\n%s\n```\n\n", registry.ConfigFile(), string(cfgJSON))
 	}
 
 	schemaBytes := registry.ConfigSchemaJSON()
 	var schema map[string]any
-	if err := json.Unmarshal(schemaBytes, &schema); err == nil {
-		if args.Focus != "" {
-			if props, ok := schema["properties"].(map[string]any); ok {
-				if section, ok := props[args.Focus]; ok {
-					sectionJSON, _ := json.MarshalIndent(section, "", "  ")
-					fmt.Fprintf(&b, "## Schema: %s\n\n```json\n%s\n```\n\n", args.Focus, string(sectionJSON))
+	if err := json.Unmarshal(schemaBytes, &schema); err != nil {
+		return nil, fmt.Errorf("failed to parse config schema: %w", err)
+	}
+	if args.Focus != "" {
+		if props, ok := schema["properties"].(map[string]any); ok {
+			if section, ok := props[args.Focus]; ok {
+				sectionJSON, err := json.MarshalIndent(section, "", "  ")
+				if err != nil {
+					return nil, fmt.Errorf("failed to marshal schema section: %w", err)
 				}
+				fmt.Fprintf(&b, "## Schema: %s\n\n```json\n%s\n```\n\n", args.Focus, string(sectionJSON))
 			}
-		} else {
-			schemaJSON, _ := json.MarshalIndent(schema, "", "  ")
-			fmt.Fprintf(&b, "## Schema\n\n```json\n%s\n```\n\n", string(schemaJSON))
 		}
+	} else {
+		schemaJSON, err := json.MarshalIndent(schema, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal schema: %w", err)
+		}
+		fmt.Fprintf(&b, "## Schema\n\n```json\n%s\n```\n\n", string(schemaJSON))
 	}
 
 	b.WriteString("## Guidance\n\n")

--- a/mcp/tools/tools.go
+++ b/mcp/tools/tools.go
@@ -107,6 +107,10 @@ func getToolHandler(toolDef types.ToolDefinition, registry types.MCPContext) (mc
 		return makeValidateHtmlHandler(registry), nil
 	case "generate_html":
 		return makeGenerateHtmlHandler(registry), nil
+	case "generate_config":
+		return makeGenerateConfigHandler(registry), nil
+	case "validate_config":
+		return makeValidateConfigHandler(registry), nil
 	default:
 		return nil, fmt.Errorf("unknown tool: %s", toolDef.Name)
 	}

--- a/mcp/tools/tools_test.go
+++ b/mcp/tools/tools_test.go
@@ -111,7 +111,7 @@ func TestToolsLoading_Integration(t *testing.T) {
 	require.NotEmpty(t, toolDefs, "Should load tool definitions")
 
 	// Verify expected tools are present
-	expectedTools := []string{"validate_html", "generate_html"}
+	expectedTools := []string{"validate_html", "generate_html", "generate_config", "validate_config"}
 	toolNames := make(map[string]bool)
 	for _, def := range toolDefs {
 		toolNames[def.Name] = true

--- a/mcp/tools/validate-config.md
+++ b/mcp/tools/validate-config.md
@@ -1,0 +1,12 @@
+---
+name: validate_config
+inputSchema:
+  type: object
+  properties: {}
+---
+
+Validate the current CEM configuration file.
+
+Runs schema validation and semantic checks against the project's config file, including filesystem I/O checks (glob pattern reachability, output path existence, URL rewrite validation, demo discovery validation).
+
+Returns structured JSON with config file path, validity status, and arrays of errors and warnings. Each error includes the field path, message, severity, and source position (line/column) when available.

--- a/mcp/tools/validate_config.go
+++ b/mcp/tools/validate_config.go
@@ -1,0 +1,120 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	IC "bennypowers.dev/cem/internal/config"
+	"bennypowers.dev/cem/internal/platform"
+	"bennypowers.dev/cem/internal/sourcepos"
+	mcpTypes "bennypowers.dev/cem/mcp/types"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	DD "bennypowers.dev/cem/generate/demodiscovery"
+	"bennypowers.dev/cem/serve/middleware/transform"
+)
+
+type validateConfigResult struct {
+	ConfigFile string                 `json:"configFile"`
+	Valid      bool                   `json:"valid"`
+	Errors     []IC.ValidationError   `json:"errors"`
+	Warnings   []IC.ValidationError   `json:"warnings"`
+}
+
+func handleValidateConfig(
+	_ context.Context,
+	_ *mcp.CallToolRequest,
+	registry mcpTypes.MCPContext,
+) (*mcp.CallToolResult, error) {
+	cfgFile := registry.ConfigFile()
+	if cfgFile == "" {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "no config file found"},
+			},
+		}, nil
+	}
+
+	rawData, err := os.ReadFile(cfgFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	cfgFormat := IC.FormatFromPath(cfgFile)
+	schemaErrs := IC.ValidateSchema(rawData, cfgFormat)
+
+	cfg, err := registry.Config()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config: %w", err)
+	}
+
+	semanticErrs := IC.Validate(cfg, IC.ValidateOptions{
+		CheckIO: true,
+		Root:    registry.Root(),
+		IO:      &platform.OSFileSystem{},
+		ValidateURLRewrites: func(rewrites []IC.URLRewrite) error {
+			return transform.ValidateURLRewrites(rewrites)
+		},
+		ValidateDemoDiscovery: func(c *IC.CemConfig) error {
+			return DD.ValidateDemoDiscoveryConfig(c, map[string]string{})
+		},
+	})
+
+	allErrs := IC.DeduplicateErrors(schemaErrs, semanticErrs)
+
+	if len(allErrs) > 0 {
+		posMap := sourcepos.BuildPositionMap(rawData, cfgFormat)
+		for i := range allErrs {
+			pointer := sourcepos.FieldToJSONPointer(allErrs[i].Field)
+			if pos, ok := sourcepos.Resolve(posMap, pointer); ok {
+				allErrs[i].Line = pos.Line
+				allErrs[i].Column = pos.Column
+			}
+		}
+	}
+
+	var errors, warnings []IC.ValidationError
+	for _, e := range allErrs {
+		if e.Severity == IC.SeverityWarning {
+			warnings = append(warnings, e)
+		} else {
+			errors = append(errors, e)
+		}
+	}
+	if errors == nil {
+		errors = []IC.ValidationError{}
+	}
+	if warnings == nil {
+		warnings = []IC.ValidationError{}
+	}
+
+	result := validateConfigResult{
+		ConfigFile: cfgFile,
+		Valid:      len(errors) == 0,
+		Errors:     errors,
+		Warnings:   warnings,
+	}
+
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal results: %w", err)
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(data)},
+		},
+	}, nil
+}
+
+func makeValidateConfigHandler(registry mcpTypes.MCPContext) mcp.ToolHandler {
+	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleValidateConfig(ctx, req, registry)
+	}
+}
+
+func MakeValidateConfigHandler(registry mcpTypes.MCPContext) mcp.ToolHandler {
+	return makeValidateConfigHandler(registry)
+}

--- a/mcp/types/context.go
+++ b/mcp/types/context.go
@@ -17,6 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package types
 
 import (
+	"bennypowers.dev/cem/internal/config"
 	"bennypowers.dev/cem/lsp/types"
 	"bennypowers.dev/cem/manifest"
 	"bennypowers.dev/cem/mcp/relationships"
@@ -34,6 +35,12 @@ type MCPContext interface {
 	// Lazy-computed cached methods for performance
 	CommonPrefixes() []string
 	AllCSSProperties() []string
+
+	// Config access
+	Config() (*config.CemConfig, error)
+	ConfigFile() string
+	ConfigSchemaJSON() []byte
+	Root() string
 }
 
 // ElementInfo represents element information using manifest types directly


### PR DESCRIPTION
## Summary

Closes #353

- Adds MCP resources for reading project config (`cem://config`, `cem://config/schema`, `cem://config/schema/{section}`) with progressive disclosure
- Adds `generate_config` tool that returns current config, JSON schema, and guidance prompts for the LLM to scan the project and decide what to configure
- Adds `validate_config` tool that runs full validation (schema + semantic + I/O checks) matching CLI `cem config validate` fidelity
- Improves all config schema descriptions for LLM clarity (what/why/defaults/relationships)
- Adds config file watching with cache invalidation so MCP server picks up config changes without restart
- Fixes MCP server version to use main version line (was hardcoded `1.0.0`)
- Extracts `DeduplicateErrors` to `internal/config` for shared use by CLI and MCP
- Derives valid schema sections from the embedded JSON schema at init time (no hardcoded section lists)
- Adds thread-safe config caching with `sync.RWMutex` and error caching on `FileSystemWorkspaceContext`

## Test plan

- [x] Red-first TDD for all new code (23 new tests)
- [x] Race detector clean (`go test -race`)
- [x] `make lint` -- 0 issues
- [x] `make test-unit` -- 4192 tests pass
- [x] Three code review passes with findings resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Exposed the configuration JSON schema through MCP resources, including per-section drill-down.
  * Added `generate_config` and `validate_config` MCP tools for config generation and validation.
  * Configuration file changes are now watched and trigger automatic reloads.

* **Bug Fixes**
  * Validation output now avoids duplicate schema-vs-semantic errors for the same field and severity.

* **Documentation**
  * Improved configuration schema descriptions across major sections, including clearer defaults and behavioral notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->