### PR TITLE
refactor(tui): migrate manifest tree rendering from pterm to treeview

### DIFF
--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -29,8 +29,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/nsf/jsondiff"
-	"github.com/pterm/pterm"
 )
 
 var update = flag.Bool("update", false, "update golden files")
@@ -132,7 +132,7 @@ func TestGenerateE2E(t *testing.T) {
 				expectedLog = fmt.Sprintf(expectedLog, tc.outputFile)
 			}
 
-			if !strings.Contains(pterm.RemoveColorFromString(stderr), expectedLog) {
+			if !strings.Contains(ansi.Strip(stderr), expectedLog) {
 				t.Fatalf("log output does not contain expected string.\nExpected: %s\nGot: %s", expectedLog, stderr)
 			}
 		})

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -19,8 +19,10 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 
+	lipgloss "charm.land/lipgloss/v2"
 	"github.com/spf13/cobra"
 
 	"bennypowers.dev/cem/internal/logging"
@@ -111,7 +113,9 @@ func makeListSectionCmd(use, short, long string, includeSection string, aliases 
 						if s, err := list.Render(renderable, opts, M.True); err != nil {
 							return err
 						} else {
-							fmt.Printf("\n%s:\n%s\n", pkg.Name, s)
+							if _, err := lipgloss.Fprintf(os.Stdout, "\n%s:\n%s\n", pkg.Name, s); err != nil {
+								return err
+							}
 						}
 					}
 					return nil
@@ -147,7 +151,9 @@ func makeListSectionCmd(use, short, long string, includeSection string, aliases 
 					if s, err := list.Render(renderable, opts, M.True); err != nil {
 						return err
 					} else {
-						fmt.Println(s)
+						if _, err := lipgloss.Fprintln(os.Stdout, s); err != nil {
+							return err
+						}
 					}
 				}
 				return nil
@@ -316,7 +322,9 @@ Example:
 				if s, err := list.RenderTagsTable(manifest, opts); err != nil {
 					return err
 				} else {
-					fmt.Printf("\n%s:\n%s\n", pkg.Name, s)
+					if _, err := lipgloss.Fprintf(os.Stdout, "\n%s:\n%s\n", pkg.Name, s); err != nil {
+								return err
+							}
 				}
 				return nil
 			})
@@ -343,7 +351,9 @@ Example:
 				if s, err := list.RenderTagsTable(manifest, opts); err != nil {
 					return err
 				} else {
-					fmt.Println(s)
+					if _, err := lipgloss.Fprintln(os.Stdout, s); err != nil {
+							return err
+						}
 				}
 			}
 			return nil
@@ -376,7 +386,9 @@ Example:
 				if s, err := list.RenderModulesTable(manifest, opts); err != nil {
 					return err
 				} else {
-					fmt.Printf("\n%s:\n%s\n", pkg.Name, s)
+					if _, err := lipgloss.Fprintf(os.Stdout, "\n%s:\n%s\n", pkg.Name, s); err != nil {
+								return err
+							}
 				}
 				return nil
 			})
@@ -403,7 +415,9 @@ Example:
 				if s, err := list.RenderModulesTable(manifest, opts); err != nil {
 					return err
 				} else {
-					fmt.Println(s)
+					if _, err := lipgloss.Fprintln(os.Stdout, s); err != nil {
+							return err
+						}
 				}
 			}
 			return nil
@@ -457,15 +471,21 @@ Examples:
 					if s, err := list.RenderTree(title, M.NewRenderablePackage(manifest), pred); err != nil {
 						return err
 					} else {
-						fmt.Println(s)
+						if _, err := lipgloss.Fprintln(os.Stdout, s); err != nil {
+							return err
+						}
 					}
 				case "table":
-					fmt.Printf("\n%s:\n", pkg.Name)
+					if _, err := lipgloss.Fprintf(os.Stdout, "\n%s:\n", pkg.Name); err != nil {
+							return err
+						}
 					opts := list.RenderOptions{}
 					if s, err := list.Render(M.NewRenderablePackage(manifest), opts, M.True); err != nil {
 						return err
 					} else {
-						fmt.Println(s)
+						if _, err := lipgloss.Fprintln(os.Stdout, s); err != nil {
+							return err
+						}
 					}
 				}
 				return nil
@@ -502,14 +522,18 @@ Examples:
 				if s, err := list.RenderTree(title, M.NewRenderablePackage(manifest), pred); err != nil {
 					return err
 				} else {
-					fmt.Println(s)
+					if _, err := lipgloss.Fprintln(os.Stdout, s); err != nil {
+							return err
+						}
 				}
 			case "table":
 				opts := list.RenderOptions{}
 				if s, err := list.Render(M.NewRenderablePackage(manifest), opts, M.True); err != nil {
 					return err
 				} else {
-					fmt.Println(s)
+					if _, err := lipgloss.Fprintln(os.Stdout, s); err != nil {
+							return err
+						}
 				}
 			}
 			return nil

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"os"
 	"slices"
 
 	lipgloss "charm.land/lipgloss/v2"
@@ -113,7 +112,7 @@ func makeListSectionCmd(use, short, long string, includeSection string, aliases 
 						if s, err := list.Render(renderable, opts, M.True); err != nil {
 							return err
 						} else {
-							if _, err := lipgloss.Fprintf(os.Stdout, "\n%s:\n%s\n", pkg.Name, s); err != nil {
+							if _, err := lipgloss.Fprintf(cmd.OutOrStdout(), "\n%s:\n%s\n", pkg.Name, s); err != nil {
 								return err
 							}
 						}
@@ -151,7 +150,7 @@ func makeListSectionCmd(use, short, long string, includeSection string, aliases 
 					if s, err := list.Render(renderable, opts, M.True); err != nil {
 						return err
 					} else {
-						if _, err := lipgloss.Fprintln(os.Stdout, s); err != nil {
+						if _, err := lipgloss.Fprintln(cmd.OutOrStdout(), s); err != nil {
 							return err
 						}
 					}
@@ -322,7 +321,7 @@ Example:
 				if s, err := list.RenderTagsTable(manifest, opts); err != nil {
 					return err
 				} else {
-					if _, err := lipgloss.Fprintf(os.Stdout, "\n%s:\n%s\n", pkg.Name, s); err != nil {
+					if _, err := lipgloss.Fprintf(cmd.OutOrStdout(), "\n%s:\n%s\n", pkg.Name, s); err != nil {
 								return err
 							}
 				}
@@ -351,7 +350,7 @@ Example:
 				if s, err := list.RenderTagsTable(manifest, opts); err != nil {
 					return err
 				} else {
-					if _, err := lipgloss.Fprintln(os.Stdout, s); err != nil {
+					if _, err := lipgloss.Fprintln(cmd.OutOrStdout(), s); err != nil {
 							return err
 						}
 				}
@@ -386,7 +385,7 @@ Example:
 				if s, err := list.RenderModulesTable(manifest, opts); err != nil {
 					return err
 				} else {
-					if _, err := lipgloss.Fprintf(os.Stdout, "\n%s:\n%s\n", pkg.Name, s); err != nil {
+					if _, err := lipgloss.Fprintf(cmd.OutOrStdout(), "\n%s:\n%s\n", pkg.Name, s); err != nil {
 								return err
 							}
 				}
@@ -415,7 +414,7 @@ Example:
 				if s, err := list.RenderModulesTable(manifest, opts); err != nil {
 					return err
 				} else {
-					if _, err := lipgloss.Fprintln(os.Stdout, s); err != nil {
+					if _, err := lipgloss.Fprintln(cmd.OutOrStdout(), s); err != nil {
 							return err
 						}
 				}
@@ -471,19 +470,19 @@ Examples:
 					if s, err := list.RenderTree(title, M.NewRenderablePackage(manifest), pred); err != nil {
 						return err
 					} else {
-						if _, err := lipgloss.Fprintln(os.Stdout, s); err != nil {
+						if _, err := lipgloss.Fprintln(cmd.OutOrStdout(), s); err != nil {
 							return err
 						}
 					}
 				case "table":
-					if _, err := lipgloss.Fprintf(os.Stdout, "\n%s:\n", pkg.Name); err != nil {
+					if _, err := lipgloss.Fprintf(cmd.OutOrStdout(), "\n%s:\n", pkg.Name); err != nil {
 							return err
 						}
 					opts := list.RenderOptions{}
 					if s, err := list.Render(M.NewRenderablePackage(manifest), opts, M.True); err != nil {
 						return err
 					} else {
-						if _, err := lipgloss.Fprintln(os.Stdout, s); err != nil {
+						if _, err := lipgloss.Fprintln(cmd.OutOrStdout(), s); err != nil {
 							return err
 						}
 					}
@@ -522,7 +521,7 @@ Examples:
 				if s, err := list.RenderTree(title, M.NewRenderablePackage(manifest), pred); err != nil {
 					return err
 				} else {
-					if _, err := lipgloss.Fprintln(os.Stdout, s); err != nil {
+					if _, err := lipgloss.Fprintln(cmd.OutOrStdout(), s); err != nil {
 							return err
 						}
 				}
@@ -531,7 +530,7 @@ Examples:
 				if s, err := list.Render(M.NewRenderablePackage(manifest), opts, M.True); err != nil {
 					return err
 				} else {
-					if _, err := lipgloss.Fprintln(os.Stdout, s); err != nil {
+					if _, err := lipgloss.Fprintln(cmd.OutOrStdout(), s); err != nil {
 							return err
 						}
 				}

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pterm/pterm"
+	"github.com/charmbracelet/x/ansi"
 )
 
 func TestListE2E(t *testing.T) {
@@ -114,7 +114,7 @@ func TestListE2E(t *testing.T) {
 					t.Fatalf("failed to read golden file: %v", err)
 				}
 
-				cleanedStdout := pterm.RemoveColorFromString(stdout)
+				cleanedStdout := ansi.Strip(stdout)
 				cleanedExpected := strings.TrimSpace(string(expected))
 
 				if !strings.Contains(cleanedStdout, cleanedExpected) {

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	lipgloss "charm.land/lipgloss/v2"
 	"github.com/spf13/cobra"
@@ -76,7 +75,7 @@ Examples:
 			if s, err := search.RenderSearchResults(manifest, pattern, format); err != nil {
 				return err
 			} else {
-				if _, err := lipgloss.Fprintln(os.Stdout, s); err != nil {
+				if _, err := lipgloss.Fprintln(cmd.OutOrStdout(), s); err != nil {
 					return err
 				}
 			}
@@ -113,7 +112,7 @@ func searchWorkspace(cmd *cobra.Command, pattern string) error {
 			return err
 		}
 		if s != "" {
-			if _, err := lipgloss.Fprintf(os.Stdout, "\n%s:\n%s\n", pkg.Name, s); err != nil {
+			if _, err := lipgloss.Fprintf(cmd.OutOrStdout(), "\n%s:\n%s\n", pkg.Name, s); err != nil {
 				return err
 			}
 		}

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -19,7 +19,9 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"os"
 
+	lipgloss "charm.land/lipgloss/v2"
 	"github.com/spf13/cobra"
 
 	"bennypowers.dev/cem/search"
@@ -74,7 +76,9 @@ Examples:
 			if s, err := search.RenderSearchResults(manifest, pattern, format); err != nil {
 				return err
 			} else {
-				fmt.Println(s)
+				if _, err := lipgloss.Fprintln(os.Stdout, s); err != nil {
+					return err
+				}
 			}
 			return nil
 		}
@@ -109,7 +113,9 @@ func searchWorkspace(cmd *cobra.Command, pattern string) error {
 			return err
 		}
 		if s != "" {
-			fmt.Printf("\n%s:\n%s\n", pkg.Name, s)
+			if _, err := lipgloss.Fprintf(os.Stdout, "\n%s:\n%s\n", pkg.Name, s); err != nil {
+				return err
+			}
 		}
 		return nil
 	})

--- a/cmd/workspace_test.go
+++ b/cmd/workspace_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/nsf/jsondiff"
-	"github.com/pterm/pterm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -58,7 +58,7 @@ func TestWorkspaceGenerate_SinglePackageOverride(t *testing.T) {
 func TestWorkspaceValidate_ValidatesAllPackages(t *testing.T) {
 	projectDir := generateWorkspaceFixture(t)
 	stdout, _ := runCemCommand(t, projectDir, "validate")
-	cleaned := pterm.RemoveColorFromString(stdout)
+	cleaned := ansi.Strip(stdout)
 	compareGolden(t, workspaceGolden("validate", false), cleaned, false)
 }
 
@@ -127,14 +127,14 @@ func workspaceGolden(name string, isJSON bool) string {
 func TestWorkspaceHealth_ScoresAllPackages(t *testing.T) {
 	projectDir := generateWorkspaceFixture(t)
 	stdout, _ := runCemCommand(t, projectDir, "health")
-	cleaned := pterm.RemoveColorFromString(stdout)
+	cleaned := ansi.Strip(stdout)
 	compareGolden(t, workspaceGolden("health-all", false), cleaned, false)
 }
 
 func TestWorkspaceHealth_TagNameFilter(t *testing.T) {
 	projectDir := generateWorkspaceFixture(t)
 	stdout, _ := runCemCommand(t, projectDir, "health", "-t", "test-button")
-	cleaned := pterm.RemoveColorFromString(stdout)
+	cleaned := ansi.Strip(stdout)
 	compareGolden(t, workspaceGolden("health-tag-filter", false), cleaned, false)
 }
 
@@ -159,7 +159,7 @@ func TestWorkspaceHealth_FormatJSON_NoMatch(t *testing.T) {
 func TestWorkspaceHealth_DeprecatedComponentFlag(t *testing.T) {
 	projectDir := generateWorkspaceFixture(t)
 	stdout, stderr := runCemCommand(t, projectDir, "health", "--component", "test-button")
-	cleaned := pterm.RemoveColorFromString(stdout)
+	cleaned := ansi.Strip(stdout)
 	compareGolden(t, workspaceGolden("health-deprecated-component", false), cleaned, false)
 	// Justification for inline assertion: deprecation warning is cobra-generated
 	// stderr whose exact format is cobra's concern, not ours. Golden-matching
@@ -170,49 +170,49 @@ func TestWorkspaceHealth_DeprecatedComponentFlag(t *testing.T) {
 func TestWorkspaceListTags_ShowsAllPackages(t *testing.T) {
 	projectDir := generateWorkspaceFixture(t)
 	stdout, _ := runCemCommand(t, projectDir, "list", "tags")
-	cleaned := pterm.RemoveColorFromString(stdout)
+	cleaned := ansi.Strip(stdout)
 	compareGolden(t, workspaceGolden("list-tags", false), cleaned, false)
 }
 
 func TestWorkspaceListModules_ShowsAllPackages(t *testing.T) {
 	projectDir := generateWorkspaceFixture(t)
 	stdout, _ := runCemCommand(t, projectDir, "list", "modules")
-	cleaned := pterm.RemoveColorFromString(stdout)
+	cleaned := ansi.Strip(stdout)
 	compareGolden(t, workspaceGolden("list-modules", false), cleaned, false)
 }
 
 func TestWorkspaceList_ShowsAllPackages(t *testing.T) {
 	projectDir := generateWorkspaceFixture(t)
 	stdout, _ := runCemCommand(t, projectDir, "list")
-	cleaned := pterm.RemoveColorFromString(stdout)
+	cleaned := ansi.Strip(stdout)
 	compareGolden(t, workspaceGolden("list-all", false), cleaned, false)
 }
 
 func TestWorkspaceSearch_FindsAcrossPackages(t *testing.T) {
 	projectDir := generateWorkspaceFixture(t)
 	stdout, _ := runCemCommand(t, projectDir, "search", "button")
-	cleaned := pterm.RemoveColorFromString(stdout)
+	cleaned := ansi.Strip(stdout)
 	compareGolden(t, workspaceGolden("search-button", false), cleaned, false)
 }
 
 func TestWorkspaceSearch_NoResults(t *testing.T) {
 	projectDir := generateWorkspaceFixture(t)
 	stdout, _ := runCemCommand(t, projectDir, "search", "zzz-nonexistent-zzz")
-	cleaned := pterm.RemoveColorFromString(stdout)
+	cleaned := ansi.Strip(stdout)
 	compareGolden(t, workspaceGolden("search-no-results", false), cleaned, false)
 }
 
 func TestWorkspaceExport_SucceedsWithConfig(t *testing.T) {
 	projectDir := generateWorkspaceFixture(t)
 	stdout, _ := runCemCommand(t, projectDir, "export")
-	cleaned := pterm.RemoveColorFromString(stdout)
+	cleaned := ansi.Strip(stdout)
 	compareGolden(t, workspaceGolden("export", false), cleaned, false)
 }
 
 func TestWorkspaceExport_WithFormat(t *testing.T) {
 	projectDir := generateWorkspaceFixture(t)
 	stdout, _ := runCemCommand(t, projectDir, "export", "--format", "react")
-	cleaned := pterm.RemoveColorFromString(stdout)
+	cleaned := ansi.Strip(stdout)
 	compareGolden(t, workspaceGolden("export-react", false), cleaned, false)
 }
 
@@ -246,6 +246,6 @@ func TestWorkspaceGenerate_DemoDiscovery(t *testing.T) {
 func TestWorkspaceListAttributes_FindsInCorrectPackage(t *testing.T) {
 	projectDir := generateWorkspaceFixture(t)
 	stdout, _ := runCemCommand(t, projectDir, "list", "attributes", "-t", "test-button")
-	cleaned := pterm.RemoveColorFromString(stdout)
+	cleaned := ansi.Strip(stdout)
 	compareGolden(t, workspaceGolden("list-attributes-button", false), cleaned, false)
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	bennypowers.dev/tree-sitter-handlebars v0.1.1
 	bennypowers.dev/tree-sitter-jinja-dialects v0.1.1
 	charm.land/lipgloss/v2 v2.0.4
+	github.com/Digital-Shane/treeview/v2 v2.0.1
 	github.com/EmranMR/tree-sitter-blade v0.12.3
 	github.com/IBM/fp-go v1.0.153
 	github.com/adrg/xdg v0.5.3
@@ -53,8 +54,10 @@ require (
 )
 
 require (
+	charm.land/bubbles/v2 v2.1.0 // indirect
+	charm.land/bubbletea/v2 v2.0.6 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
-	github.com/charmbracelet/ultraviolet v0.0.0-20251205161215-1948445e3318 // indirect
+	github.com/charmbracelet/ultraviolet v0.0.0-20260422141423-a0f1f21775f7 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
@@ -73,7 +76,7 @@ require (
 	github.com/bitfield/gotestdox v0.2.2 // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
 	github.com/charmbracelet/lipgloss v1.0.0 // indirect
-	github.com/charmbracelet/x/ansi v0.11.7 // indirect
+	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/containerd/console v1.0.5 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
@@ -122,7 +125,7 @@ require (
 	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/tools v0.40.0 // indirect
 	gotest.tools/gotestsum v1.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,14 @@ bennypowers.dev/tree-sitter-handlebars v0.1.1 h1:JqzXwslMjbtH1Z73iJbtqTCW/ET0MFk
 bennypowers.dev/tree-sitter-handlebars v0.1.1/go.mod h1:U2HyV0nhqQZAWU5SjpvTKT/ahOcLHYAQgM1z6nJ3YJI=
 bennypowers.dev/tree-sitter-jinja-dialects v0.1.1 h1:04RG/fGUgOQnmI0NzkBFTY249y/s+xAG1lP35T5QJaM=
 bennypowers.dev/tree-sitter-jinja-dialects v0.1.1/go.mod h1:CwooWUonL1YUBFVF/tDf7muTjIUtc/4PczSO3zokpro=
+charm.land/bubbles/v2 v2.1.0 h1:YSnNh5cPYlYjPxRrzs5VEn3vwhtEn3jVGRBT3M7/I0g=
+charm.land/bubbles/v2 v2.1.0/go.mod h1:l97h4hym2hvWBVfmJDtrEHHCtkIKeTEb3TTJ4ZOB3wY=
+charm.land/bubbletea/v2 v2.0.6 h1:UHN/91OyuhaOFGSrBXQ/hMZD8IO1Uc4BvHlgHXL2WJo=
+charm.land/bubbletea/v2 v2.0.6/go.mod h1:MH/D8ZLlN3op37vQvijKuU29g3rqTp+aQapURFonF9g=
 charm.land/lipgloss/v2 v2.0.4 h1:lcPeVtcp23SNra7lHy8iYE4UC2aIipVQ47sbGyyxR5Q=
 charm.land/lipgloss/v2 v2.0.4/go.mod h1:0653x8epbZSzdDfO/XPS1a/uYPOBeSsCssOpJOqDzik=
+github.com/Digital-Shane/treeview/v2 v2.0.1 h1:13h+ML6zCrYzAkS6e/7ac+xAAkW+0y8+Nl5DtlAhsmk=
+github.com/Digital-Shane/treeview/v2 v2.0.1/go.mod h1:DbPsk+lLX9xpUrQv5hG6FCfeb0PYVGZ/xC3j1bQaZbk=
 github.com/EmranMR/tree-sitter-blade v0.12.3 h1:fHlO2FYPa3za3VofNqVR9w5L8khuwm2V2rbtXO2DIVw=
 github.com/EmranMR/tree-sitter-blade v0.12.3/go.mod h1:nZ3dJUgOfc2zaLba4caFAUWFevlo88VuLCU/EUD/29U=
 github.com/IBM/fp-go v1.0.153 h1:KkzjWvInCfW1queBSpb1DV2/ZkaTIKVqV3dO8WfOvas=
@@ -65,8 +71,8 @@ github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
 github.com/charmbracelet/lipgloss v1.0.0 h1:O7VkGDvqEdGi93X+DeqsQ7PKHDgtQfF8j8/O2qFMQNg=
 github.com/charmbracelet/lipgloss v1.0.0/go.mod h1:U5fy9Z+C38obMs+T+tJqst9VGzlOYGj4ri9reL3qUlo=
-github.com/charmbracelet/ultraviolet v0.0.0-20251205161215-1948445e3318 h1:OqDqxQZliC7C8adA7KjelW3OjtAxREfeHkNcd66wpeI=
-github.com/charmbracelet/ultraviolet v0.0.0-20251205161215-1948445e3318/go.mod h1:Y6kE2GzHfkyQQVCSL9r2hwokSrIlHGzZG+71+wDYSZI=
+github.com/charmbracelet/ultraviolet v0.0.0-20260422141423-a0f1f21775f7 h1:PeRlqWGEoO0apcS62iEgxQhVnFCTOYyQvi2sUTdf6IE=
+github.com/charmbracelet/ultraviolet v0.0.0-20260422141423-a0f1f21775f7/go.mod h1:3YdTxlnV/L0bQ3VN8WOSw8doF7LZV/xawUQ4MuAPDvo=
 github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dAYC84jI=
 github.com/charmbracelet/x/ansi v0.11.7/go.mod h1:9qGpnAVYz+8ACONkZBUWPtL7lulP9No6p1epAihUZwQ=
 github.com/charmbracelet/x/exp/golden v0.0.0-20250806222409-83e3a29d542f h1:pk6gmGpCE7F3FcjaOEKYriCvpmIN4+6OS/RD0vm4uIA=
@@ -324,8 +330,8 @@ golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKl
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
-golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -260,7 +260,7 @@ func (l *Logger) Critical(format string, args ...any) {
 
 	switch mode {
 	case ModeCLI, ModeServe:
-		lipgloss.Fprintf(os.Stderr, "%s %s\n", errorPrefix, message) //nolint:errcheck
+		_, _ = lipgloss.Fprintf(os.Stderr, "%s %s\n", errorPrefix, message)
 	case ModeLSP:
 		if lspContext != nil {
 			// Always use window/showMessage for critical errors (popup)
@@ -289,7 +289,7 @@ func (l *Logger) Notify(format string, args ...any) {
 
 	switch mode {
 	case ModeCLI, ModeServe:
-		lipgloss.Fprintf(os.Stderr, "%s %s\n", infoPrefix, message) //nolint:errcheck
+		_, _ = lipgloss.Fprintf(os.Stderr, "%s %s\n", infoPrefix, message)
 	case ModeLSP:
 		if lspContext != nil {
 			go func() {
@@ -315,10 +315,10 @@ func (l *Logger) NotifyWithActions(message string, actions []MessageAction) {
 
 	switch mode {
 	case ModeCLI, ModeServe:
-		lipgloss.Fprintf(os.Stderr, "%s %s\n", infoPrefix, message) //nolint:errcheck
+		_, _ = lipgloss.Fprintf(os.Stderr, "%s %s\n", infoPrefix, message)
 		for _, action := range actions {
 			if action.URL != "" {
-				lipgloss.Fprintf(os.Stderr, "%s   %s: %s\n", infoPrefix, action.Title, action.URL) //nolint:errcheck
+				_, _ = lipgloss.Fprintf(os.Stderr, "%s   %s: %s\n", infoPrefix, action.Title, action.URL)
 			}
 		}
 	case ModeLSP:
@@ -391,7 +391,7 @@ func (l *Logger) Success(format string, args ...any) {
 
 	switch mode {
 	case ModeCLI, ModeServe:
-		lipgloss.Fprintf(os.Stderr, "%s %s\n", successPrefix, fmt.Sprintf(format, args...)) //nolint:errcheck
+		_, _ = lipgloss.Fprintf(os.Stderr, "%s %s\n", successPrefix, fmt.Sprintf(format, args...))
 	case ModeLSP:
 		message := fmt.Sprintf(format, args...)
 		l.logLSP(LogLevelInfo, message, lspContext)
@@ -432,7 +432,7 @@ func (l *Logger) logCLI(level LogLevel, message string) {
 	case LogLevelError:
 		prefix = errorPrefix
 	}
-	lipgloss.Fprintf(os.Stderr, "%s %s\n", prefix, message) //nolint:errcheck
+	_, _ = lipgloss.Fprintf(os.Stderr, "%s %s\n", prefix, message)
 }
 
 // logLSP handles LSP-mode logging using LSP protocol messages

--- a/list/tree.go
+++ b/list/tree.go
@@ -17,12 +17,16 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package list
 
 import (
+	"context"
 	"reflect"
 	"strings"
 
+	lipgloss "charm.land/lipgloss/v2"
 	M "bennypowers.dev/cem/manifest"
-	"github.com/pterm/pterm"
+	treeview "github.com/Digital-Shane/treeview/v2"
 )
+
+var sectionStyle = lipgloss.NewStyle().Bold(true)
 
 func RenderTree(title string, renderable M.Renderable, pred M.PredicateFunc) (string, error) {
 	if renderable == nil || isTypedNil(renderable) {
@@ -30,16 +34,22 @@ func RenderTree(title string, renderable M.Renderable, pred M.PredicateFunc) (st
 	}
 	root := renderable.ToTreeNode(pred)
 
-	if root.Children == nil {
+	if !root.HasChildren() {
 		return "", nil
 	}
 
-	var builder strings.Builder
-	builder.WriteString(pterm.DefaultSection.Sprintf("%s", title))
-	s, err := pterm.DefaultTree.WithRoot(root).Srender()
+	tree := treeview.NewTree([]*treeview.Node[M.DisplayNode]{root},
+		treeview.WithExpandFunc[M.DisplayNode](func(_ *treeview.Node[M.DisplayNode]) bool { return true }),
+	)
+
+	s, err := tree.Render(context.Background())
 	if err != nil {
 		return "", err
 	}
+
+	var builder strings.Builder
+	builder.WriteString(sectionStyle.Render(title))
+	builder.WriteString("\n")
 	builder.WriteString(s)
 	return builder.String(), nil
 }

--- a/manifest/attribute.go
+++ b/manifest/attribute.go
@@ -20,8 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-
-	"github.com/pterm/pterm"
 )
 
 var _ Deprecatable = (*Attribute)(nil)
@@ -198,7 +196,7 @@ func (x *RenderableAttribute) Label() string {
 	if x.CustomElementField != nil && x.CustomElementField.Reflects {
 		label += " (reflects)"
 	}
-	label += pterm.Gray(" " + x.Attribute.Summary)
+	label += summaryStyle.Render(" " + x.Attribute.Summary)
 	return label
 }
 
@@ -255,6 +253,6 @@ func (x *RenderableAttribute) ToTableRow() []string {
 	}
 }
 
-func (x *RenderableAttribute) ToTreeNode(p PredicateFunc) pterm.TreeNode {
-	return tn(x.Label())
+func (x *RenderableAttribute) ToTreeNode(p PredicateFunc) TreeNode {
+	return tn("attribute", x.Label())
 }

--- a/manifest/class.go
+++ b/manifest/class.go
@@ -19,8 +19,6 @@ package manifest
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/pterm/pterm"
 )
 
 var _ Deprecatable = (*ClassDeclaration)(nil)
@@ -206,7 +204,7 @@ func (x *RenderableClassDeclaration) Name() string {
 }
 
 func (x *RenderableClassDeclaration) Label() string {
-	return pterm.LightBlue("class") +
+	return kindStyle.Render("class") +
 		" " +
 		highlightIfDeprecated(x)
 }
@@ -223,15 +221,15 @@ func (x *RenderableClassDeclaration) Children() []Renderable {
 	return x.ChildNodes
 }
 
-func (x *RenderableClassDeclaration) GroupedChildren(p PredicateFunc) []pterm.TreeNode {
-	var nodes []pterm.TreeNode
+func (x *RenderableClassDeclaration) GroupedChildren(p PredicateFunc) []TreeNode {
+	var nodes []TreeNode
 	fs := toTreeChildren(x.fields, p)
 	ms := toTreeChildren(x.methods, p)
 	if len(fs) > 0 {
-		nodes = append(nodes, tn(pterm.Blue("Fields"), fs...))
+		nodes = append(nodes, tn("section", categoryStyle.Render("Fields"), fs...))
 	}
 	if len(ms) > 0 {
-		nodes = append(nodes, tn(pterm.Blue("Methods"), ms...))
+		nodes = append(nodes, tn("section", categoryStyle.Render("Methods"), ms...))
 	}
 	return nodes
 }
@@ -252,8 +250,8 @@ func (x *RenderableClassDeclaration) ToTableRow() []string {
 	}
 }
 
-func (x *RenderableClassDeclaration) ToTreeNode(p PredicateFunc) pterm.TreeNode {
-	return tn(x.Label(), x.GroupedChildren(p)...)
+func (x *RenderableClassDeclaration) ToTreeNode(p PredicateFunc) TreeNode {
+	return tn("class", x.Label(), x.GroupedChildren(p)...)
 }
 
 func (x *RenderableClassDeclaration) Sections() []Section {

--- a/manifest/class_test.go
+++ b/manifest/class_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pterm/pterm"
+	treeview "github.com/Digital-Shane/treeview/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -35,9 +35,9 @@ func stripANSI(s string) string {
 	return ansiRegexp.ReplaceAllString(s, "")
 }
 
-func dumpTree(t *testing.T, node pterm.TreeNode, depth int) {
-	t.Logf("%s%q\n", strings.Repeat("  ", depth), stripANSI(node.Text))
-	for _, child := range node.Children {
+func dumpTree(t *testing.T, node TreeNode, depth int) {
+	t.Logf("%s%q\n", strings.Repeat("  ", depth), stripANSI(node.Name()))
+	for _, child := range node.Children() {
 		dumpTree(t, child, depth+1)
 	}
 }
@@ -55,42 +55,42 @@ func TestRenderableClassDeclaration(t *testing.T) {
 		node := renderable.ToTreeNode(True)
 
 		// Find the module node by partial match if necessary
-		var moduleNode *pterm.TreeNode
-		for _, child := range node.Children {
-			if stripANSI(child.Text) == "src/my-module.js" || strings.Contains(stripANSI(child.Text), "my-module") {
-				moduleNode = &child
+		var moduleNode TreeNode
+		for _, child := range node.Children() {
+			if stripANSI(child.Name()) == "src/my-module.js" || strings.Contains(stripANSI(child.Name()), "my-module") {
+				moduleNode = child
 				break
 			}
 		}
 		if !assert.NotNil(t, moduleNode, "Module node should exist") {
-			t.Logf("Available root children: %#v", node.Children)
+			t.Logf("Available root children: %#v", node.Children())
 			t.FailNow()
 		}
 
 		// Find the class node, ignoring ANSI color codes
-		var classNode *pterm.TreeNode
-		for _, child := range moduleNode.Children {
-			text := stripANSI(child.Text)
+		var classNode TreeNode
+		for _, child := range moduleNode.Children() {
+			text := stripANSI(child.Name())
 			if strings.Contains(text, "MyClass") && strings.Contains(text, "class") {
-				classNode = &child
+				classNode = child
 				break
 			}
 		}
 		if !assert.NotNil(t, classNode, "Class node should exist") {
-			t.Logf("Available module children: %#v", moduleNode.Children)
+			t.Logf("Available module children: %#v", moduleNode.Children())
 			t.FailNow()
 		}
 
 		t.Run("RootNodeIsClass", func(t *testing.T) {
-			assert.Contains(t, stripANSI(classNode.Text), "class")
-			assert.Contains(t, stripANSI(classNode.Text), "MyClass")
+			assert.Contains(t, stripANSI(classNode.Name()), "class")
+			assert.Contains(t, stripANSI(classNode.Name()), "MyClass")
 		})
 
 		t.Run("ChildrenAreGroupedByKind", func(t *testing.T) {
 			kinds := []string{"Fields", "Methods"}
 			groupLabels := make([]string, 0)
-			for _, child := range classNode.Children {
-				groupLabels = append(groupLabels, stripANSI(child.Text))
+			for _, child := range classNode.Children() {
+				groupLabels = append(groupLabels, stripANSI(child.Name()))
 			}
 			for _, kind := range kinds {
 				assert.Containsf(t, groupLabels, kind, "expected group %q in class node children", kind)
@@ -98,17 +98,17 @@ func TestRenderableClassDeclaration(t *testing.T) {
 		})
 
 		t.Run("FieldsGroupedTogether", func(t *testing.T) {
-			var fieldsGroup *pterm.TreeNode
-			for _, child := range classNode.Children {
-				if stripANSI(child.Text) == "Fields" {
-					fieldsGroup = &child
+			var fieldsGroup TreeNode
+			for _, child := range classNode.Children() {
+				if stripANSI(child.Name()) == "Fields" {
+					fieldsGroup = child
 					break
 				}
 			}
 			if assert.NotNil(t, fieldsGroup, "Fields group should exist") {
 				fieldNames := []string{}
-				for _, f := range fieldsGroup.Children {
-					fieldNames = append(fieldNames, stripANSI(f.Text))
+				for _, f := range fieldsGroup.Children() {
+					fieldNames = append(fieldNames, stripANSI(f.Name()))
 				}
 				dumpTree(t, node, 0)
 				assert.Subset(t, fieldNames, []string{"myField1", "myField2", "anotherField"})
@@ -116,25 +116,31 @@ func TestRenderableClassDeclaration(t *testing.T) {
 		})
 
 		t.Run("MethodsGroupedTogether", func(t *testing.T) {
-			var methodsGroup *pterm.TreeNode
-			for _, child := range classNode.Children {
-				if stripANSI(child.Text) == "Methods" {
-					methodsGroup = &child
+			var methodsGroup TreeNode
+			for _, child := range classNode.Children() {
+				if stripANSI(child.Name()) == "Methods" {
+					methodsGroup = child
 					break
 				}
 			}
 			if assert.NotNil(t, methodsGroup, "Methods group should exist") {
 				methodNames := []string{}
-				for _, m := range methodsGroup.Children {
-					methodNames = append(methodNames, stripANSI(m.Text))
+				for _, m := range methodsGroup.Children() {
+					methodNames = append(methodNames, stripANSI(m.Name()))
 				}
 				assert.Subset(t, methodNames, []string{"myMethod1", "myMethod2"})
 			}
 		})
 
 		t.Run("VisualTreeOutput", func(t *testing.T) {
-			_, err := pterm.DefaultTree.WithRoot(node).Srender()
-			assert.NoError(t, err)
+			tree := treeview.NewTree([]TreeNode{node},
+				treeview.WithExpandFunc[DisplayNode](func(_ TreeNode) bool { return true }),
+			)
+			model := treeview.NewTuiTreeModel(tree,
+				treeview.WithTuiDisableNavBar[DisplayNode](true),
+			)
+			s := model.View().Content
+			assert.NotEmpty(t, s)
 		})
 	})
 }

--- a/manifest/classfield.go
+++ b/manifest/classfield.go
@@ -20,8 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-
-	"github.com/pterm/pterm"
 )
 
 var _ Deprecatable = (*ClassField)(nil)
@@ -149,7 +147,7 @@ func (x *RenderableClassField) Name() string {
 func (x *RenderableClassField) Label() string {
 	sum := ""
 	if x.ClassField.Summary != "" {
-		sum = pterm.Gray(x.ClassField.Summary)
+		sum = summaryStyle.Render(x.ClassField.Summary)
 	}
 	return strings.TrimSpace(highlightIfDeprecated(x) + " " + sum)
 }
@@ -182,8 +180,8 @@ func (x *RenderableClassField) ToTableRow() []string {
 	}
 }
 
-func (x *RenderableClassField) ToTreeNode(pred PredicateFunc) pterm.TreeNode {
-	return pterm.TreeNode{Text: x.Label()}
+func (x *RenderableClassField) ToTreeNode(pred PredicateFunc) TreeNode {
+	return tn("field", x.Label())
 }
 
 // CustomElementField extends ClassField with attribute/reflects.
@@ -285,7 +283,7 @@ func (x *RenderableCustomElementField) Name() string {
 }
 
 func (x *RenderableCustomElementField) Label() string {
-	return highlightIfDeprecated(x) + " " + pterm.Gray(x.CustomElementField.Summary)
+	return highlightIfDeprecated(x) + " " + summaryStyle.Render(x.CustomElementField.Summary)
 }
 
 func (x *RenderableCustomElementField) IsDeprecated() bool {
@@ -316,6 +314,6 @@ func (x *RenderableCustomElementField) ToTableRow() []string {
 	}
 }
 
-func (x *RenderableCustomElementField) ToTreeNode(pred PredicateFunc) pterm.TreeNode {
-	return pterm.TreeNode{Text: x.Label()}
+func (x *RenderableCustomElementField) ToTreeNode(pred PredicateFunc) TreeNode {
+	return tn("field", x.Label())
 }

--- a/manifest/classmethod.go
+++ b/manifest/classmethod.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/pterm/pterm"
 )
 
 var _ Deprecatable = (*ClassMethod)(nil)
@@ -138,7 +136,7 @@ func (x *RenderableClassMethod) Name() string {
 func (x *RenderableClassMethod) Label() string {
 	sum := ""
 	if x.Method.Summary != "" {
-		sum = pterm.Gray(x.Method.Summary)
+		sum = summaryStyle.Render(x.Method.Summary)
 	}
 	return strings.TrimSpace(highlightIfDeprecated(x) + " " + sum)
 }
@@ -178,8 +176,8 @@ func (x *RenderableClassMethod) ToTableRow() []string {
 	}
 }
 
-func (x *RenderableClassMethod) ToTreeNode(pred PredicateFunc) pterm.TreeNode {
-	return pterm.TreeNode{Text: x.Label()}
+func (x *RenderableClassMethod) ToTreeNode(pred PredicateFunc) TreeNode {
+	return tn("method", x.Label())
 }
 
 func NewRenderableClassMethod(

--- a/manifest/context.go
+++ b/manifest/context.go
@@ -377,7 +377,7 @@ func toTreeChildren(xs []Renderable, p PredicateFunc) (nodes []TreeNode) {
 		}
 
 		if p(n) || len(children) > 0 {
-			node := tn("node", n.Label())
+			node := n.ToTreeNode(p)
 			node.SetChildren(children)
 			nodes = append(nodes, node)
 		}

--- a/manifest/context.go
+++ b/manifest/context.go
@@ -18,13 +18,21 @@ package manifest
 
 import (
 	"errors"
+	"fmt"
 	"slices"
 	"strings"
+	"sync/atomic"
 
-	"github.com/pterm/pterm"
+	treeview "github.com/Digital-Shane/treeview/v2"
 )
 
 type PredicateFunc func(Renderable) bool
+
+type DisplayNode struct {
+	Label string
+}
+
+type TreeNode = *treeview.Node[DisplayNode]
 
 type Renderable interface {
 	Deprecatable
@@ -33,12 +41,12 @@ type Renderable interface {
 	Deprecation() Deprecated
 	ColumnHeadings() []string
 	ToTableRow() []string
-	ToTreeNode(pred PredicateFunc) pterm.TreeNode
+	ToTreeNode(pred PredicateFunc) TreeNode
 	Children() []Renderable
 }
 
 type GroupedRenderable interface {
-	GroupedChildren(p PredicateFunc) []pterm.TreeNode
+	GroupedChildren(p PredicateFunc) []TreeNode
 }
 
 type Section struct {
@@ -61,9 +69,9 @@ func formatDeprecated(deprecated any) (label string) {
 	}
 	switch v := deprecated.(type) {
 	case DeprecatedReason:
-		return "(" + pterm.Red("DEPRECATED") + ": " + pterm.LightRed(v) + ")"
+		return "(" + deprecatedStyle.Render("DEPRECATED") + ": " + deprecatedReasonStyle.Render(string(v)) + ")"
 	default:
-		return "(" + pterm.Red("DEPRECATED") + ")"
+		return "(" + deprecatedStyle.Render("DEPRECATED") + ")"
 	}
 }
 
@@ -353,26 +361,33 @@ func (x *Package) TagRenderableDemos(tagName string) (demos []*RenderableDemo, e
 	return demos, nil
 }
 
-func toTreeChildren(xs []Renderable, p PredicateFunc) (nodes []pterm.TreeNode) {
+var nodeCounter atomic.Int64
+
+func nextNodeID(kind string) string {
+	return fmt.Sprintf("%s-%d", kind, nodeCounter.Add(1))
+}
+
+func toTreeChildren(xs []Renderable, p PredicateFunc) (nodes []TreeNode) {
 	for _, n := range xs {
-		var children []pterm.TreeNode
-		// If this Renderable knows how to group its children, use that
+		var children []TreeNode
 		if gr, ok := n.(GroupedRenderable); ok {
 			children = append(children, gr.GroupedChildren(p)...)
 		} else {
-			// Otherwise, use the default recursion+filtering
 			children = toTreeChildren(n.Children(), p)
 		}
 
 		if p(n) || len(children) > 0 {
-			node := n.ToTreeNode(p)
-			node.Children = children
+			node := tn("node", n.Label())
+			node.SetChildren(children)
 			nodes = append(nodes, node)
 		}
 	}
 	return nodes
 }
 
-func tn(text string, children ...pterm.TreeNode) pterm.TreeNode {
-	return pterm.TreeNode{Text: text, Children: children}
+func tn(kind, text string, children ...TreeNode) TreeNode {
+	node := treeview.NewNode(nextNodeID(kind), text, DisplayNode{Label: text})
+	node.SetChildren(children)
+	node.Expand()
+	return node
 }

--- a/manifest/csscustomproperty.go
+++ b/manifest/csscustomproperty.go
@@ -19,8 +19,6 @@ package manifest
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/pterm/pterm"
 )
 
 var _ Deprecatable = (*CssCustomProperty)(nil)
@@ -107,7 +105,7 @@ func (x *RenderableCssCustomProperty) Name() string {
 }
 
 func (x *RenderableCssCustomProperty) Label() string {
-	return highlightIfDeprecated(x) + " " + pterm.Gray(x.CssCustomProperty.Summary)
+	return highlightIfDeprecated(x) + " " + summaryStyle.Render(x.CssCustomProperty.Summary)
 }
 
 func (x *RenderableCssCustomProperty) IsDeprecated() bool {
@@ -141,8 +139,8 @@ func (x *RenderableCssCustomProperty) ToTableRow() []string {
 	}
 }
 
-func (x *RenderableCssCustomProperty) ToTreeNode(pred PredicateFunc) pterm.TreeNode {
-	return pterm.TreeNode{Text: x.Label()}
+func (x *RenderableCssCustomProperty) ToTreeNode(pred PredicateFunc) TreeNode {
+	return tn("css-property", x.Label())
 }
 
 func NewRenderableCssCustomProperty(

--- a/manifest/csscustomstate.go
+++ b/manifest/csscustomstate.go
@@ -19,8 +19,6 @@ package manifest
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/pterm/pterm"
 )
 
 var _ Deprecatable = (*CssCustomState)(nil)
@@ -112,7 +110,7 @@ func (x *RenderableCssCustomState) Name() string {
 }
 
 func (x *RenderableCssCustomState) Label() string {
-	return highlightIfDeprecated(x) + " " + pterm.Gray(x.CssCustomState.Summary)
+	return highlightIfDeprecated(x) + " " + summaryStyle.Render(x.CssCustomState.Summary)
 }
 
 func (x *RenderableCssCustomState) IsDeprecated() bool {
@@ -148,6 +146,6 @@ func (x *RenderableCssCustomState) ToTableRow() []string {
 	}
 }
 
-func (x *RenderableCssCustomState) ToTreeNode(pred PredicateFunc) pterm.TreeNode {
-	return pterm.TreeNode{Text: x.Label()}
+func (x *RenderableCssCustomState) ToTreeNode(pred PredicateFunc) TreeNode {
+	return tn("css-state", x.Label())
 }

--- a/manifest/csspart.go
+++ b/manifest/csspart.go
@@ -19,8 +19,6 @@ package manifest
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/pterm/pterm"
 )
 
 var _ Deprecatable = (*CssPart)(nil)
@@ -130,7 +128,7 @@ func (x *RenderableCssPart) Name() string {
 }
 
 func (x *RenderableCssPart) Label() string {
-	return highlightIfDeprecated(x) + " " + pterm.Gray(x.CssPart.Summary)
+	return highlightIfDeprecated(x) + " " + summaryStyle.Render(x.CssPart.Summary)
 }
 
 func (x *RenderableCssPart) IsDeprecated() bool {
@@ -166,6 +164,6 @@ func (x *RenderableCssPart) ToTableRow() []string {
 	}
 }
 
-func (x *RenderableCssPart) ToTreeNode(pred PredicateFunc) pterm.TreeNode {
-	return pterm.TreeNode{Text: x.Label()}
+func (x *RenderableCssPart) ToTreeNode(pred PredicateFunc) TreeNode {
+	return tn("css-part", x.Label())
 }

--- a/manifest/customelement.go
+++ b/manifest/customelement.go
@@ -21,8 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-
-	"github.com/pterm/pterm"
 )
 
 var _ Deprecatable = (*CustomElementDeclaration)(nil)
@@ -474,32 +472,32 @@ func (x *RenderableCustomElementDeclaration) Children() []Renderable {
 	return x.ChildNodes
 }
 
-func (x *RenderableCustomElementDeclaration) GroupedChildren(p PredicateFunc) []pterm.TreeNode {
-	var cs []pterm.TreeNode
+func (x *RenderableCustomElementDeclaration) GroupedChildren(p PredicateFunc) []TreeNode {
+	var cs []TreeNode
 
 	if attrs := toTreeChildren(x.attributes, p); len(attrs) > 0 {
-		cs = append(cs, tn(pterm.Blue("Attributes"), attrs...))
+		cs = append(cs, tn("section", categoryStyle.Render("Attributes"), attrs...))
 	}
 	if slots := toTreeChildren(x.slots, p); len(slots) > 0 {
-		cs = append(cs, tn(pterm.Blue("Slots"), slots...))
+		cs = append(cs, tn("section", categoryStyle.Render("Slots"), slots...))
 	}
 	if events := toTreeChildren(x.events, p); len(events) > 0 {
-		cs = append(cs, tn(pterm.Blue("Events"), events...))
+		cs = append(cs, tn("section", categoryStyle.Render("Events"), events...))
 	}
 	if fields := toTreeChildren(x.fields, p); len(fields) > 0 {
-		cs = append(cs, tn(pterm.Blue("Fields"), fields...))
+		cs = append(cs, tn("section", categoryStyle.Render("Fields"), fields...))
 	}
 	if methods := toTreeChildren(x.methods, p); len(methods) > 0 {
-		cs = append(cs, tn(pterm.Blue("Methods"), methods...))
+		cs = append(cs, tn("section", categoryStyle.Render("Methods"), methods...))
 	}
 	if cssprops := toTreeChildren(x.cssprops, p); len(cssprops) > 0 {
-		cs = append(cs, tn(pterm.Blue("CSS Properties"), cssprops...))
+		cs = append(cs, tn("section", categoryStyle.Render("CSS Properties"), cssprops...))
 	}
 	if cssparts := toTreeChildren(x.cssparts, p); len(cssparts) > 0 {
-		cs = append(cs, tn(pterm.Blue("Parts"), cssparts...))
+		cs = append(cs, tn("section", categoryStyle.Render("Parts"), cssparts...))
 	}
 	if cssstates := toTreeChildren(x.cssstates, p); len(cssstates) > 0 {
-		cs = append(cs, tn(pterm.Blue("States"), cssstates...))
+		cs = append(cs, tn("section", categoryStyle.Render("States"), cssstates...))
 	}
 
 	return cs
@@ -529,8 +527,8 @@ func (x *RenderableCustomElementDeclaration) ToTableRow() []string {
 	}
 }
 
-func (x *RenderableCustomElementDeclaration) ToTreeNode(p PredicateFunc) pterm.TreeNode {
-	return tn(x.Label(), x.GroupedChildren(p)...)
+func (x *RenderableCustomElementDeclaration) ToTreeNode(p PredicateFunc) TreeNode {
+	return tn("element", x.Label(), x.GroupedChildren(p)...)
 }
 
 func (x *RenderableCustomElementDeclaration) Sections() []Section {

--- a/manifest/customelement_test.go
+++ b/manifest/customelement_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"bennypowers.dev/cem/internal/platform/testutil"
-	"github.com/pterm/pterm"
+	treeview "github.com/Digital-Shane/treeview/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -44,10 +44,10 @@ func TestRenderableCustomElementDeclaration(t *testing.T) {
 		node := renderable.ToTreeNode(True)
 
 		// Find the module node
-		var moduleNode *pterm.TreeNode
-		for _, child := range node.Children {
-			if stripANSI(child.Text) == "module src/my-module.js" {
-				moduleNode = &child
+		var moduleNode TreeNode
+		for _, child := range node.Children() {
+			if stripANSI(child.Name()) == "module src/my-module.js" {
+				moduleNode = child
 				break
 			}
 		}
@@ -56,11 +56,11 @@ func TestRenderableCustomElementDeclaration(t *testing.T) {
 		}
 
 		// Find the custom element class node
-		var elemNode *pterm.TreeNode
-		for _, child := range moduleNode.Children {
-			text := stripANSI(child.Text)
+		var elemNode TreeNode
+		for _, child := range moduleNode.Children() {
+			text := stripANSI(child.Name())
 			if strings.Contains(text, "<my-element>") {
-				elemNode = &child
+				elemNode = child
 				break
 			}
 		}
@@ -70,7 +70,7 @@ func TestRenderableCustomElementDeclaration(t *testing.T) {
 		}
 
 		t.Run("RootNodeIsElement", func(t *testing.T) {
-			assert.Contains(t, stripANSI(elemNode.Text), "my-element")
+			assert.Contains(t, stripANSI(elemNode.Name()), "my-element")
 		})
 
 		t.Run("ChildrenAreGroupedByKind", func(t *testing.T) {
@@ -79,8 +79,8 @@ func TestRenderableCustomElementDeclaration(t *testing.T) {
 				"CSS Properties", "Parts", "States",
 			}
 			groupLabels := make([]string, 0)
-			for _, child := range elemNode.Children {
-				groupLabels = append(groupLabels, stripANSI(child.Text))
+			for _, child := range elemNode.Children() {
+				groupLabels = append(groupLabels, stripANSI(child.Name()))
 			}
 			for _, kind := range kinds {
 				assert.Containsf(t, groupLabels, kind, "expected group %q in tree node children", kind)
@@ -88,8 +88,14 @@ func TestRenderableCustomElementDeclaration(t *testing.T) {
 		})
 
 		t.Run("VisualTreeOutput", func(t *testing.T) {
-			_, err := pterm.DefaultTree.WithRoot(node).Srender()
-			assert.NoError(t, err)
+			tree := treeview.NewTree([]TreeNode{node},
+				treeview.WithExpandFunc[DisplayNode](func(_ TreeNode) bool { return true }),
+			)
+			model := treeview.NewTuiTreeModel(tree,
+				treeview.WithTuiDisableNavBar[DisplayNode](true),
+			)
+			s := model.View().Content
+			assert.NotEmpty(t, s)
 		})
 	})
 }

--- a/manifest/demo.go
+++ b/manifest/demo.go
@@ -16,10 +16,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 package manifest
 
-import (
-	"github.com/pterm/pterm"
-)
-
 var _ Renderable = (*RenderableDemo)(nil)
 
 // Demo for custom elements.
@@ -91,7 +87,7 @@ func (x *RenderableDemo) Children() []Renderable {
 	return nil
 }
 
-func (x *RenderableDemo) GroupedChildren(p PredicateFunc) []pterm.TreeNode {
+func (x *RenderableDemo) GroupedChildren(p PredicateFunc) []TreeNode {
 	return nil
 }
 
@@ -120,8 +116,8 @@ func (x *RenderableDemo) ToTableRow() []string {
 	}
 }
 
-func (x *RenderableDemo) ToTreeNode(p PredicateFunc) pterm.TreeNode {
-	return tn(x.Label(), x.GroupedChildren(p)...)
+func (x *RenderableDemo) ToTreeNode(p PredicateFunc) TreeNode {
+	return tn("demo", x.Label(), x.GroupedChildren(p)...)
 }
 
 func (x *RenderableDemo) Sections() []Section {

--- a/manifest/deprecations_test.go
+++ b/manifest/deprecations_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pterm/pterm"
+	treeview "github.com/Digital-Shane/treeview/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -121,14 +121,14 @@ func TestDeprecated(t *testing.T) {
 
 			// We'll flatten the tree to a list of text labels for easier searching.
 			var flat []string
-			var flatten func(node *pterm.TreeNode)
-			flatten = func(node *pterm.TreeNode) {
-				flat = append(flat, stripANSI(node.Text))
-				for i := range node.Children {
-					flatten(&node.Children[i])
+			var flatten func(node TreeNode)
+			flatten = func(node TreeNode) {
+				flat = append(flat, stripANSI(node.Name()))
+				for _, child := range node.Children() {
+					flatten(child)
 				}
 			}
-			flatten(&rootNode)
+			flatten(rootNode)
 
 			for _, check := range checks {
 				var found bool
@@ -164,8 +164,14 @@ func TestDeprecated(t *testing.T) {
 
 		// To visually inspect output for debugging
 		rootNode := renderable.ToTreeNode(IsDeprecated)
-		s, err := pterm.DefaultTree.WithRoot(rootNode).Srender()
+		tree := treeview.NewTree([]TreeNode{rootNode},
+			treeview.WithExpandFunc[DisplayNode](func(_ TreeNode) bool { return true }),
+		)
+		model := treeview.NewTuiTreeModel(tree,
+			treeview.WithTuiDisableNavBar[DisplayNode](true),
+		)
+		s := model.View().Content
 		t.Log(s)
-		assert.NoError(t, err)
+		assert.NotEmpty(t, s)
 	})
 }

--- a/manifest/event.go
+++ b/manifest/event.go
@@ -19,8 +19,6 @@ package manifest
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/pterm/pterm"
 )
 
 var _ Deprecatable = (*Event)(nil)
@@ -152,6 +150,6 @@ func (x *RenderableEvent) ToTableRow() []string {
 	}
 }
 
-func (x *RenderableEvent) ToTreeNode(pred PredicateFunc) pterm.TreeNode {
-	return tn(x.Label())
+func (x *RenderableEvent) ToTreeNode(pred PredicateFunc) TreeNode {
+	return tn("event", x.Label())
 }

--- a/manifest/function.go
+++ b/manifest/function.go
@@ -19,8 +19,6 @@ package manifest
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/pterm/pterm"
 )
 
 var _ Deprecatable = (*FunctionDeclaration)(nil)
@@ -212,7 +210,7 @@ func (x *RenderableFunctionDeclaration) Name() string {
 }
 
 func (x *RenderableFunctionDeclaration) Label() string {
-	return pterm.LightBlue("function") + " " + highlightIfDeprecated(x)
+	return kindStyle.Render("function") + " " + highlightIfDeprecated(x)
 }
 
 func (x *RenderableFunctionDeclaration) IsDeprecated() bool {
@@ -243,6 +241,6 @@ func (x *RenderableFunctionDeclaration) ToTableRow() []string {
 	}
 }
 
-func (x *RenderableFunctionDeclaration) ToTreeNode(pred PredicateFunc) pterm.TreeNode {
-	return tn(x.Label(), toTreeChildren(x.Children(), pred)...)
+func (x *RenderableFunctionDeclaration) ToTreeNode(pred PredicateFunc) TreeNode {
+	return tn("function", x.Label(), toTreeChildren(x.Children(), pred)...)
 }

--- a/manifest/mixin.go
+++ b/manifest/mixin.go
@@ -19,8 +19,6 @@ package manifest
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/pterm/pterm"
 )
 
 var _ Deprecatable = (*MixinDeclaration)(nil)
@@ -197,7 +195,7 @@ func (x *RenderableMixinDeclaration) Name() string {
 }
 
 func (x *RenderableMixinDeclaration) Label() string {
-	return pterm.LightBlue("mixin") + " " + highlightIfDeprecated(x)
+	return kindStyle.Render("mixin") + " " + highlightIfDeprecated(x)
 }
 
 func (x *RenderableMixinDeclaration) IsDeprecated() bool {
@@ -224,9 +222,9 @@ func (x *RenderableMixinDeclaration) ToTableRow() []string {
 	}
 }
 
-func (x *RenderableMixinDeclaration) ToTreeNode(p PredicateFunc) pterm.TreeNode {
+func (x *RenderableMixinDeclaration) ToTreeNode(p PredicateFunc) TreeNode {
 	// TODO: grouped params, return, class stuff as children
-	return tn(x.Label(), toTreeChildren(x.Children(), p)...)
+	return tn("mixin", x.Label(), toTreeChildren(x.Children(), p)...)
 }
 
 func (x *CustomElementMixinDeclaration) IsDeprecated() bool {
@@ -320,7 +318,7 @@ func (x *RenderableCustomElementMixinDeclaration) Name() string {
 }
 
 func (x *RenderableCustomElementMixinDeclaration) Label() string {
-	return pterm.LightBlue("custom element mixin") + " " + highlightIfDeprecated(x)
+	return kindStyle.Render("custom element mixin") + " " + highlightIfDeprecated(x)
 }
 
 func (x *RenderableCustomElementMixinDeclaration) ColumnHeadings() []string {
@@ -335,7 +333,7 @@ func (x *RenderableCustomElementMixinDeclaration) ToTableRow() []string {
 	}
 }
 
-func (x *RenderableCustomElementMixinDeclaration) ToTreeNode(p PredicateFunc) pterm.TreeNode {
+func (x *RenderableCustomElementMixinDeclaration) ToTreeNode(p PredicateFunc) TreeNode {
 	// TODO: group children in constructor
-	return tn(x.Label(), toTreeChildren(x.Children(), p)...)
+	return tn("custom-element-mixin", x.Label(), toTreeChildren(x.Children(), p)...)
 }

--- a/manifest/module.go
+++ b/manifest/module.go
@@ -20,8 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-
-	"github.com/pterm/pterm"
 )
 
 // Module may expand in future; currently only JavaScriptModule.
@@ -236,7 +234,7 @@ func (x *RenderableModule) Name() string {
 }
 
 func (x *RenderableModule) Label() string {
-	return pterm.LightBlue("module") + " " + highlightIfDeprecated(x)
+	return kindStyle.Render("module") + " " + highlightIfDeprecated(x)
 }
 
 func (x *RenderableModule) IsDeprecated() bool {
@@ -266,6 +264,6 @@ func (x *RenderableModule) ToTableRow() []string {
 	}
 }
 
-func (x *RenderableModule) ToTreeNode(p PredicateFunc) pterm.TreeNode {
-	return tn(x.Label(), toTreeChildren(x.Children(), p)...)
+func (x *RenderableModule) ToTreeNode(p PredicateFunc) TreeNode {
+	return tn("module", x.Label(), toTreeChildren(x.Children(), p)...)
 }

--- a/manifest/package.go
+++ b/manifest/package.go
@@ -19,8 +19,6 @@ package manifest
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/pterm/pterm"
 )
 
 var _ Deprecatable = (*Package)(nil)
@@ -279,6 +277,6 @@ func (x *RenderablePackage) ToTableRow() []string {
 	return []string{}
 }
 
-func (x *RenderablePackage) ToTreeNode(p PredicateFunc) pterm.TreeNode {
-	return tn(x.Label(), toTreeChildren(x.Children(), p)...)
+func (x *RenderablePackage) ToTreeNode(p PredicateFunc) TreeNode {
+	return tn("package", x.Label(), toTreeChildren(x.Children(), p)...)
 }

--- a/manifest/slot.go
+++ b/manifest/slot.go
@@ -19,8 +19,6 @@ package manifest
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/pterm/pterm"
 )
 
 var _ Deprecatable = (*Slot)(nil)
@@ -154,6 +152,6 @@ func (x *RenderableSlot) ToTableRow() []string {
 	}
 }
 
-func (x *RenderableSlot) ToTreeNode(p PredicateFunc) pterm.TreeNode {
-	return tn(x.Label())
+func (x *RenderableSlot) ToTreeNode(p PredicateFunc) TreeNode {
+	return tn("slot", x.Label())
 }

--- a/manifest/styles.go
+++ b/manifest/styles.go
@@ -1,0 +1,11 @@
+package manifest
+
+import lipgloss "charm.land/lipgloss/v2"
+
+var (
+	categoryStyle         = lipgloss.NewStyle().Foreground(lipgloss.Blue)
+	kindStyle             = lipgloss.NewStyle().Foreground(lipgloss.BrightBlue)
+	summaryStyle          = lipgloss.NewStyle().Foreground(lipgloss.BrightBlack)
+	deprecatedStyle       = lipgloss.NewStyle().Foreground(lipgloss.Red)
+	deprecatedReasonStyle = lipgloss.NewStyle().Foreground(lipgloss.BrightRed)
+)

--- a/manifest/variable.go
+++ b/manifest/variable.go
@@ -19,8 +19,6 @@ package manifest
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/pterm/pterm"
 )
 
 var _ Deprecatable = (*VariableDeclaration)(nil)
@@ -162,6 +160,6 @@ func (x *RenderableVariableDeclaration) ToTableRow() []string {
 	}
 }
 
-func (x *RenderableVariableDeclaration) ToTreeNode(p PredicateFunc) pterm.TreeNode {
-	return tn(x.Label())
+func (x *RenderableVariableDeclaration) ToTreeNode(p PredicateFunc) TreeNode {
+	return tn("variable", x.Label())
 }

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -21,7 +21,7 @@ import (
 
 	"bennypowers.dev/cem/manifest"
 	"bennypowers.dev/cem/search"
-	"github.com/pterm/pterm"
+	treeview "github.com/Digital-Shane/treeview/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -43,8 +43,8 @@ func (m *mockRenderable) IsDeprecated() bool               { return false }
 func (m *mockRenderable) Deprecation() manifest.Deprecated { return nil }
 func (m *mockRenderable) ColumnHeadings() []string         { return []string{"Name"} }
 func (m *mockRenderable) ToTableRow() []string             { return []string{m.name} }
-func (m *mockRenderable) ToTreeNode(pred manifest.PredicateFunc) pterm.TreeNode {
-	return pterm.TreeNode{Text: m.name}
+func (m *mockRenderable) ToTreeNode(pred manifest.PredicateFunc) manifest.TreeNode {
+	return treeview.NewNodeSimple(m.name, manifest.DisplayNode{Label: m.name})
 }
 func (m *mockRenderable) Children() []manifest.Renderable { return nil }
 


### PR DESCRIPTION
## Summary

Second step of the pterm-to-charmbracelet migration (#373). Replaces `pterm.TreeNode` and pterm color functions across 20 manifest/*.go files with treeview v2 nodes and lipgloss styles.

- **manifest/styles.go**: new file with lipgloss styles replacing pterm color functions (category, kind, summary, deprecated)
- **manifest/context.go**: `DisplayNode` type, `TreeNode` alias for `*treeview.Node[DisplayNode]`, updated `Renderable`/`GroupedRenderable` interfaces, `tn()` and `toTreeChildren()` helpers
- **17 manifest/*.go files**: mechanical pterm-to-lipgloss/treeview replacement
- **list/tree.go**: `pterm.DefaultTree` replaced with `tree.Render(ctx)` for static output (no viewport truncation)
- **cmd/list.go, cmd/search.go**: output routed through `lipgloss.Fprintln`/`lipgloss.Fprintf` for NO_COLOR and non-TTY color profile support
- **E2E tests**: `pterm.RemoveColorFromString` replaced with `ansi.Strip` (pterm's regex misses lipgloss's short reset sequences)

pterm remains in go.mod for table rendering (migrated in #376).

Closes #375

## Test plan

- [x] `make lint` -- 0 issues
- [x] `make test-unit` -- 4192 tests pass
- [x] `go test -tags=e2e ./cmd/` -- 115 E2E tests pass
- [x] `cem list --format tree -p examples/kitchen-sink` -- full 245-line tree renders with correct connectors
- [x] `NO_COLOR=1 cem list --format tree -p examples/kitchen-sink` -- ANSI codes stripped
- [x] `cem list -p examples/kitchen-sink` -- default table format unaffected
- [x] `cem search button -p examples/kitchen-sink` -- search tree renders
- [x] `cem list --format tree --deprecated -p examples/kitchen-sink` -- deprecation filtering works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated internal rendering libraries for improved consistency and maintainability. No changes to command behavior or output appearance.

* **Dependencies**
  * Added `treeview/v2` and `ansi` libraries for enhanced UI rendering.
  * Updated `golang.org/x` dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->