### PR TITLE
fix(validate): emit single JSON document in workspace mode

### DIFF
--- a/cmd/testdata/fixtures/workspace-validate/package.json
+++ b/cmd/testdata/fixtures/workspace-validate/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "workspace-validate-test",
+  "private": true,
+  "workspaces": ["packages/*"]
+}

--- a/cmd/testdata/fixtures/workspace-validate/packages/alpha/custom-elements.json
+++ b/cmd/testdata/fixtures/workspace-validate/packages/alpha/custom-elements.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "alpha-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "name": "AlphaElement",
+          "tagName": "alpha-element",
+          "customElement": true,
+          "members": []
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "alpha-element",
+          "declaration": {
+            "name": "AlphaElement",
+            "module": "alpha-element.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/cmd/testdata/fixtures/workspace-validate/packages/alpha/package.json
+++ b/cmd/testdata/fixtures/workspace-validate/packages/alpha/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@test/alpha",
+  "customElements": "custom-elements.json"
+}

--- a/cmd/testdata/fixtures/workspace-validate/packages/beta/custom-elements.json
+++ b/cmd/testdata/fixtures/workspace-validate/packages/beta/custom-elements.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "beta-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "name": "BetaElement",
+          "tagName": "beta-element",
+          "customElement": true,
+          "members": []
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "beta-element",
+          "declaration": {
+            "name": "BetaElement",
+            "module": "beta-element.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/cmd/testdata/fixtures/workspace-validate/packages/beta/package.json
+++ b/cmd/testdata/fixtures/workspace-validate/packages/beta/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@test/beta",
+  "customElements": "custom-elements.json"
+}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -40,6 +40,8 @@ func validateWorkspace(cmd *cobra.Command) error {
 	allDisabled = append(allDisabled, configDisabled...)
 	allDisabled = append(allDisabled, disableFlags...)
 
+	var collected []V.PackageValidationResult
+
 	results := workspace.ForEachPackage(ctx.Root(), func(pkg workspace.PackageInfo) error {
 		manifestPath := filepath.Join(pkg.Path, pkg.CustomElementsRef)
 		options := V.ValidationOptions{
@@ -50,18 +52,33 @@ func validateWorkspace(cmd *cobra.Command) error {
 		if err != nil {
 			return err
 		}
-		displayOptions := V.DisplayOptions{
-			Format: format,
+
+		if format == "text" || format == "" {
+			displayOptions := V.DisplayOptions{Format: format}
+			cmd.PrintErrln("\n" + pkg.Name + ":")
+			if err := V.PrintValidationResult(cmd.OutOrStdout(), manifestPath, result, displayOptions); err != nil {
+				return err
+			}
+		} else {
+			result.Path = manifestPath
+			collected = append(collected, V.PackageValidationResult{
+				Package: pkg.Name,
+				Result:  result,
+			})
 		}
-		cmd.PrintErrln("\n" + pkg.Name + ":")
-		if err := V.PrintValidationResult(cmd.OutOrStdout(), manifestPath, result, displayOptions); err != nil {
-			return err
-		}
+
 		if !result.IsValid {
 			return fmt.Errorf("validation failed")
 		}
 		return nil
 	})
+
+	if format != "text" && format != "" {
+		displayOptions := V.DisplayOptions{Format: format}
+		if err := V.PrintWorkspaceValidationResults(cmd.OutOrStdout(), collected, displayOptions); err != nil {
+			return err
+		}
+	}
 
 	return workspace.ReportResults("Validated manifests", results)
 }

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -20,11 +20,25 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestValidateWorkspaceJSON(t *testing.T) {
+	projectDir := setupTest(t, "workspace-validate")
+	stdout, _ := runCemCommand(t, projectDir, "validate", "--format=json")
+
+	var results []json.RawMessage
+	if err := json.Unmarshal([]byte(stdout), &results); err != nil {
+		t.Fatalf("workspace --format=json must produce a single JSON array, got parse error: %v\nstdout: %s", err, stdout)
+	}
+	if len(results) != 2 {
+		t.Errorf("expected 2 package results, got %d", len(results))
+	}
+}
 
 func TestValidateE2E(t *testing.T) {
 	testCases := []struct {

--- a/validate/display.go
+++ b/validate/display.go
@@ -52,6 +52,24 @@ type DisplayOptions struct {
 	Format string
 }
 
+// PackageValidationResult pairs a package name with its validation result for workspace output.
+type PackageValidationResult struct {
+	Package string            `json:"package"`
+	Result  *ValidationResult `json:"result"`
+}
+
+// PrintWorkspaceValidationResults prints collected workspace validation results as a single output.
+func PrintWorkspaceValidationResults(w io.Writer, results []PackageValidationResult, options DisplayOptions) error {
+	switch options.Format {
+	case "json":
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(results)
+	default:
+		return fmt.Errorf("unsupported workspace format: %s", options.Format)
+	}
+}
+
 // PrintValidationResult prints the validation result with appropriate formatting
 func PrintValidationResult(w io.Writer, manifestPath string, result *ValidationResult, options DisplayOptions) error {
 	switch options.Format {


### PR DESCRIPTION
## Summary

- Workspace-mode `validate --format json` was writing one JSON object per
  package to stdout. Consumers like the benchmark script's `jq --argjson`
  require a single JSON value, so concatenated objects caused parse failures
  (breaking `docs.yaml` CI for the last 3 pushes).
- Follow the health command pattern: collect results during the workspace
  loop, then encode once as a JSON array. Text format is unchanged.
- Add `PackageValidationResult` type and `PrintWorkspaceValidationResults`
  to the validate package, mirroring `health.PackageHealthResult`.

## Test plan

- [x] `dist/cem validate --format json` outputs a JSON array (not concatenated objects)
- [x] `dist/cem validate` text output unchanged
- [x] `dist/cem validate --format json -p examples/kitchen-sink` still outputs single object
- [x] New e2e test `TestValidateWorkspaceJSON` passes
- [x] All 116 e2e tests pass
- [x] `golangci-lint run` clean
- [x] `go vet ./...` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace validation now supports JSON output format, aggregating validation results across all packages for easier integration with external tools and scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->