### PR TITLE
fix(validate,benchmark): consistent JSON output and benchmark fixes

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -40,7 +40,7 @@ func validateWorkspace(cmd *cobra.Command) error {
 	allDisabled = append(allDisabled, configDisabled...)
 	allDisabled = append(allDisabled, disableFlags...)
 
-	var collected []V.PackageValidationResult
+	var collected []*V.ValidationResult
 
 	results := workspace.ForEachPackage(ctx.Root(), func(pkg workspace.PackageInfo) error {
 		manifestPath := filepath.Join(pkg.Path, pkg.CustomElementsRef)
@@ -53,18 +53,18 @@ func validateWorkspace(cmd *cobra.Command) error {
 			return err
 		}
 
-		if format == "text" || format == "" {
+		switch format {
+		case "text", "":
 			displayOptions := V.DisplayOptions{Format: format}
 			cmd.PrintErrln("\n" + pkg.Name + ":")
 			if err := V.PrintValidationResult(cmd.OutOrStdout(), manifestPath, result, displayOptions); err != nil {
 				return err
 			}
-		} else {
+		case "json":
 			result.Path = manifestPath
-			collected = append(collected, V.PackageValidationResult{
-				Package: pkg.Name,
-				Result:  result,
-			})
+			collected = append(collected, result)
+		default:
+			return fmt.Errorf("invalid format %q: must be text or json", format)
 		}
 
 		if !result.IsValid {
@@ -74,8 +74,7 @@ func validateWorkspace(cmd *cobra.Command) error {
 	})
 
 	if format != "text" && format != "" {
-		displayOptions := V.DisplayOptions{Format: format}
-		if err := V.PrintWorkspaceValidationResults(cmd.OutOrStdout(), collected, displayOptions); err != nil {
+		if err := V.PrintValidationResultsJSON(cmd.OutOrStdout(), collected); err != nil {
 			return err
 		}
 	}
@@ -95,7 +94,7 @@ var validateCmd = &cobra.Command{
 	Long:  `Validate a custom-elements.json manifest against its JSON schema.`,
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if workspace.ShouldUseWorkspaceMode(cmd) {
+		if workspace.ShouldUseWorkspaceMode(cmd) && len(args) == 0 {
 			if err := validateWorkspace(cmd); err != nil {
 				os.Exit(1)
 			}
@@ -139,12 +138,19 @@ var validateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		displayOptions := V.DisplayOptions{
-			Format: format,
-		}
-		if err := V.PrintValidationResult(cmd.OutOrStdout(), manifestPath, result, displayOptions); err != nil {
-			cmd.PrintErrln("Error displaying validation results:", err)
-			os.Exit(1)
+		switch format {
+		case "json":
+			result.Path = manifestPath
+			if err := V.PrintValidationResultsJSON(cmd.OutOrStdout(), []*V.ValidationResult{result}); err != nil {
+				cmd.PrintErrln("Error displaying validation results:", err)
+				os.Exit(1)
+			}
+		default:
+			displayOptions := V.DisplayOptions{Format: format}
+			if err := V.PrintValidationResult(cmd.OutOrStdout(), manifestPath, result, displayOptions); err != nil {
+				cmd.PrintErrln("Error displaying validation results:", err)
+				os.Exit(1)
+			}
 		}
 
 		// Exit with error code if validation failed

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -27,6 +27,19 @@ import (
 	"testing"
 )
 
+func TestValidateSingleManifestJSONIsArray(t *testing.T) {
+	projectDir := setupTest(t, "valid-manifest")
+	stdout, _ := runCemCommand(t, projectDir, "validate", "--format=json")
+
+	var results []json.RawMessage
+	if err := json.Unmarshal([]byte(stdout), &results); err != nil {
+		t.Fatalf("--format=json must produce a JSON array, got parse error: %v\nstdout: %s", err, stdout)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 result, got %d", len(results))
+	}
+}
+
 func TestValidateWorkspaceJSON(t *testing.T) {
 	projectDir := setupTest(t, "workspace-validate")
 	stdout, _ := runCemCommand(t, projectDir, "validate", "--format=json")

--- a/lsp/benchmark/configs/cem-minimal.lua
+++ b/lsp/benchmark/configs/cem-minimal.lua
@@ -29,7 +29,15 @@ local cem_config = {
 		"javascript",
 	},
 	single_file_support = true,
-	capabilities = vim.lsp.protocol.make_client_capabilities(),
+	capabilities = (function()
+		local caps = vim.lsp.protocol.make_client_capabilities()
+		-- Disable pull diagnostics so the server uses push (textDocument/publishDiagnostics).
+		-- The benchmark handler listens for push notifications.
+		if caps.textDocument then
+			caps.textDocument.diagnostic = nil
+		end
+		return caps
+	end)(),
 	on_attach = function(_, _) end,
 	on_init = function(_, _) end,
 }

--- a/lsp/benchmark/configs/wc-toolkit-minimal.lua
+++ b/lsp/benchmark/configs/wc-toolkit-minimal.lua
@@ -30,7 +30,15 @@ local wc_toolkit_config = {
     'javascript',
   },
   single_file_support = true,
-  capabilities = vim.lsp.protocol.make_client_capabilities(),
+  capabilities = (function()
+    local caps = vim.lsp.protocol.make_client_capabilities()
+    -- Disable pull diagnostics so the server uses push (textDocument/publishDiagnostics).
+    -- The benchmark handler listens for push notifications.
+    if caps.textDocument then
+      caps.textDocument.diagnostic = nil
+    end
+    return caps
+  end)(),
   on_attach = function(client, bufnr)
     -- Minimal attach - no keybindings or fancy features
   end,

--- a/lsp/benchmark/modules/diagnostics_benchmark.lua
+++ b/lsp/benchmark/modules/diagnostics_benchmark.lua
@@ -9,33 +9,7 @@ function M.run_diagnostics_benchmark(config, fixture_dir)
 	local server_name = _G.BENCHMARK_LSP_NAME or "unknown"
 	local DIAGNOSTICS_TIMEOUT_MS = 3000
 
-	-- Track diagnostics - store bufnr for use in handler
-	local received_diagnostics = {}
-	local diagnostics_received = false
-	local test_bufnr = nil
-
-	-- Add client-specific diagnostics handler to config
-	-- This avoids modifying global handlers and prevents collisions with other LSP usage
-	local client_config = vim.tbl_deep_extend("force", config, {
-		handlers = {
-			["textDocument/publishDiagnostics"] = function(diag_err, result, ctx, handler_config)
-				if result and result.diagnostics then
-					received_diagnostics = result.diagnostics
-					diagnostics_received = true
-					-- Update diagnostics state using modern API
-					-- Use stored bufnr if ctx.bufnr is nil (root cause fix)
-					local bufnr = ctx.bufnr or test_bufnr
-					if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
-						local namespace = vim.api.nvim_create_namespace(("lsp_%d"):format(ctx.client_id))
-						vim.diagnostic.set(namespace, bufnr, result.diagnostics)
-					end
-				end
-			end,
-		},
-	})
-
-	-- Setup LSP client with custom handlers
-	local client, err = benchmark.setup_client(client_config, fixture_dir)
+	local client, err = benchmark.setup_client(config, fixture_dir)
 	if not client then
 		return {
 			success = false,
@@ -46,36 +20,34 @@ function M.run_diagnostics_benchmark(config, fixture_dir)
 
 	local diagnostics_start = vim.uv.hrtime()
 
-	-- Now open the file (which will trigger didOpen and diagnostics)
 	local bufnr, test_file = benchmark.setup_test_file(fixture_dir, "diagnostics", "html", 2000, client)
 	if not bufnr then
 		benchmark.cleanup_test(nil, nil, client)
 		return {
 			success = false,
 			success_rate = 0.0,
-			error = test_file, -- test_file contains error message on failure
+			error = test_file,
 		}
 	end
 
-	-- Store bufnr for handler to use (root cause fix)
-	test_bufnr = bufnr
-
-	-- Wait for diagnostics to be published (if not already received)
-	local diagnostics_success = diagnostics_received
+	-- Neovim 0.11+ routes publishDiagnostics through vim.diagnostic internally;
+	-- custom client handlers for this method are bypassed. Poll vim.diagnostic.get()
+	-- instead of waiting for a handler callback.
+	local diagnostics_success = #vim.diagnostic.get(bufnr) > 0
 		or vim.wait(DIAGNOSTICS_TIMEOUT_MS, function()
-			return diagnostics_received or client:is_stopped()
+			return #vim.diagnostic.get(bufnr) > 0 or client:is_stopped()
 		end)
 
 	local diagnostics_duration = (vim.uv.hrtime() - diagnostics_start) / 1e6
 	local client_stopped = client:is_stopped()
+	local received_diagnostics = vim.diagnostic.get(bufnr)
 
-	-- Check if server supports diagnostics
 	local supports_diagnostics = client.server_capabilities
 		and (client.server_capabilities.diagnosticProvider or client.server_capabilities.textDocumentSync)
 
 	local result = {
-		success = false, -- Will be set to true only if diagnostics work correctly
-		success_rate = 0.0, -- Will be set to 1.0 if diagnostics work correctly
+		success = false,
+		success_rate = 0.0,
 		server_name = server_name,
 		duration_ms = diagnostics_duration,
 		diagnostics_count = #received_diagnostics,
@@ -91,7 +63,6 @@ function M.run_diagnostics_benchmark(config, fixture_dir)
 	elseif not diagnostics_success then
 		result.error = string.format("Timeout waiting for diagnostics (%gs)", DIAGNOSTICS_TIMEOUT_MS / 1000)
 	else
-		-- Validate that we received real diagnostics with proper structure
 		local has_valid_diagnostics = false
 		local error_count = 0
 		local warning_count = 0
@@ -99,8 +70,7 @@ function M.run_diagnostics_benchmark(config, fixture_dir)
 		local hint_count = 0
 
 		for _, diagnostic in ipairs(received_diagnostics) do
-			-- Check that diagnostic has required fields
-			if diagnostic.range and diagnostic.message and #diagnostic.message > 0 then
+			if diagnostic.lnum ~= nil and diagnostic.message and #diagnostic.message > 0 then
 				has_valid_diagnostics = true
 
 				if diagnostic.severity == vim.diagnostic.severity.ERROR then
@@ -122,17 +92,15 @@ function M.run_diagnostics_benchmark(config, fixture_dir)
 			hints = hint_count,
 		}
 
-		-- Only mark as success if we got valid diagnostics with content
 		if has_valid_diagnostics then
 			result.success = true
 			result.success_rate = 1.0
 		else
-			result.error = "No valid diagnostics received (missing range or message)"
+			result.error = "No valid diagnostics received (missing lnum or message)"
 			result.success_rate = 0.0
 		end
 	end
 
-	-- Clean up
 	benchmark.cleanup_test(bufnr, test_file, client)
 
 	return result

--- a/lsp/benchmark/modules/references_benchmark.lua
+++ b/lsp/benchmark/modules/references_benchmark.lua
@@ -296,6 +296,11 @@ function M.run_references_benchmark(config, fixture_dir)
 		results.references_supported = supports_references
 		results.not_supported = not supports_references
 
+		if not supports_references then
+			results.error = "Feature not available in server capabilities"
+			return
+		end
+
 		-- Build small scale test list using dynamic positions
 		local small_scale_tests = {}
 		if positions_map["my-nav"] then
@@ -462,52 +467,27 @@ function M.run_references_benchmark(config, fixture_dir)
 		collectgarbage("collect")
 		results.memory_usage = collectgarbage("count") * 1024 -- Convert KB to bytes
 
-		-- Success requires both completing tests AND finding references
-		results.success = total_references >= 10 and total_tests >= 8
-		results.success_rate = results.success and 1.0 or 0.0
+		local successful_tests = 0
+		for _, scale in pairs(results.project_scale_results) do
+			if scale.tests then
+				for _, test in ipairs(scale.tests) do
+					if test.success then
+						successful_tests = successful_tests + 1
+					end
+				end
+			end
+		end
 
-		-- Set error message if criteria not met
+		results.success = total_tests > 0 and successful_tests > 0
+		results.success_rate = total_tests > 0 and (successful_tests / total_tests) or 0.0
+
 		if not results.success then
 			if results.not_supported then
 				results.error = "Feature not available in server capabilities"
+			elseif total_tests == 0 then
+				results.error = "no reference tests completed"
 			else
-				local reasons = {}
-				if total_references < 10 then
-					-- Check if there were any LSP errors
-					local had_errors = false
-					for _, scale in pairs(results.project_scale_results) do
-						if scale.tests then
-							for _, test in ipairs(scale.tests) do
-								if test.lsp_error then
-									had_errors = true
-									break
-								end
-							end
-						end
-					end
-
-					if had_errors then
-						table.insert(
-							reasons,
-							string.format(
-								"insufficient references found (%d < 10) - LSP errors occurred",
-								total_references
-							)
-						)
-					else
-						table.insert(
-							reasons,
-							string.format(
-								"insufficient references found (%d < 10) - server returned empty results",
-								total_references
-							)
-						)
-					end
-				end
-				if total_tests < 8 then
-					table.insert(reasons, string.format("insufficient tests completed (%d < 8)", total_tests))
-				end
-				results.error = table.concat(reasons, "; ")
+				results.error = string.format("no references found across %d tests", total_tests)
 			end
 		end
 	end)

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -134,9 +134,9 @@ for i in "${!ids[@]}"; do
     validation_stderr=$(mktemp)
     (cd .. && go run . validate --format json "docs/$resultFile") >"$validation_tmp" 2>"$validation_stderr" || true
 
-    # Try to extract valid JSON from output
-    if [[ -s "$validation_tmp" ]] && jq . "$validation_tmp" >/dev/null 2>&1; then
-      validation_result=$(cat "$validation_tmp")
+    # validate --format json always returns an array; extract the first result
+    if [[ -s "$validation_tmp" ]] && jq '.[0]' "$validation_tmp" >/dev/null 2>&1; then
+      validation_result=$(jq '.[0]' "$validation_tmp")
     elif [[ -s "$validation_stderr" ]]; then
       # Log what we got for debugging
       echo "Validation output:" >&2

--- a/validate/display.go
+++ b/validate/display.go
@@ -52,22 +52,14 @@ type DisplayOptions struct {
 	Format string
 }
 
-// PackageValidationResult pairs a package name with its validation result for workspace output.
-type PackageValidationResult struct {
-	Package string            `json:"package"`
-	Result  *ValidationResult `json:"result"`
-}
-
-// PrintWorkspaceValidationResults prints collected workspace validation results as a single output.
-func PrintWorkspaceValidationResults(w io.Writer, results []PackageValidationResult, options DisplayOptions) error {
-	switch options.Format {
-	case "json":
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(results)
-	default:
-		return fmt.Errorf("unsupported workspace format: %s", options.Format)
+// PrintValidationResultsJSON encodes one or more validation results as a JSON array.
+func PrintValidationResultsJSON(w io.Writer, results []*ValidationResult) error {
+	if results == nil {
+		results = []*ValidationResult{}
 	}
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(results)
 }
 
 // PrintValidationResult prints the validation result with appropriate formatting


### PR DESCRIPTION
Fixes docs.yaml CI failure from #384.

`validate --format json` now returns `[]ValidationResult` in all modes
(single-file wraps in a one-element array). Positional file arg bypasses
workspace mode.

LSP benchmark diagnostics were timing out because Neovim 0.11+ handles
`publishDiagnostics` internally, so the custom handler never fired.
Switched to polling `vim.diagnostic.get()`. References benchmark now
reports the count instead of failing when a server returns zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LSP diagnostic handling by switching to push-based diagnostics delivery instead of pull-based, ensuring more reliable diagnostic reporting in benchmarks.

* **Improvements**
  * Updated validate command's JSON output format to return results as an array for consistent parsing.
  * Simplified validation result aggregation and display logic for better performance.

* **Tests**
  * Added test coverage for JSON array output format in single manifest validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->