### PR TITLE
refactor(tui): replace pterm color calls with lipgloss in cmd layer

### DIFF
--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -20,20 +20,15 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd_test
 
 import (
-	"bytes"
-	"encoding/json"
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"bennypowers.dev/cem/internal/platform/testutil"
 	"github.com/charmbracelet/x/ansi"
-	"github.com/nsf/jsondiff"
 )
-
-var update = flag.Bool("update", false, "update golden files")
 
 func TestGenerateE2E(t *testing.T) {
 	testCases := []struct {
@@ -79,7 +74,6 @@ func TestGenerateE2E(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			projectDir := setupTest(t, tc.fixture)
 			outputFilePath := filepath.Join(projectDir, tc.outputFile)
-			goldenPath := filepath.Join("testdata", "goldens", tc.name+".json")
 
 			command := tc.command
 			if len(command) > 0 && command[len(command)-1] == "--package" {
@@ -102,30 +96,11 @@ func TestGenerateE2E(t *testing.T) {
 				t.Fatalf("Failed to read output file: %v", err)
 			}
 
-			if *update {
-				if err := os.WriteFile(goldenPath, content, 0644); err != nil {
-					t.Fatalf("failed to write golden file: %v", err)
-				}
-			}
-
-			expected, err := os.ReadFile(goldenPath)
-			if err != nil {
-				t.Fatalf("golden file missing: %s (have you run with -update?)\nerror: %v", goldenPath, err)
-			}
-
-			// Validate JSON
-			var jsExpected, jsActual any
-			if err := json.Unmarshal(expected, &jsExpected); err != nil {
-				t.Fatalf("expected golden file is invalid JSON: %v", err)
-			}
-			if err := json.Unmarshal(content, &jsActual); err != nil {
-				t.Fatalf("actual output is invalid JSON: %v\noutput:\n%s", err, content)
-			}
-
-			if !bytes.Equal(expected, content) {
-				options := jsondiff.DefaultConsoleOptions()
-				t.Error(jsondiff.Compare(expected, content, &options))
-			}
+			testutil.CheckGolden(t, tc.name, content, testutil.GoldenOptions{
+				Dir:         "testdata/goldens",
+				Extension:   ".json",
+				UseJSONDiff: true,
+			})
 
 			expectedLog := tc.expectedLog
 			if tc.name == "WithOutputFlag" {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -36,7 +36,6 @@ import (
 	"bennypowers.dev/cem/serve/middleware/transform"
 	"bennypowers.dev/cem/serve/middleware/types"
 	W "bennypowers.dev/cem/internal/workspace"
-	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -176,7 +175,7 @@ var serveCmd = &cobra.Command{
 			},
 		}
 
-		// Create pterm logger
+		// Create logger
 		log := logger.NewPtermLogger()
 		defer func() {
 			if l, ok := log.(interface{ Stop() }); ok {
@@ -199,7 +198,7 @@ var serveCmd = &cobra.Command{
 			}
 		}()
 
-		// Set pterm logger
+		// Set logger
 		server.SetLogger(log)
 
 		// Set watch directory to project root
@@ -303,25 +302,14 @@ var serveCmd = &cobra.Command{
 		actualPort := server.Port()
 		log.Success("Server started on http://localhost:%d%s", actualPort, reloadStatus)
 
-		// Update status with running info (with colors)
-		reloadColor := pterm.FgRed.Sprint("false")
-		if reload {
-			reloadColor = pterm.FgGreen.Sprint("true")
-		}
-		statusMsg := fmt.Sprintf("Running on %s%s Live reload: %s %s Press %s for help, %s to quit",
-			pterm.FgCyan.Sprintf("http://localhost:%d", actualPort),
-			pterm.FgGray.Sprint(" |"),
-			reloadColor,
-			pterm.FgGray.Sprint("|"),
-			pterm.FgYellow.Sprint("h"),
-			pterm.FgYellow.Sprint("q"),
-		)
+		// Update status with running info
+		statusMsg := formatStatusLine(actualPort, reload)
 		if l, ok := log.(interface{ SetStatus(string) }); ok {
 			l.SetStatus(statusMsg)
 		}
 
 		// Start keyboard input handler after a brief delay
-		// This allows pterm's live area to stabilize before we enable raw mode
+		// This allows the live area to stabilize before we enable raw mode
 		quitChan := make(chan struct{})
 		go func() {
 			time.Sleep(100 * time.Millisecond)

--- a/cmd/serve_status.go
+++ b/cmd/serve_status.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+
+	lipgloss "charm.land/lipgloss/v2"
+)
+
+var (
+	statusURLStyle      = lipgloss.NewStyle().Foreground(lipgloss.Cyan)
+	statusSepStyle      = lipgloss.NewStyle().Foreground(lipgloss.BrightBlack)
+	statusKeyStyle      = lipgloss.NewStyle().Foreground(lipgloss.Yellow)
+	statusEnabledStyle  = lipgloss.NewStyle().Foreground(lipgloss.Green)
+	statusDisabledStyle = lipgloss.NewStyle().Foreground(lipgloss.Red)
+)
+
+func formatStatusLine(port int, reload bool) string {
+	reloadColor := statusDisabledStyle.Render("false")
+	if reload {
+		reloadColor = statusEnabledStyle.Render("true")
+	}
+	sep := statusSepStyle.Render("|")
+	// NOTE: may be replaced with native bubbles components in issue 377, 379
+	return fmt.Sprintf("Running on %s %s Live reload: %s %s Press %s for help, %s to quit",
+		statusURLStyle.Render(fmt.Sprintf("http://localhost:%d", port)),
+		sep,
+		reloadColor,
+		sep,
+		statusKeyStyle.Render("h"),
+		statusKeyStyle.Render("q"),
+	)
+}

--- a/cmd/serve_status_test.go
+++ b/cmd/serve_status_test.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"testing"
+
+	"bennypowers.dev/cem/internal/platform/testutil"
+)
+
+func TestFormatStatusLine(t *testing.T) {
+	tests := []struct {
+		name   string
+		port   int
+		reload bool
+	}{
+		{name: "reload-enabled", port: 8000, reload: true},
+		{name: "reload-disabled", port: 3000, reload: false},
+		{name: "port-zero", port: 0, reload: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatStatusLine(tc.port, tc.reload)
+			testutil.CheckGolden(t, tc.name, []byte(got), testutil.GoldenOptions{
+				Dir: "testdata/goldens/serve-status",
+			})
+		})
+	}
+}

--- a/cmd/testdata/goldens/serve-status/port-zero.txt
+++ b/cmd/testdata/goldens/serve-status/port-zero.txt
@@ -1,0 +1,1 @@
+Running on [36mhttp://localhost:0[m [90m|[m Live reload: [32mtrue[m [90m|[m Press [33mh[m for help, [33mq[m to quit

--- a/cmd/testdata/goldens/serve-status/reload-disabled.txt
+++ b/cmd/testdata/goldens/serve-status/reload-disabled.txt
@@ -1,0 +1,1 @@
+Running on [36mhttp://localhost:3000[m [90m|[m Live reload: [31mfalse[m [90m|[m Press [33mh[m for help, [33mq[m to quit

--- a/cmd/testdata/goldens/serve-status/reload-enabled.txt
+++ b/cmd/testdata/goldens/serve-status/reload-enabled.txt
@@ -1,0 +1,1 @@
+Running on [36mhttp://localhost:8000[m [90m|[m Live reload: [32mtrue[m [90m|[m Press [33mh[m for help, [33mq[m to quit

--- a/cmd/workspace_test.go
+++ b/cmd/workspace_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"bennypowers.dev/cem/internal/platform/testutil"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/nsf/jsondiff"
 	"github.com/stretchr/testify/assert"
@@ -82,7 +83,7 @@ func normalizeTextOutput(s string) string {
 func compareGolden(t *testing.T, goldenPath, actual string, isJSON bool) {
 	t.Helper()
 
-	if *update {
+	if *testutil.Update {
 		if err := os.MkdirAll(filepath.Dir(goldenPath), 0755); err != nil {
 			t.Fatalf("failed to create golden dir: %v", err)
 		}


### PR DESCRIPTION
## Summary

- Extract `formatStatusLine()` from inline pterm color calls in `cmd/serve.go` to a dedicated function using lipgloss styles
- Remove `pterm` import from `serve.go` (no longer needed for styling)
- Add golden-based unit tests for status line formatting

`list.go` and `search.go` were already migrated to lipgloss in #383.

Closes #380

## Test plan

- [x] `make test-unit` passes (4202 tests)
- [x] `make lint` clean (0 issues)
- [ ] Manual: `cem serve -p examples/kitchen-sink` -- verify status line colors
- [ ] Manual: `cem list -p examples/kitchen-sink` -- verify package headers
- [ ] Manual: `cem search -p examples/kitchen-sink button` -- verify search output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined the development server status display implementation, improving maintainability while preserving the display of server URL, live reload status, and interactive help hints.

* **Tests**
  * Added comprehensive test coverage for server status messages across various configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->