### PR TITLE
feat(generate): resolve const variable references in @customElement decorator

### DIFF
--- a/generate/classDeclarations.go
+++ b/generate/classDeclarations.go
@@ -312,12 +312,8 @@ func (mp *ModuleProcessor) generateLitElementClassDeclaration(
 		},
 	}
 
-	tagNameNodes, ok := captures["tag-name"]
-	if ok && len(tagNameNodes) > 0 {
-		tagName := tagNameNodes[0].Text
-		if tagName != "" {
-			declaration.TagName = tagName
-		}
+	if tagName := mp.resolveTagName(captures); tagName != "" {
+		declaration.TagName = tagName
 	}
 
 	declaration.CustomElement.Attributes = A.Chain(func(member M.ClassMember) []M.Attribute {
@@ -464,4 +460,34 @@ func (mp *ModuleProcessor) parseHeritageExpression(node *ts.Node) (superclass st
 	}
 
 	return "", nil
+}
+
+func (mp *ModuleProcessor) resolveTagName(captures Q.CaptureMap) string {
+	if nodes, ok := captures["tag-name"]; ok && len(nodes) > 0 {
+		return nodes[0].Text
+	}
+	if refs, ok := captures["tag-name-ref"]; ok && len(refs) > 0 {
+		return mp.resolveConstStringValue(refs[0].Text)
+	}
+	return ""
+}
+
+// see also: typescript.resolveConstStringValue in ecmascript.go
+func (mp *ModuleProcessor) resolveConstStringValue(name string) string {
+	qm, err := Q.NewQueryMatcher(mp.queryManager, "typescript", "constStringValue")
+	if err != nil {
+		return ""
+	}
+	defer qm.Close()
+	for captures := range qm.ParentCaptures(mp.root, mp.code, "const.name") {
+		nameNodes, ok := captures["const.name"]
+		if !ok || len(nameNodes) == 0 || nameNodes[0].Text != name {
+			continue
+		}
+		valueNodes, ok := captures["const.value"]
+		if ok && len(valueNodes) > 0 {
+			return valueNodes[0].Text
+		}
+	}
+	return ""
 }

--- a/generate/modules.go
+++ b/generate/modules.go
@@ -496,12 +496,18 @@ func (mp *ModuleProcessor) processDeclarations() error {
 				Capture: "ce",
 				Query:   "declarations",
 			})
-		} else if tagNameNodes, ok := captures["ce.tagName"]; !ok || len(tagNameNodes) <= 0 {
-			mp.errors = errors.Join(mp.errors, &Q.NoCaptureError{Capture: "ce.tagName", Query: "declarations"})
 		} else if classNameNodes, ok := captures["ce.className"]; !ok || len(classNameNodes) <= 0 {
 			mp.errors = errors.Join(mp.errors, &Q.NoCaptureError{Capture: "ce.className", Query: "declarations"})
 		} else {
-			tagName := tagNameNodes[0].Text
+			var tagName string
+			if tagNameNodes, ok := captures["ce.tagName"]; ok && len(tagNameNodes) > 0 {
+				tagName = tagNameNodes[0].Text
+			} else if refNodes, ok := captures["ce.tagNameRef"]; ok && len(refNodes) > 0 {
+				tagName = mp.resolveConstStringValue(refNodes[0].Text)
+			}
+			if tagName == "" {
+				continue
+			}
 			className := classNameNodes[0].Text
 			idx := slices.IndexFunc(mp.module.Declarations, func(decl M.Declaration) bool {
 				d, ok := decl.(*M.ClassDeclaration)
@@ -616,7 +622,7 @@ func (mp *ModuleProcessor) processDeclarations() error {
 		})
 		if index >= 0 {
 			d := mp.module.Declarations[index]
-			if declaration, ok := d.(*M.CustomElementDeclaration); ok {
+			if declaration, ok := d.(*M.CustomElementDeclaration); ok && declaration.TagName != "" {
 				mp.module.Exports = append(mp.module.Exports, M.NewCustomElementExport(
 					declaration.TagName,
 					reference,

--- a/generate/testdata/fixtures/cross-package-types/custom-elements.json
+++ b/generate/testdata/fixtures/cross-package-types/custom-elements.json
@@ -47,14 +47,6 @@
       ],
       "exports": [
         {
-          "kind": "custom-element-definition",
-          "name": "",
-          "declaration": {
-            "name": "DtsElement",
-            "module": "src/dts-element.js"
-          }
-        },
-        {
           "kind": "js",
           "name": "DtsElement",
           "declaration": {
@@ -95,14 +87,6 @@
         }
       ],
       "exports": [
-        {
-          "kind": "custom-element-definition",
-          "name": "",
-          "declaration": {
-            "name": "JsdocElement",
-            "module": "src/jsdoc-element.js"
-          }
-        },
         {
           "kind": "js",
           "name": "JsdocElement",

--- a/generate/testdata/fixtures/cross-package-types/golden/all.json
+++ b/generate/testdata/fixtures/cross-package-types/golden/all.json
@@ -47,14 +47,6 @@
       ],
       "exports": [
         {
-          "kind": "custom-element-definition",
-          "name": "",
-          "declaration": {
-            "name": "DtsElement",
-            "module": "src/dts-element.js"
-          }
-        },
-        {
           "kind": "js",
           "name": "DtsElement",
           "declaration": {
@@ -95,14 +87,6 @@
         }
       ],
       "exports": [
-        {
-          "kind": "custom-element-definition",
-          "name": "",
-          "declaration": {
-            "name": "JsdocElement",
-            "module": "src/jsdoc-element.js"
-          }
-        },
         {
           "kind": "js",
           "name": "JsdocElement",

--- a/generate/testdata/fixtures/project-classes/golden/class-custom-element-let-tagname.json
+++ b/generate/testdata/fixtures/project-classes/golden/class-custom-element-let-tagname.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/class-custom-element-let-tagname.js",
+      "declarations": [
+        {
+          "name": "LetElement",
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "source": {
+            "href": "https://github.com/bennypowers/cem/tree/main/generate/testdata/fixtures/project-classes/src/class-custom-element-let-tagname.ts#L6"
+          },
+          "kind": "class",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "LetElement",
+          "declaration": {
+            "name": "LetElement",
+            "module": "src/class-custom-element-let-tagname.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/generate/testdata/fixtures/project-classes/golden/class-custom-element-variable-tagname-scoped.json
+++ b/generate/testdata/fixtures/project-classes/golden/class-custom-element-variable-tagname-scoped.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/class-custom-element-variable-tagname-scoped.js",
+      "declarations": [
+        {
+          "name": "ScopedElement",
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "source": {
+            "href": "https://github.com/bennypowers/cem/tree/main/generate/testdata/fixtures/project-classes/src/class-custom-element-variable-tagname-scoped.ts#L11"
+          },
+          "kind": "class",
+          "tagName": "scoped-right-element",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "scoped-right-element",
+          "declaration": {
+            "name": "ScopedElement",
+            "module": "src/class-custom-element-variable-tagname-scoped.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "ScopedElement",
+          "declaration": {
+            "name": "ScopedElement",
+            "module": "src/class-custom-element-variable-tagname-scoped.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/generate/testdata/fixtures/project-classes/golden/class-custom-element-variable-tagname-unexported.json
+++ b/generate/testdata/fixtures/project-classes/golden/class-custom-element-variable-tagname-unexported.json
@@ -1,0 +1,34 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/class-custom-element-variable-tagname-unexported.js",
+      "declarations": [
+        {
+          "name": "UnexportedVariableElement",
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "source": {
+            "href": "https://github.com/bennypowers/cem/tree/main/generate/testdata/fixtures/project-classes/src/class-custom-element-variable-tagname-unexported.ts#L5"
+          },
+          "kind": "class",
+          "tagName": "unexported-variable-element",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "unexported-variable-element",
+          "declaration": {
+            "name": "UnexportedVariableElement",
+            "module": "src/class-custom-element-variable-tagname-unexported.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/generate/testdata/fixtures/project-classes/golden/class-custom-element-variable-tagname.json
+++ b/generate/testdata/fixtures/project-classes/golden/class-custom-element-variable-tagname.json
@@ -1,0 +1,57 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/class-custom-element-variable-tagname.js",
+      "declarations": [
+        {
+          "name": "tagName",
+          "kind": "variable",
+          "source": {
+            "href": "https://github.com/bennypowers/cem/tree/main/generate/testdata/fixtures/project-classes/src/class-custom-element-variable-tagname.ts#L3"
+          }
+        },
+        {
+          "name": "VariableElement",
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "source": {
+            "href": "https://github.com/bennypowers/cem/tree/main/generate/testdata/fixtures/project-classes/src/class-custom-element-variable-tagname.ts#L6"
+          },
+          "kind": "class",
+          "tagName": "variable-element",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "tagName",
+          "declaration": {
+            "name": "tagName",
+            "module": "src/class-custom-element-variable-tagname.js"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "variable-element",
+          "declaration": {
+            "name": "VariableElement",
+            "module": "src/class-custom-element-variable-tagname.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "VariableElement",
+          "declaration": {
+            "name": "VariableElement",
+            "module": "src/class-custom-element-variable-tagname.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/generate/testdata/fixtures/project-classes/src/class-custom-element-let-tagname.ts
+++ b/generate/testdata/fixtures/project-classes/src/class-custom-element-let-tagname.ts
@@ -1,0 +1,7 @@
+import { LitElement, customElement } from 'lit';
+
+let tagName = 'let-element';
+
+@customElement(tagName)
+export class LetElement extends LitElement {
+}

--- a/generate/testdata/fixtures/project-classes/src/class-custom-element-variable-tagname-scoped.ts
+++ b/generate/testdata/fixtures/project-classes/src/class-custom-element-variable-tagname-scoped.ts
@@ -1,0 +1,12 @@
+import { LitElement, customElement } from 'lit';
+
+function getTagName() {
+  const tagName = 'scoped-wrong-element';
+  return tagName;
+}
+
+const tagName = 'scoped-right-element';
+
+@customElement(tagName)
+export class ScopedElement extends LitElement {
+}

--- a/generate/testdata/fixtures/project-classes/src/class-custom-element-variable-tagname-unexported.ts
+++ b/generate/testdata/fixtures/project-classes/src/class-custom-element-variable-tagname-unexported.ts
@@ -1,0 +1,10 @@
+import { LitElement, customElement } from 'lit';
+
+const tagName = 'unexported-variable-element';
+
+@customElement(tagName)
+class UnexportedVariableElement extends LitElement {
+  render() {
+    return 'hello';
+  }
+}

--- a/generate/testdata/fixtures/project-classes/src/class-custom-element-variable-tagname.ts
+++ b/generate/testdata/fixtures/project-classes/src/class-custom-element-variable-tagname.ts
@@ -1,0 +1,10 @@
+import { LitElement, customElement } from 'lit';
+
+export const tagName = 'variable-element';
+
+@customElement(tagName)
+export class VariableElement extends LitElement {
+  render() {
+    return 'hello';
+  }
+}

--- a/generate/testdata/fixtures/project-demos/custom-elements.json
+++ b/generate/testdata/fixtures/project-demos/custom-elements.json
@@ -95,21 +95,21 @@
               }
             },
             {
-              "url": "https://bennypowers.dev/cem-demos/demo-discovery/discovery/",
+              "url": "https://bennypowers.dev/cem-demos/discovery/discovery/",
               "source": {
                 "href": "https://github.com/bennypowers/cem/tree/main/generate/src/demo-discovery/demos/discovery.html"
               }
             },
             {
               "description": "Demo with YAML frontmatter metadata",
-              "url": "https://bennypowers.dev/cem-demos/demo-discovery/frontmatter/",
+              "url": "https://bennypowers.dev/cem-demos/discovery/frontmatter/",
               "source": {
                 "href": "https://github.com/bennypowers/cem/tree/main/generate/src/demo-discovery/demos/frontmatter.html"
               }
             },
             {
               "description": "A complete HTML document demonstrating demo-discovery element",
-              "url": "https://bennypowers.dev/cem-demos/demo-discovery/full-document/",
+              "url": "https://bennypowers.dev/cem-demos/discovery/full-document/",
               "source": {
                 "href": "https://github.com/bennypowers/cem/tree/main/generate/src/demo-discovery/demos/full-document.html"
               }

--- a/generate/testdata/fixtures/project-no-package/golden/vanilla-declare.json
+++ b/generate/testdata/fixtures/project-no-package/golden/vanilla-declare.json
@@ -20,14 +20,6 @@
       ],
       "exports": [
         {
-          "kind": "custom-element-definition",
-          "name": "",
-          "declaration": {
-            "name": "VanillaElement",
-            "module": "src/vanilla-declare.js"
-          }
-        },
-        {
           "kind": "js",
           "name": "VanillaElement",
           "declaration": {

--- a/generate/testdata/fixtures/type-alias-unwrapping/custom-elements.json
+++ b/generate/testdata/fixtures/type-alias-unwrapping/custom-elements.json
@@ -37,14 +37,6 @@
       ],
       "exports": [
         {
-          "kind": "custom-element-definition",
-          "name": "",
-          "declaration": {
-            "name": "MyElement",
-            "module": "src/circular-alias.js"
-          }
-        },
-        {
           "kind": "js",
           "name": "MyElement",
           "declaration": {
@@ -99,14 +91,6 @@
         }
       ],
       "exports": [
-        {
-          "kind": "custom-element-definition",
-          "name": "",
-          "declaration": {
-            "name": "MyComponent",
-            "module": "src/cross-module.js"
-          }
-        },
         {
           "kind": "js",
           "name": "MyComponent",
@@ -177,14 +161,6 @@
       ],
       "exports": [
         {
-          "kind": "custom-element-definition",
-          "name": "",
-          "declaration": {
-            "name": "MyElement",
-            "module": "src/lowercase-alias.js"
-          }
-        },
-        {
           "kind": "js",
           "name": "MyElement",
           "declaration": {
@@ -233,14 +209,6 @@
         }
       ],
       "exports": [
-        {
-          "kind": "custom-element-definition",
-          "name": "",
-          "declaration": {
-            "name": "MyButton",
-            "module": "src/nested-alias.js"
-          }
-        },
         {
           "kind": "js",
           "name": "MyButton",
@@ -293,14 +261,6 @@
       ],
       "exports": [
         {
-          "kind": "custom-element-definition",
-          "name": "",
-          "declaration": {
-            "name": "MyElement",
-            "module": "src/no-alias.js"
-          }
-        },
-        {
           "kind": "js",
           "name": "MyElement",
           "declaration": {
@@ -341,14 +301,6 @@
         }
       ],
       "exports": [
-        {
-          "kind": "custom-element-definition",
-          "name": "",
-          "declaration": {
-            "name": "MyButton",
-            "module": "src/simple-alias.js"
-          }
-        },
         {
           "kind": "js",
           "name": "MyButton",
@@ -472,14 +424,6 @@
         }
       ],
       "exports": [
-        {
-          "kind": "custom-element-definition",
-          "name": "",
-          "declaration": {
-            "name": "MyButton",
-            "module": "src/union-alias.js"
-          }
-        },
         {
           "kind": "js",
           "name": "MyButton",

--- a/generate/testdata/fixtures/type-alias-unwrapping/golden/all.json
+++ b/generate/testdata/fixtures/type-alias-unwrapping/golden/all.json
@@ -37,14 +37,6 @@
       ],
       "exports": [
         {
-          "kind": "custom-element-definition",
-          "name": "",
-          "declaration": {
-            "name": "MyElement",
-            "module": "src/circular-alias.js"
-          }
-        },
-        {
           "kind": "js",
           "name": "MyElement",
           "declaration": {
@@ -99,14 +91,6 @@
         }
       ],
       "exports": [
-        {
-          "kind": "custom-element-definition",
-          "name": "",
-          "declaration": {
-            "name": "MyComponent",
-            "module": "src/cross-module.js"
-          }
-        },
         {
           "kind": "js",
           "name": "MyComponent",
@@ -177,14 +161,6 @@
       ],
       "exports": [
         {
-          "kind": "custom-element-definition",
-          "name": "",
-          "declaration": {
-            "name": "MyElement",
-            "module": "src/lowercase-alias.js"
-          }
-        },
-        {
           "kind": "js",
           "name": "MyElement",
           "declaration": {
@@ -233,14 +209,6 @@
         }
       ],
       "exports": [
-        {
-          "kind": "custom-element-definition",
-          "name": "",
-          "declaration": {
-            "name": "MyButton",
-            "module": "src/nested-alias.js"
-          }
-        },
         {
           "kind": "js",
           "name": "MyButton",
@@ -293,14 +261,6 @@
       ],
       "exports": [
         {
-          "kind": "custom-element-definition",
-          "name": "",
-          "declaration": {
-            "name": "MyElement",
-            "module": "src/no-alias.js"
-          }
-        },
-        {
           "kind": "js",
           "name": "MyElement",
           "declaration": {
@@ -341,14 +301,6 @@
         }
       ],
       "exports": [
-        {
-          "kind": "custom-element-definition",
-          "name": "",
-          "declaration": {
-            "name": "MyButton",
-            "module": "src/simple-alias.js"
-          }
-        },
         {
           "kind": "js",
           "name": "MyButton",
@@ -472,14 +424,6 @@
         }
       ],
       "exports": [
-        {
-          "kind": "custom-element-definition",
-          "name": "",
-          "declaration": {
-            "name": "MyButton",
-            "module": "src/union-alias.js"
-          }
-        },
         {
           "kind": "js",
           "name": "MyButton",

--- a/internal/languages/typescript/ecmascript.go
+++ b/internal/languages/typescript/ecmascript.go
@@ -88,6 +88,18 @@ func FindTagNameDefinitionInSource(content []byte, tagName string, queryManager 
 				}
 			}
 		}
+		if refs, ok := captureMap["tag-name-ref"]; ok {
+			for _, ref := range refs {
+				resolved := resolveConstStringValue(tree.RootNode(), content, ref.Text, queryManager)
+				if resolved == tagName {
+					node := Q.GetDescendantById(tree.RootNode(), ref.NodeId)
+					if node != nil {
+						r := Q.NodeToRange(node, content)
+						return &r, nil
+					}
+				}
+			}
+		}
 	}
 
 	return nil, nil
@@ -208,11 +220,16 @@ func FindDefinedElementTags(code []byte, qm *Q.QueryManager) []string {
 			if int(capture.Index) >= matcher.CaptureCount() {
 				continue
 			}
-			if matcher.GetCaptureNameByIndex(capture.Index) == "defined.tagName" {
-				tag := capture.Node.Utf8Text(code)
-				if !slices.Contains(tags, tag) {
-					tags = append(tags, tag)
-				}
+			name := matcher.GetCaptureNameByIndex(capture.Index)
+			var tag string
+			switch name {
+			case "defined.tagName":
+				tag = capture.Node.Utf8Text(code)
+			case "defined.tagNameRef":
+				tag = resolveConstStringValue(root, code, capture.Node.Utf8Text(code), qm)
+			}
+			if tag != "" && !slices.Contains(tags, tag) {
+				tags = append(tags, tag)
 			}
 		}
 	}
@@ -291,4 +308,24 @@ func adjustTemplateRange(templateRange *Q.Range, templateNode *ts.Node, content 
 			Character: templateStart.Character + templateRange.End.Character,
 		},
 	}
+}
+
+// see also: ModuleProcessor.resolveConstStringValue in classDeclarations.go
+func resolveConstStringValue(root *ts.Node, code []byte, name string, qm *Q.QueryManager) string {
+	matcher, err := Q.NewQueryMatcher(qm, "typescript", "constStringValue")
+	if err != nil {
+		return ""
+	}
+	defer matcher.Close()
+	for captures := range matcher.ParentCaptures(root, code, "const.name") {
+		nameNodes, ok := captures["const.name"]
+		if !ok || len(nameNodes) == 0 || nameNodes[0].Text != name {
+			continue
+		}
+		valueNodes, ok := captures["const.value"]
+		if ok && len(valueNodes) > 0 {
+			return valueNodes[0].Text
+		}
+	}
+	return ""
 }

--- a/internal/languages/typescript/ecmascript_test.go
+++ b/internal/languages/typescript/ecmascript_test.go
@@ -223,6 +223,125 @@ export class ElementTwo extends LitElement {}
 		}
 	})
 
+	t.Run("customElement decorator with const variable", func(t *testing.T) {
+		src := []byte(`import { LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+export const tagName = 'variable-element';
+
+@customElement(tagName)
+export class VariableElement extends LitElement {}
+`)
+		tags := FindDefinedElementTags(src, qm)
+		if len(tags) != 1 || tags[0] != "variable-element" {
+			t.Errorf("expected [variable-element], got %v", tags)
+		}
+	})
+
+	t.Run("customElement decorator with unexported const variable", func(t *testing.T) {
+		src := []byte(`import { LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+const tagName = 'unexported-variable-element';
+
+@customElement(tagName)
+class UnexportedVariableElement extends LitElement {}
+`)
+		tags := FindDefinedElementTags(src, qm)
+		if len(tags) != 1 || tags[0] != "unexported-variable-element" {
+			t.Errorf("expected [unexported-variable-element], got %v", tags)
+		}
+	})
+
+	t.Run("customElements.define with const variable", func(t *testing.T) {
+		src := []byte(`const tagName = 'define-variable-element';
+class DefineVariableElement extends HTMLElement {}
+customElements.define(tagName, DefineVariableElement);
+`)
+		tags := FindDefinedElementTags(src, qm)
+		if len(tags) != 1 || tags[0] != "define-variable-element" {
+			t.Errorf("expected [define-variable-element], got %v", tags)
+		}
+	})
+
+	t.Run("function-scoped const is not resolved", func(t *testing.T) {
+		src := []byte(`import { LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+function getTag() {
+  const tagName = 'scoped-element';
+  return tagName;
+}
+
+@customElement(tagName)
+export class ScopedElement extends LitElement {}
+`)
+		tags := FindDefinedElementTags(src, qm)
+		if len(tags) != 0 {
+			t.Errorf("expected no tags (function-scoped const), got %v", tags)
+		}
+	})
+
+	t.Run("var variable is not resolved", func(t *testing.T) {
+		src := []byte(`import { LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+var tagName = 'var-element';
+
+@customElement(tagName)
+export class VarElement extends LitElement {}
+`)
+		tags := FindDefinedElementTags(src, qm)
+		if len(tags) != 0 {
+			t.Errorf("expected no tags (var is not const), got %v", tags)
+		}
+	})
+
+	t.Run("HTMLElement with const variable via customElements.define", func(t *testing.T) {
+		src := []byte(`const tagName = 'html-variable-element';
+export class HtmlVariableElement extends HTMLElement {}
+customElements.define(tagName, HtmlVariableElement);
+`)
+		tags := FindDefinedElementTags(src, qm)
+		if len(tags) != 1 || tags[0] != "html-variable-element" {
+			t.Errorf("expected [html-variable-element], got %v", tags)
+		}
+	})
+
+	t.Run("top-level const shadows function-scoped const", func(t *testing.T) {
+		src := []byte(`import { LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+function setup() {
+  const tagName = 'wrong-element';
+}
+
+const tagName = 'right-element';
+
+@customElement(tagName)
+export class ShadowElement extends LitElement {}
+`)
+		tags := FindDefinedElementTags(src, qm)
+		if len(tags) != 1 || tags[0] != "right-element" {
+			t.Errorf("expected [right-element], got %v", tags)
+		}
+	})
+
+	t.Run("let variable is not resolved", func(t *testing.T) {
+		src := []byte(`import { LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+let tagName = 'let-element';
+
+@customElement(tagName)
+export class LetElement extends LitElement {}
+`)
+		tags := FindDefinedElementTags(src, qm)
+		if len(tags) != 0 {
+			t.Errorf("expected no tags (let is not const), got %v", tags)
+		}
+	})
+
 	t.Run("no definitions", func(t *testing.T) {
 		src := []byte(`export class PlainClass {}`)
 		tags := FindDefinedElementTags(src, qm)

--- a/internal/languages/typescript/language.go
+++ b/internal/languages/typescript/language.go
@@ -33,11 +33,11 @@ func (l *language) QueryFS() embed.FS        { return queryFiles }
 func (l *language) QueryNames(scope languages.Scope) []string {
 	switch scope {
 	case languages.ScopeLSP:
-		return []string{"htmlTemplates", "completionContext", "imports", "classes", "classMemberDeclaration", "exports", "importAttributes", "definedElements"}
+		return []string{"htmlTemplates", "completionContext", "imports", "classes", "classMemberDeclaration", "exports", "importAttributes", "definedElements", "constStringValue"}
 	case languages.ScopeGenerate:
-		return []string{"classMemberDeclaration", "classes", "declarations", "imports", "typeAliases", "exports"}
+		return []string{"classMemberDeclaration", "classes", "declarations", "imports", "typeAliases", "exports", "constStringValue"}
 	case languages.ScopeAll:
-		return []string{"classMemberDeclaration", "classes", "declarations", "imports", "htmlTemplates", "completionContext", "typeAliases", "exports", "importAttributes", "definedElements"}
+		return []string{"classMemberDeclaration", "classes", "declarations", "imports", "htmlTemplates", "completionContext", "typeAliases", "exports", "importAttributes", "definedElements", "constStringValue"}
 	}
 	return nil
 }

--- a/internal/languages/typescript/queries/classes.scm
+++ b/internal/languages/typescript/queries/classes.scm
@@ -74,14 +74,21 @@
   ; @customElement('custom-element')
   ; export class CustomElement extends CustomBase {}
   ; ```
+  ; also matches:
+  ; ```ts
+  ; const tagName = 'custom-element';
+  ; @customElement(tagName)
+  ; export class CustomElement extends CustomBase {}
+  ; ```
   (comment)* @class.jsdoc . (#match? @class.jsdoc "^/\\*\\*") .
   (export_statement
     (decorator) *
     decorator: (decorator
       (call_expression
         function: (identifier) @class.decorator.name
-        arguments: (arguments (string (string_fragment) @tag-name)
-                              (#eq? @class.decorator.name "customElement"))))
+        arguments: (arguments
+                     [(string (string_fragment) @tag-name) (identifier) @tag-name-ref]
+                     (#eq? @class.decorator.name "customElement"))))
     (decorator) *
     declaration: (class_declaration
       name: (type_identifier) @class.name
@@ -164,8 +171,9 @@
     decorator: (decorator
       (call_expression
         function: (identifier) @class.decorator.name
-        arguments: (arguments (string (string_fragment) @tag-name)
-                              (#eq? @class.decorator.name "customElement"))))
+        arguments: (arguments
+                     [(string (string_fragment) @tag-name) (identifier) @tag-name-ref]
+                     (#eq? @class.decorator.name "customElement"))))
     (decorator) *
     name: (type_identifier) @class.name
     (class_heritage

--- a/internal/languages/typescript/queries/constStringValue.scm
+++ b/internal/languages/typescript/queries/constStringValue.scm
@@ -1,0 +1,18 @@
+; Resolves top-level const variable declarations with string literal values.
+; Used to resolve variable references in @customElement(varName) decorators.
+; Only matches module-level declarations (direct children of program node).
+
+(program ; export const tagName = 'my-element';
+  (export_statement
+    (lexical_declaration
+      "const"
+      (variable_declarator
+        name: (identifier) @const.name
+        value: (string (string_fragment) @const.value)))))
+
+(program ; const tagName = 'my-element';
+  (lexical_declaration
+    "const"
+    (variable_declarator
+      name: (identifier) @const.name
+      value: (string (string_fragment) @const.value))))

--- a/internal/languages/typescript/queries/declarations.scm
+++ b/internal/languages/typescript/queries/declarations.scm
@@ -82,11 +82,15 @@
 ( ; custom element export
   ; case:
   ; customElements.define('tag-name', Class);
+  ; also matches:
+  ; const tagName = 'tag-name';
+  ; customElements.define(tagName, Class);
   call_expression
     function: (member_expression
       object: (identifier) @ce.namespace (#eq? @ce.namespace "customElements")
       property: (property_identifier) @ce.methodname) (#eq? @ce.methodname "define")
     arguments: (arguments
-      (string
-        (string_fragment) @ce.tagName)
+      [(string
+         (string_fragment) @ce.tagName)
+       (identifier) @ce.tagNameRef]
       (identifier) @ce.className)) @ce

--- a/internal/languages/typescript/queries/definedElements.scm
+++ b/internal/languages/typescript/queries/definedElements.scm
@@ -1,12 +1,14 @@
 ; Captures tag names from custom element definitions in the current file.
 ; Used by LSP diagnostics to skip "unknown element" errors for locally-defined elements.
+; Supports both string literals and identifier references (resolved via constStringValue query).
 
 ( ; @customElement('tag-name') on exported classes
   (export_statement
     (decorator
       (call_expression
         function: (identifier) @_decorator.name
-        arguments: (arguments (string (string_fragment) @defined.tagName))
+        arguments: (arguments
+                     [(string (string_fragment) @defined.tagName) (identifier) @defined.tagNameRef])
         (#eq? @_decorator.name "customElement")))
     declaration: (class_declaration)))
 
@@ -15,7 +17,8 @@
     (decorator
       (call_expression
         function: (identifier) @_decorator.name
-        arguments: (arguments (string (string_fragment) @defined.tagName))
+        arguments: (arguments
+                     [(string (string_fragment) @defined.tagName) (identifier) @defined.tagNameRef])
         (#eq? @_decorator.name "customElement")))))
 
 ( ; customElements.define('tag-name', Class)
@@ -24,5 +27,6 @@
       object: (identifier) @_ce.namespace (#eq? @_ce.namespace "customElements")
       property: (property_identifier) @_ce.method (#eq? @_ce.method "define"))
     arguments: (arguments
-      (string
-        (string_fragment) @defined.tagName))))
+      [(string
+         (string_fragment) @defined.tagName)
+       (identifier) @defined.tagNameRef])))


### PR DESCRIPTION
## Summary

When `@customElement(tagName)` is called with an identifier instead of a string literal, resolve it by looking for a matching top-level `const` declaration with a string literal value in the same file. This covers the common pattern of defining the tag name as a reusable constant:

```ts
export const tagName = 'my-element';

@customElement(tagName)
export class MyElement extends LitElement {}
```

Only top-level `const` declarations are resolved. `let`, `var`, and function-scoped declarations are excluded since tag names are static and should not be reassignable or scope-dependent.

Resolution applies across:
- `cem generate` manifest output
- LSP diagnostics (element tag detection)
- LSP go-to-definition for variable-based tag names
- `customElements.define(varName, Class)` calls

Also fixes a pre-existing issue where `customElements.define()` with same-file HTMLElement subclasses produced broken `custom-element-definition` exports with empty `"name": ""`.

## Test plan

- [x] Golden fixture: exported `const` variable resolves tag name
- [x] Golden fixture: unexported `const` variable resolves tag name
- [x] Golden fixture: `let` variable does NOT resolve (negative case)
- [x] Golden fixture: function-scoped `const` ignored, top-level resolved
- [x] LSP unit test: `@customElement(constVar)` with exported const
- [x] LSP unit test: `@customElement(constVar)` with unexported const
- [x] LSP unit test: `customElements.define(constVar, Class)`
- [x] LSP unit test: `let` not resolved (negative)
- [x] LSP unit test: `var` not resolved (negative)
- [x] LSP unit test: HTMLElement with const variable
- [x] LSP unit test: top-level const shadows function-scoped const
- [x] LSP unit test: function-scoped const not resolved (negative)
- [x] All 4349 existing tests pass, zero regressions

Closes #393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved custom element detection so tag names defined through constants or references are now recognized.
  * Added support for identifying elements declared with either direct tag names or referenced tag-name values.

* **Bug Fixes**
  * Fixed cases where some custom elements were previously skipped or exported without the correct tag name.
  * Updated tag handling so related diagnostics and generated output are more accurate for scoped and aliased declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->