### PR TITLE
test: improve test isolation and fixture loading for MapFS coverage

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,7 +71,7 @@ linters:
       - path: internal/config/schema_test\.go
         linters:
           - forbidigo
-      - path: internal/modulegraph/.*_test\.go
+      - path: internal/modulegraph/transitive_module_graph_test\.go
         linters:
           - forbidigo
       - path: internal/workspace/httpcache_test\.go
@@ -80,7 +80,10 @@ linters:
       - path: lsp/document_test\.go
         linters:
           - forbidigo
-      - path: lsp/methods/textDocument/publishDiagnostics/.*_test\.go
+      - path: lsp/methods/textDocument/publishDiagnostics/tagDiagnostics_test\.go
+        linters:
+          - forbidigo
+      - path: lsp/methods/textDocument/publishDiagnostics/transitive_integration_test\.go
         linters:
           - forbidigo
       - path: lsp/methods/textDocument/references/references_test\.go
@@ -92,7 +95,16 @@ linters:
       - path: serve/middleware/importmap/.*_test\.go
         linters:
           - forbidigo
-      - path: lsp/methods/textDocument/completion/.*_test\.go
+      - path: lsp/methods/textDocument/completion/completion_button_element_regression_test\.go
+        linters:
+          - forbidigo
+      - path: lsp/methods/textDocument/completion/completion_generate_integration_test\.go
+        linters:
+          - forbidigo
+      - path: lsp/methods/textDocument/completion/completion_test\.go
+        linters:
+          - forbidigo
+      - path: lsp/methods/textDocument/completion/completion_test_helpers_test\.go
         linters:
           - forbidigo
       - path: lsp/methods/textDocument/codeAction/.*_test\.go
@@ -107,10 +119,7 @@ linters:
       - path: validate/validate_test\.go
         linters:
           - forbidigo
-      - path: mcp/tools/generate_html_test\.go
-        linters:
-          - forbidigo
-      - path: serve/middleware/routes/.*_test\.go
+      - path: serve/middleware/routes/chrome_test\.go
         linters:
           - forbidigo
       - path: lsp/incremental_integration_test\.go
@@ -119,10 +128,16 @@ linters:
       - path: mcp/context_config_reload_test\.go
         linters:
           - forbidigo
-      - path: mcp/resources/.*_test\.go
+      - path: mcp/resources/multiple_schemas_test\.go
         linters:
           - forbidigo
-      - path: mcp/tools/.*_test\.go
+      - path: mcp/resources/resources_test\.go
+        linters:
+          - forbidigo
+      - path: mcp/tools/generate_html_test\.go
+        linters:
+          - forbidigo
+      - path: mcp/tools/tools_test\.go
         linters:
           - forbidigo
       - path: generate/generate_benchmark_test\.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,7 +40,125 @@ linters:
         text: doublestar\.Glob
         linters:
           - forbidigo
-      - path: _test\.go
+      # Per-file test exclusions (blanket _test.go exclusion removed in #399)
+      # E2E tests run the binary as a subprocess -- direct os.* calls expected
+      - path: cmd/.*_test\.go
+        linters:
+          - forbidigo
+      # Integration tests that write to real temp dirs for file watching / OS behavior
+      - path: lsp/server_integration_(file_watch|generate_watch)_test\.go
+        linters:
+          - forbidigo
+      - path: serve/filewatcher.*_test\.go
+        linters:
+          - forbidigo
+      # OS integration subtests and golden file update logic
+      - path: generate/demodiscovery/discovery_test\.go
+        linters:
+          - forbidigo
+      - path: generate/generate_nil_manifest_regression_test\.go
+        linters:
+          - forbidigo
+      - path: generate/generate_test\.go
+        linters:
+          - forbidigo
+      - path: generate/external_types_test\.go
+        linters:
+          - forbidigo
+      - path: export/export_test\.go
+        linters:
+          - forbidigo
+      - path: internal/config/schema_test\.go
+        linters:
+          - forbidigo
+      - path: internal/modulegraph/.*_test\.go
+        linters:
+          - forbidigo
+      - path: internal/workspace/httpcache_test\.go
+        linters:
+          - forbidigo
+      - path: lsp/document_test\.go
+        linters:
+          - forbidigo
+      - path: lsp/methods/textDocument/publishDiagnostics/.*_test\.go
+        linters:
+          - forbidigo
+      - path: lsp/methods/textDocument/references/references_test\.go
+        linters:
+          - forbidigo
+      - path: serve/build_test\.go
+        linters:
+          - forbidigo
+      - path: serve/middleware/importmap/.*_test\.go
+        linters:
+          - forbidigo
+      - path: lsp/methods/textDocument/completion/.*_test\.go
+        linters:
+          - forbidigo
+      - path: lsp/methods/textDocument/codeAction/.*_test\.go
+        linters:
+          - forbidigo
+      - path: lsp/ephemeral_hover_test\.go
+        linters:
+          - forbidigo
+      - path: internal/workspace/.*_test\.go
+        linters:
+          - forbidigo
+      - path: validate/validate_test\.go
+        linters:
+          - forbidigo
+      - path: mcp/tools/generate_html_test\.go
+        linters:
+          - forbidigo
+      - path: serve/middleware/routes/.*_test\.go
+        linters:
+          - forbidigo
+      - path: lsp/incremental_integration_test\.go
+        linters:
+          - forbidigo
+      - path: mcp/context_config_reload_test\.go
+        linters:
+          - forbidigo
+      - path: mcp/resources/.*_test\.go
+        linters:
+          - forbidigo
+      - path: mcp/tools/.*_test\.go
+        linters:
+          - forbidigo
+      - path: generate/generate_benchmark_test\.go
+        linters:
+          - forbidigo
+      - path: generate/source_href_integration_test\.go
+        linters:
+          - forbidigo
+      - path: internal/config/discovery_test\.go
+        linters:
+          - forbidigo
+      - path: lsp/jsx_support_test\.go
+        linters:
+          - forbidigo
+      - path: lsp/php_twig_support_test\.go
+        linters:
+          - forbidigo
+      - path: lsp/server_context_test\.go
+        linters:
+          - forbidigo
+      - path: mcp/integration_test\.go
+        linters:
+          - forbidigo
+      - path: serve/server_test\.go
+        linters:
+          - forbidigo
+      - path: lsp/simple_repo_inmemory_test\.go
+        linters:
+          - forbidigo
+      - path: lsp/template_support_test\.go
+        linters:
+          - forbidigo
+      - path: lsp/workspace_inmemory_test\.go
+        linters:
+          - forbidigo
+      - path: lsp/workspace_single_package_test\.go
         linters:
           - forbidigo
       - path: mcp/tools/gen-adapters/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,10 +68,18 @@ IMPORTANT: When writing tests, **always** use fixture/golden pattern. We **alway
                 <!-- ^cursor -->
   ```
 
-  TypeScript:
+  TypeScript (inside Lit template literals, use HTML comments):
   ```typescript
-  const tpl = html`<test-element .`;
-                                  /* ^cursor */
+  const tpl = html`
+    <test-element .testAttr="hello"></test-element>
+    <!--          ^cursor -->
+  `;
+  ```
+
+  TypeScript (outside template literals, use JS comments):
+  ```typescript
+  import { html } from 'lit';
+  /*        ^cursor */
   ```
 
   CSS:
@@ -80,9 +88,11 @@ IMPORTANT: When writing tests, **always** use fixture/golden pattern. We **alway
                 /* ^cursor */
   ```
 
+  For HTML fixtures, the loader extracts cursors automatically. For TS fixtures, tests call `fixture.ParseCursor(testhelpers.TSCursorParser)` since tree-sitter is needed to find template literal boundaries. For CSS, use `fixture.ParseCursor(testhelpers.CSSCursorParser)`.
+
   The fixture loader strips the marker line from `InputContent` and populates `fixture.Cursor *protocol.Position`. Tests use `fixture.Cursor` directly instead of maintaining a separate Go map of cursor positions. When no marker is present, `Cursor` is nil.
 
-  **Fallback**: When a comment marker isn't practical (cursor inside a value, ambiguous column), use YAML frontmatter:
+  **Fallback**: When a comment marker isn't practical (cursor inside a value, ambiguous column), use YAML frontmatter. Avoid frontmatter in `.ts` files as it causes biome/eslint issues:
   ```html
   ---
   cursor:
@@ -107,7 +117,7 @@ IMPORTANT: When writing tests, **always** use fixture/golden pattern. We **alway
 
 - **Regression Test Isolation**: Keep regression test fixtures in separate directories (e.g., `testdata-regression/`) to avoid interference with standard test discovery
 
-- **Filesystem in Tests**: Test code follows the same `platform.FileSystem` rules as production code. Load fixture data via `testutil.NewFixtureFS()`, `testutil.LoadTestdataFS()`, or `testutil.LoadFixtureFile()` -- never via direct `os.ReadFile`/`os.Open` calls. When constructing `MCPContext` or similar objects that accept a `platform.FileSystem`, pass the workspace's `MapFileSystem` instead of `nil` to exercise the injected FS path. The only exception is OS integration subtests (e.g., filewatcher tests) that must write to real temp dirs via `t.TempDir()`.
+- **Filesystem in Tests**: Test code follows the same `platform.FileSystem` rules as production code. Load fixture data via `testutil.NewFixtureFS()`, `testutil.LoadTestdataFS()`, or `testutil.LoadFixtureFile()` -- never via direct `os.ReadFile`/`os.Open` calls. When constructing `MCPContext` or similar objects that accept a `platform.FileSystem`, pass the workspace's `MapFileSystem` instead of `nil` to exercise the injected FS path. Two exceptions: (1) OS integration subtests (e.g., filewatcher tests) that must write to real temp dirs via `t.TempDir()`, and (2) E2E tests (`//go:build e2e` in `cmd/`) that run the built binary as a subprocess and compare stdout against golden files on disk.
 
 - **Error Path Testing**: When testing filesystem error paths that rely on OS permissions (e.g., unreadable files), use an error-injecting `FileSystem` wrapper instead of `os.Chmod`. MapFS does not enforce permissions, so permission-based error tests need a wrapper that returns errors for specific paths.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,13 +60,45 @@ IMPORTANT: When writing tests, **always** use fixture/golden pattern. We **alway
   - `expected.json` or `expected-*.json` (optional, for assertions)
   - `package.json` pointing `customElements` block to `manifest.json`
 
+- **Cursor Positions via `^cursor` Marker**: Position-dependent LSP tests (hover, completion, definition, references) embed cursor position directly in the fixture input file using a comment marker. The `^` column is the cursor character; the line above is the cursor line. Use language-appropriate comment syntax:
+
+  HTML:
+  ```html
+  <test-element .testAttr="hello"></test-element>
+                <!-- ^cursor -->
+  ```
+
+  TypeScript:
+  ```typescript
+  const tpl = html`<test-element .`;
+                                  /* ^cursor */
+  ```
+
+  CSS:
+  ```css
+  my-element::part(button) {
+                /* ^cursor */
+  ```
+
+  The fixture loader strips the marker line from `InputContent` and populates `fixture.Cursor *protocol.Position`. Tests use `fixture.Cursor` directly instead of maintaining a separate Go map of cursor positions. When no marker is present, `Cursor` is nil.
+
+  **Fallback**: When a comment marker isn't practical (cursor inside a value, ambiguous column), use YAML frontmatter:
+  ```html
+  ---
+  cursor:
+    line: 0
+    character: 14
+  ---
+  <test-element .testAttr="hello"></test-element>
+  ```
+
 - **RunLSPFixtures Pattern**:
   ```go
   testutil.RunLSPFixtures(t, "testdata/my-test-suite", func(t *testing.T, fixture *testutil.LSPFixture) {
       // Setup context
       ctx := testhelpers.NewMockServerContext()
 
-      // Use fixture.InputContent, fixture.Manifest, etc.
+      // Use fixture.InputContent, fixture.Manifest, fixture.Cursor, etc.
       // Load expected data with fixture.GetExpected("key", &expected)
   })
   ```
@@ -74,6 +106,10 @@ IMPORTANT: When writing tests, **always** use fixture/golden pattern. We **alway
 - **Multiple Expected Files**: Use `expected-variant.json`, `expected-size.json` pattern for testing multiple positions/cases in one fixture
 
 - **Regression Test Isolation**: Keep regression test fixtures in separate directories (e.g., `testdata-regression/`) to avoid interference with standard test discovery
+
+- **Filesystem in Tests**: Test code follows the same `platform.FileSystem` rules as production code. Load fixture data via `testutil.NewFixtureFS()`, `testutil.LoadTestdataFS()`, or `testutil.LoadFixtureFile()` -- never via direct `os.ReadFile`/`os.Open` calls. When constructing `MCPContext` or similar objects that accept a `platform.FileSystem`, pass the workspace's `MapFileSystem` instead of `nil` to exercise the injected FS path. The only exception is OS integration subtests (e.g., filewatcher tests) that must write to real temp dirs via `t.TempDir()`.
+
+- **Error Path Testing**: When testing filesystem error paths that rely on OS permissions (e.g., unreadable files), use an error-injecting `FileSystem` wrapper instead of `os.Chmod`. MapFS does not enforce permissions, so permission-based error tests need a wrapper that returns errors for specific paths.
 
 ### Testing Tiers
 

--- a/generate/demodiscovery/discovery_test.go
+++ b/generate/demodiscovery/discovery_test.go
@@ -111,16 +111,11 @@ func TestExtractDemoMetadata(t *testing.T) {
 
 	t.Run("mapfs", func(t *testing.T) {
 		runFixtureTest[DemoMetadata](t, "extract-metadata", func(t *testing.T, inputPath string, expected *DemoMetadata) {
-			// Stage fixture on disk for NewMapWorkspaceContext to load
-			tmpDir := t.TempDir()
-			tmpPath := filepath.Join(tmpDir, "input.html")
-
 			input := testutil.LoadFixtureFile(t, inputPath)
-			if err := os.WriteFile(tmpPath, input, 0644); err != nil {
-				t.Fatalf("Failed to write test file: %v", err)
-			}
+			mfs := platform.NewMapFileSystem(nil)
+			mfs.AddFile("/input.html", string(input), 0644)
 
-			ctx := testworkspace.NewMapWorkspaceContext(t, tmpDir)
+			ctx := testworkspace.NewMapWorkspaceContextFromFS(mfs, "/")
 			result, err := extractDemoMetadata(ctx, "/input.html", ctx.FileSystem())
 			if err != nil {
 				t.Fatalf("extractDemoMetadata failed: %v", err)
@@ -441,21 +436,12 @@ func TestExtractDemoTags(t *testing.T) {
 				t.Fatalf("Failed to unmarshal config JSON: %v", err)
 			}
 
-			// Stage fixture on disk for NewMapWorkspaceContext to load
-			tmpDir := t.TempDir()
-			tmpPath := filepath.Join(tmpDir, config.DemoPath)
-			if err := os.MkdirAll(filepath.Dir(tmpPath), 0755); err != nil {
-				t.Fatalf("Failed to create directories: %v", err)
-			}
-
 			input := testutil.LoadFixtureFile(t, inputPath)
-			if err := os.WriteFile(tmpPath, input, 0644); err != nil {
-				t.Fatalf("Failed to write test file: %v", err)
-			}
-
-			ctx := testworkspace.NewMapWorkspaceContext(t, tmpDir)
-			// Use virtual path matching MapFS layout (rooted at "/")
+			mfs := platform.NewMapFileSystem(nil)
 			virtualPath := filepath.Join("/", config.DemoPath)
+			mfs.AddFile(virtualPath, string(input), 0644)
+
+			ctx := testworkspace.NewMapWorkspaceContextFromFS(mfs, "/")
 			result, err := extractDemoTags(ctx, virtualPath, config.ElementAliases, ctx.FileSystem())
 			if err != nil {
 				t.Fatalf("extractDemoTags failed: %v", err)
@@ -495,19 +481,10 @@ func TestExtractDemoTagsWithPattern_WorkspaceFallback(t *testing.T) {
 	})
 
 	t.Run("mapfs", func(t *testing.T) {
-		// Stage files on disk for NewMapWorkspaceContextWithRoot to load.
-		// Use WithRoot so filepath.Base(root) returns "pf-v5-button",
-		// which the workspace fallback logic needs.
-		pkgDir := filepath.Join(t.TempDir(), "pf-v5-button")
-		demoDir := filepath.Join(pkgDir, "demo")
-		if err := os.MkdirAll(demoDir, 0755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(demoDir, "basic.html"), []byte(html), 0644); err != nil {
-			t.Fatal(err)
-		}
+		mfs := platform.NewMapFileSystem(nil)
+		mfs.AddFile("/pf-v5-button/demo/basic.html", html, 0644)
 
-		ctx := testworkspace.NewMapWorkspaceContextWithRoot(t, pkgDir, "/pf-v5-button")
+		ctx := testworkspace.NewMapWorkspaceContextFromFS(mfs, "/pf-v5-button")
 		tags, err := extractDemoTagsWithPattern(ctx, "demo/basic.html", ":tag/demo/:demo.html", nil, ctx.FileSystem())
 		if err != nil {
 			t.Fatalf("extractDemoTagsWithPattern failed: %v", err)
@@ -644,16 +621,11 @@ func TestNewDemoMap(t *testing.T) {
 	})
 
 	t.Run("mapfs", func(t *testing.T) {
-		// Stage files on disk for NewMapWorkspaceContext to load
-		tmpDir := t.TempDir()
-		if err := os.WriteFile(filepath.Join(tmpDir, "demo1.html"), demo1Input, 0644); err != nil {
-			t.Fatalf("Failed to write demo1: %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(tmpDir, "demo2.html"), demo2Input, 0644); err != nil {
-			t.Fatalf("Failed to write demo2: %v", err)
-		}
+		mfs := platform.NewMapFileSystem(nil)
+		mfs.AddFile("/demo1.html", string(demo1Input), 0644)
+		mfs.AddFile("/demo2.html", string(demo2Input), 0644)
 
-		ctx := testworkspace.NewMapWorkspaceContext(t, tmpDir)
+		ctx := testworkspace.NewMapWorkspaceContextFromFS(mfs, "/")
 
 		demoMap, err := NewDemoMap(ctx, []string{"/demo1.html", "/demo2.html"}, config.ElementAliases, ctx.FileSystem())
 		if err != nil {

--- a/generate/generate_nil_manifest_regression_test.go
+++ b/generate/generate_nil_manifest_regression_test.go
@@ -1,6 +1,7 @@
 package generate_test
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,6 +13,25 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type errorFileSystem struct {
+	*platform.MapFileSystem
+	errorPaths map[string]error
+}
+
+func (e *errorFileSystem) ReadFile(name string) ([]byte, error) {
+	if err, ok := e.errorPaths[name]; ok {
+		return nil, err
+	}
+	return e.MapFileSystem.ReadFile(name)
+}
+
+func (e *errorFileSystem) Open(name string) (fs.File, error) {
+	if err, ok := e.errorPaths[name]; ok {
+		return nil, err
+	}
+	return e.MapFileSystem.Open(name)
+}
 
 // Inline: regression test, verifying specific fix
 
@@ -152,7 +172,32 @@ func TestGenerateWithFileReadError(t *testing.T) {
 	})
 
 	t.Run("mapfs", func(t *testing.T) {
-		t.Skip("MapFS does not enforce file permissions, cannot simulate read errors")
+		synctest.Test(t, func(t *testing.T) {
+			mapFS := platform.NewMapFileSystem(nil)
+			root := "/test-workspace"
+
+			mapFS.AddFile(root+"/package.json", `{"name": "test-package"}`, 0644)
+			mapFS.AddFile(root+"/.config/cem.yaml", "generate:\n  files:\n    - restricted.ts\n", 0644)
+			mapFS.AddFile(root+"/restricted.ts", "export class Test {}", 0644)
+
+			errFS := &errorFileSystem{
+				MapFileSystem: mapFS,
+				errorPaths: map[string]error{
+					root + "/restricted.ts": fs.ErrPermission,
+					"restricted.ts":         fs.ErrPermission,
+				},
+			}
+
+			workspace := W.NewFileSystemWorkspaceContext(root, W.WithFileSystem(errFS))
+			err := workspace.Init()
+			require.NoError(t, err)
+
+			manifestStr, err := G.Generate(workspace, errFS)
+
+			assert.Error(t, err, "Generate should return an error when file cannot be read")
+			assert.Nil(t, manifestStr, "Manifest should be nil when generation fails")
+			assert.Contains(t, err.Error(), "NewModuleProcessor", "Error should indicate NewModuleProcessor failure")
+		})
 	})
 }
 

--- a/internal/platform/testutil/lsp.go
+++ b/internal/platform/testutil/lsp.go
@@ -25,17 +25,21 @@ import (
 	"testing"
 
 	"bennypowers.dev/cem/internal/platform"
+	protocol "github.com/bennypowers/glsp/protocol_3_17"
+	"golang.org/x/net/html"
+	"gopkg.in/yaml.v3"
 )
 
 // LSPFixture represents a single LSP test scenario loaded from fixtures
 type LSPFixture struct {
-	Name            string            // Test scenario name (directory name)
-	InputHTML       string            // HTML content from input.html (deprecated: use InputContent)
-	InputContent    string            // Content from input.html or input.ts
-	InputType       string            // File type: "html" or "ts"
-	Manifest        json.RawMessage   // Optional manifest data from manifest.json
-	ExpectedMap     map[string]any    // Expected results from expected-*.json or expected.json
-	AdditionalFiles map[string]string // Additional source files in the fixture directory (filename → content)
+	Name            string              // Test scenario name (directory name)
+	InputHTML       string              // HTML content from input.html (deprecated: use InputContent)
+	InputContent    string              // Content from input.html or input.ts
+	InputType       string              // File type: "html" or "ts"
+	Manifest        json.RawMessage     // Optional manifest data from manifest.json
+	ExpectedMap     map[string]any      // Expected results from expected-*.json or expected.json
+	AdditionalFiles map[string]string   // Additional source files in the fixture directory (filename → content)
+	Cursor          *protocol.Position  // Cursor position extracted from ^cursor marker or YAML frontmatter
 }
 
 // RunLSPFixtures discovers and runs LSP tests from a testdata directory.
@@ -106,9 +110,12 @@ func loadLSPFixtureFromMapFS(t *testing.T, mfs *platform.MapFileSystem, scenario
 		path := filepath.Join(scenarioName, candidate.name)
 		data, err := mfs.ReadFile(path)
 		if err == nil {
-			fixture.InputContent = string(data)
-			fixture.InputHTML = string(data)
+			content := string(data)
+			cleaned, cursor := extractCursor(content, candidate.fileType)
+			fixture.InputContent = cleaned
+			fixture.InputHTML = cleaned
 			fixture.InputType = candidate.fileType
+			fixture.Cursor = cursor
 			found = true
 			break
 		}
@@ -187,4 +194,127 @@ func (f *LSPFixture) GetExpected(key string, v any) error {
 		return err
 	}
 	return json.Unmarshal(bytes, v)
+}
+
+// CursorParser extracts a ^cursor marker from file content.
+// Returns cleaned content (marker stripped) and cursor position (nil if not found).
+type CursorParser func(content string) (string, *protocol.Position)
+
+// ParseCursor extracts cursor position using the given parser.
+// Skips if Cursor is already set (e.g., by frontmatter or HTML extraction during load).
+func (f *LSPFixture) ParseCursor(parser CursorParser) {
+	if f.Cursor != nil {
+		return
+	}
+	cleaned, cursor := parser(f.InputContent)
+	if cursor != nil {
+		f.InputContent = cleaned
+		f.InputHTML = cleaned
+		f.Cursor = cursor
+	}
+}
+
+// extractCursor checks content for a ^cursor comment marker or YAML frontmatter.
+// For HTML, uses golang.org/x/net/html tokenizer to find comment nodes.
+// For TS/CSS, only checks frontmatter; use ParseCursor with a tree-sitter parser.
+func extractCursor(content string, fileType string) (string, *protocol.Position) {
+	if fileType == "html" {
+		cleaned, cursor := extractHTMLCursorMarker(content)
+		if cursor != nil {
+			return cleaned, cursor
+		}
+	}
+	return extractCursorFrontmatter(content)
+}
+
+// extractHTMLCursorMarker uses the Go HTML tokenizer to find <!-- ^cursor --> comments.
+func extractHTMLCursorMarker(content string) (string, *protocol.Position) {
+	tokenizer := html.NewTokenizer(strings.NewReader(content))
+	byteOffset := 0
+	for {
+		tt := tokenizer.Next()
+		if tt == html.ErrorToken {
+			break
+		}
+		raw := string(tokenizer.Raw())
+		if tt == html.CommentToken && strings.Contains(raw, "^cursor") {
+			caretInRaw := strings.Index(raw, "^")
+			if caretInRaw < 0 {
+				byteOffset += len(raw)
+				continue
+			}
+			caretGlobal := byteOffset + caretInRaw
+			caretLine, caretCol := byteOffsetToLineCol(content, caretGlobal)
+			if caretLine == 0 {
+				byteOffset += len(raw)
+				continue
+			}
+			// Strip the entire line containing the comment
+			lineStart := byteOffset
+			for lineStart > 0 && content[lineStart-1] != '\n' {
+				lineStart--
+			}
+			lineEnd := byteOffset + len(raw)
+			if lineEnd < len(content) && content[lineEnd] == '\n' {
+				lineEnd++
+			}
+			cleaned := content[:lineStart] + content[lineEnd:]
+			return cleaned, &protocol.Position{
+				Line:      uint32(caretLine - 1),
+				Character: uint32(caretCol),
+			}
+		}
+		byteOffset += len(raw)
+	}
+	return content, nil
+}
+
+func byteOffsetToLineCol(content string, offset int) (int, int) {
+	line := 0
+	col := 0
+	for i := range offset {
+		if i >= len(content) {
+			break
+		}
+		if content[i] == '\n' {
+			line++
+			col = 0
+		} else {
+			col++
+		}
+	}
+	return line, col
+}
+
+// cursorFrontmatter is the YAML structure for cursor position in frontmatter.
+type cursorFrontmatter struct {
+	Cursor *struct {
+		Line      uint32 `yaml:"line"`
+		Character uint32 `yaml:"character"`
+	} `yaml:"cursor"`
+}
+
+// extractCursorFrontmatter checks for YAML frontmatter with cursor position.
+func extractCursorFrontmatter(content string) (string, *protocol.Position) {
+	if !strings.HasPrefix(content, "---\n") {
+		return content, nil
+	}
+	end := strings.Index(content[4:], "\n---\n")
+	if end < 0 {
+		return content, nil
+	}
+	fmContent := content[4 : 4+end]
+	body := content[4+end+5:]
+
+	var fm cursorFrontmatter
+	if err := yaml.Unmarshal([]byte(fmContent), &fm); err != nil {
+		return content, nil
+	}
+	if fm.Cursor == nil {
+		return content, nil
+	}
+	return body, &protocol.Position{
+		Line:      fm.Cursor.Line,
+		Character: fm.Cursor.Character,
+	}
 }

--- a/internal/platform/testutil/lsp.go
+++ b/internal/platform/testutil/lsp.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"bennypowers.dev/cem/internal/platform"
+	"bennypowers.dev/cem/internal/textutil"
 	protocol "github.com/bennypowers/glsp/protocol_3_17"
 	"golang.org/x/net/html"
 	"gopkg.in/yaml.v3"
@@ -244,7 +245,7 @@ func extractHTMLCursorMarker(content string) (string, *protocol.Position) {
 				continue
 			}
 			caretGlobal := byteOffset + caretInRaw
-			caretLine, caretCol := byteOffsetToLineCol(content, caretGlobal)
+			caretLine, caretChar := byteOffsetToPosition(content, caretGlobal)
 			if caretLine == 0 {
 				byteOffset += len(raw)
 				continue
@@ -261,7 +262,7 @@ func extractHTMLCursorMarker(content string) (string, *protocol.Position) {
 			cleaned := content[:lineStart] + content[lineEnd:]
 			return cleaned, &protocol.Position{
 				Line:      uint32(caretLine - 1),
-				Character: uint32(caretCol),
+				Character: caretChar,
 			}
 		}
 		byteOffset += len(raw)
@@ -269,21 +270,22 @@ func extractHTMLCursorMarker(content string) (string, *protocol.Position) {
 	return content, nil
 }
 
-func byteOffsetToLineCol(content string, offset int) (int, int) {
-	line := 0
-	col := 0
+// byteOffsetToPosition converts a byte offset in content to an LSP-compatible
+// (line, character) pair where character is in UTF-16 code units.
+func byteOffsetToPosition(content string, offset int) (line int, character uint32) {
+	lineStart := 0
 	for i := range offset {
 		if i >= len(content) {
 			break
 		}
 		if content[i] == '\n' {
 			line++
-			col = 0
-		} else {
-			col++
+			lineStart = i + 1
 		}
 	}
-	return line, col
+	byteCol := uint(offset - lineStart)
+	character = textutil.ByteOffsetToUTF16(content[lineStart:], byteCol)
+	return line, character
 }
 
 // cursorFrontmatter is the YAML structure for cursor position in frontmatter.

--- a/internal/platform/testutil/lsp.go
+++ b/internal/platform/testutil/lsp.go
@@ -216,16 +216,22 @@ func (f *LSPFixture) ParseCursor(parser CursorParser) {
 }
 
 // extractCursor checks content for a ^cursor comment marker or YAML frontmatter.
+// Marker always takes precedence. Frontmatter is always stripped if present.
 // For HTML, uses golang.org/x/net/html tokenizer to find comment nodes.
 // For TS/CSS, only checks frontmatter; use ParseCursor with a tree-sitter parser.
 func extractCursor(content string, fileType string) (string, *protocol.Position) {
+	// Strip frontmatter first (if present) so it never appears in InputContent
+	body, fmCursor := extractCursorFrontmatter(content)
 	if fileType == "html" {
-		cleaned, cursor := extractHTMLCursorMarker(content)
-		if cursor != nil {
-			return cleaned, cursor
+		cleaned, markerCursor := extractHTMLCursorMarker(body)
+		if markerCursor != nil {
+			return cleaned, markerCursor
 		}
 	}
-	return extractCursorFrontmatter(content)
+	if fmCursor != nil {
+		return body, fmCursor
+	}
+	return content, nil
 }
 
 // extractHTMLCursorMarker uses the Go HTML tokenizer to find <!-- ^cursor --> comments.

--- a/internal/platform/testutil/lsp.go
+++ b/internal/platform/testutil/lsp.go
@@ -216,7 +216,7 @@ func (f *LSPFixture) ParseCursor(parser CursorParser) {
 }
 
 // extractCursor checks content for a ^cursor comment marker or YAML frontmatter.
-// Marker always takes precedence. Frontmatter is always stripped if present.
+// Marker always takes precedence. Frontmatter is stripped when it contains a cursor key.
 // For HTML, uses golang.org/x/net/html tokenizer to find comment nodes.
 // For TS/CSS, only checks frontmatter; use ParseCursor with a tree-sitter parser.
 func extractCursor(content string, fileType string) (string, *protocol.Position) {

--- a/internal/platform/testutil/lsp.go
+++ b/internal/platform/testutil/lsp.go
@@ -256,12 +256,15 @@ func extractHTMLCursorMarker(content string) (string, *protocol.Position) {
 				byteOffset += len(raw)
 				continue
 			}
-			// Strip the entire line containing the comment
+			// Strip the entire line containing the comment (LF and CRLF)
 			lineStart := byteOffset
 			for lineStart > 0 && content[lineStart-1] != '\n' {
 				lineStart--
 			}
 			lineEnd := byteOffset + len(raw)
+			if lineEnd < len(content) && content[lineEnd] == '\r' {
+				lineEnd++
+			}
 			if lineEnd < len(content) && content[lineEnd] == '\n' {
 				lineEnd++
 			}

--- a/internal/platform/testutil/lsp_cursor_test.go
+++ b/internal/platform/testutil/lsp_cursor_test.go
@@ -17,6 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package testutil
 
 import (
+	"strings"
 	"testing"
 
 	protocol "github.com/bennypowers/glsp/protocol_3_17"
@@ -167,15 +168,24 @@ title: test
 }
 
 func TestExtractCursor_HTMLMarkerOverFrontmatter(t *testing.T) {
-	content := "<test-element></test-element>\n<!-- ^cursor -->\n"
+	content := "---\ncursor:\n  line: 99\n  character: 99\n---\n<test-element></test-element>\n<!-- ^cursor -->\n"
 	cleaned, cursor := extractCursor(content, "html")
 	if cursor == nil {
 		t.Fatal("Expected cursor from HTML marker, got nil")
 	}
 	if cursor.Line != 0 {
-		t.Errorf("Line: want 0, got %d", cursor.Line)
+		t.Errorf("Line: want 0 (from marker), got %d", cursor.Line)
 	}
-	_ = cleaned
+	if cursor.Character == 99 {
+		t.Error("Cursor came from frontmatter, not marker")
+	}
+	if strings.Contains(cleaned, "---") {
+		t.Errorf("Frontmatter not stripped from cleaned content: %q", cleaned)
+	}
+	wantClean := "<test-element></test-element>\n"
+	if cleaned != wantClean {
+		t.Errorf("Cleaned content mismatch.\nWant: %q\nGot:  %q", wantClean, cleaned)
+	}
 }
 
 func TestExtractCursor_FrontmatterFallbackForTS(t *testing.T) {

--- a/internal/platform/testutil/lsp_cursor_test.go
+++ b/internal/platform/testutil/lsp_cursor_test.go
@@ -209,6 +209,37 @@ const y = 2;
 	}
 }
 
+func TestExtractCursor_HTMLFrontmatterFallback(t *testing.T) {
+	content := "---\ncursor:\n  line: 2\n  character: 5\n---\n<html>\n<body>\n  <test-el></test-el>\n</body>\n</html>\n"
+	cleaned, cursor := extractCursor(content, "html")
+	if cursor == nil {
+		t.Fatal("Expected cursor from frontmatter fallback, got nil")
+	}
+	if cursor.Line != 2 || cursor.Character != 5 {
+		t.Errorf("Want (2,5), got (%d,%d)", cursor.Line, cursor.Character)
+	}
+	if strings.Contains(cleaned, "---") {
+		t.Errorf("Frontmatter not stripped: %q", cleaned)
+	}
+}
+
+func TestExtractHTMLCursorMarker_CRLF(t *testing.T) {
+	content := "<!DOCTYPE html>\r\n<html>\r\n<body>\r\n  <test-element></test-element>\r\n<!-- ^cursor -->\r\n</body>\r\n</html>\r\n"
+	cleaned, cursor := extractHTMLCursorMarker(content)
+	if cursor == nil {
+		t.Fatal("Expected cursor, got nil")
+	}
+	if cursor.Line != 3 {
+		t.Errorf("Line: want 3, got %d", cursor.Line)
+	}
+	if cursor.Character != 5 {
+		t.Errorf("Character: want 5, got %d", cursor.Character)
+	}
+	if strings.Contains(cleaned, "^cursor") {
+		t.Errorf("Cursor marker not stripped from cleaned content")
+	}
+}
+
 func TestExtractCursor_NilWhenNoMarkerOrFrontmatter(t *testing.T) {
 	_, cursor := extractCursor("<test-element></test-element>\n", "html")
 	if cursor != nil {

--- a/internal/platform/testutil/lsp_cursor_test.go
+++ b/internal/platform/testutil/lsp_cursor_test.go
@@ -1,0 +1,246 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package testutil
+
+import (
+	"testing"
+
+	protocol "github.com/bennypowers/glsp/protocol_3_17"
+)
+
+func TestExtractHTMLCursorMarker(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantLine  uint32
+		wantChar  uint32
+		wantClean string
+		wantNil   bool
+	}{
+		{
+			name:      "edge case line 0",
+			content:   "<test-element attr=\"hello\"></test-element>\n<!-- ^cursor -->\n",
+			wantLine:  0,
+			wantChar:  5,
+			wantClean: "<test-element attr=\"hello\"></test-element>\n",
+		},
+		{
+			name: "caret under nested element",
+			content: `<!DOCTYPE html>
+<html>
+<body>
+  <test-element></test-element>
+  <!--       ^cursor -->
+</body>
+</html>`,
+			wantLine:  3,
+			wantChar:  13,
+			wantClean: "<!DOCTYPE html>\n<html>\n<body>\n  <test-element></test-element>\n</body>\n</html>",
+		},
+		{
+			name: "caret under attribute value",
+			content: `<!DOCTYPE html>
+<html>
+<body>
+  <test-element test-attr="hello"></test-element>
+  <!--                     ^cursor -->
+</body>
+</html>`,
+			wantLine:  3,
+			wantChar:  27,
+			wantClean: "<!DOCTYPE html>\n<html>\n<body>\n  <test-element test-attr=\"hello\"></test-element>\n</body>\n</html>",
+		},
+		{
+			name:    "no marker",
+			content: "<test-element></test-element>\n",
+			wantNil: true,
+		},
+		{
+			name:    "marker on first line has no line above",
+			content: "<!-- ^cursor -->\n<test-element></test-element>\n",
+			wantNil: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleaned, cursor := extractHTMLCursorMarker(tt.content)
+			if tt.wantNil {
+				if cursor != nil {
+					t.Errorf("Expected nil cursor, got %+v", cursor)
+				}
+				return
+			}
+			if cursor == nil {
+				t.Fatal("Expected cursor, got nil")
+			}
+			if cursor.Line != tt.wantLine {
+				t.Errorf("Line: want %d, got %d", tt.wantLine, cursor.Line)
+			}
+			if cursor.Character != tt.wantChar {
+				t.Errorf("Character: want %d, got %d", tt.wantChar, cursor.Character)
+			}
+			if cleaned != tt.wantClean {
+				t.Errorf("Cleaned content mismatch.\nWant:\n%q\nGot:\n%q", tt.wantClean, cleaned)
+			}
+		})
+	}
+}
+
+func TestExtractCursorFrontmatter(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantLine  uint32
+		wantChar  uint32
+		wantClean string
+		wantNil   bool
+	}{
+		{
+			name: "basic frontmatter",
+			content: `---
+cursor:
+  line: 2
+  character: 10
+---
+<html>
+<body>
+  <test-element></test-element>
+</body>
+</html>
+`,
+			wantLine:  2,
+			wantChar:  10,
+			wantClean: "<html>\n<body>\n  <test-element></test-element>\n</body>\n</html>\n",
+		},
+		{
+			name: "no cursor key in frontmatter",
+			content: `---
+title: test
+---
+<html></html>
+`,
+			wantNil: true,
+		},
+		{
+			name:    "no frontmatter",
+			content: "<html></html>\n",
+			wantNil: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleaned, cursor := extractCursorFrontmatter(tt.content)
+			if tt.wantNil {
+				if cursor != nil {
+					t.Errorf("Expected nil cursor, got %+v", cursor)
+				}
+				return
+			}
+			if cursor == nil {
+				t.Fatal("Expected cursor, got nil")
+			}
+			if cursor.Line != tt.wantLine {
+				t.Errorf("Line: want %d, got %d", tt.wantLine, cursor.Line)
+			}
+			if cursor.Character != tt.wantChar {
+				t.Errorf("Character: want %d, got %d", tt.wantChar, cursor.Character)
+			}
+			if cleaned != tt.wantClean {
+				t.Errorf("Cleaned content mismatch.\nWant:\n%q\nGot:\n%q", tt.wantClean, cleaned)
+			}
+		})
+	}
+}
+
+func TestExtractCursor_HTMLMarkerOverFrontmatter(t *testing.T) {
+	content := "<test-element></test-element>\n<!-- ^cursor -->\n"
+	cleaned, cursor := extractCursor(content, "html")
+	if cursor == nil {
+		t.Fatal("Expected cursor from HTML marker, got nil")
+	}
+	if cursor.Line != 0 {
+		t.Errorf("Line: want 0, got %d", cursor.Line)
+	}
+	_ = cleaned
+}
+
+func TestExtractCursor_FrontmatterFallbackForTS(t *testing.T) {
+	content := `---
+cursor:
+  line: 1
+  character: 5
+---
+const x = 1;
+const y = 2;
+`
+	cleaned, cursor := extractCursor(content, "ts")
+	if cursor == nil {
+		t.Fatal("Expected cursor from frontmatter, got nil")
+	}
+	if cursor.Line != 1 || cursor.Character != 5 {
+		t.Errorf("Want (1,5), got (%d,%d)", cursor.Line, cursor.Character)
+	}
+	if cleaned != "const x = 1;\nconst y = 2;\n" {
+		t.Errorf("Frontmatter not stripped: %q", cleaned)
+	}
+}
+
+func TestExtractCursor_NilWhenNoMarkerOrFrontmatter(t *testing.T) {
+	_, cursor := extractCursor("<test-element></test-element>\n", "html")
+	if cursor != nil {
+		t.Errorf("Expected nil cursor, got %+v", cursor)
+	}
+}
+
+func TestLSPFixture_ParseCursor(t *testing.T) {
+	fixture := &LSPFixture{
+		InputContent: "some content",
+		InputHTML:    "some content",
+	}
+	mockParser := func(content string) (string, *protocol.Position) {
+		return "cleaned", &protocol.Position{Line: 3, Character: 7}
+	}
+	fixture.ParseCursor(mockParser)
+	if fixture.Cursor == nil {
+		t.Fatal("Expected Cursor to be set")
+	}
+	if fixture.Cursor.Line != 3 || fixture.Cursor.Character != 7 {
+		t.Errorf("Want (3,7), got (%d,%d)", fixture.Cursor.Line, fixture.Cursor.Character)
+	}
+	if fixture.InputContent != "cleaned" {
+		t.Errorf("InputContent not updated: %q", fixture.InputContent)
+	}
+}
+
+func TestLSPFixture_ParseCursor_SkipsWhenAlreadySet(t *testing.T) {
+	fixture := &LSPFixture{
+		InputContent: "original",
+		Cursor:       &protocol.Position{Line: 1, Character: 2},
+	}
+	called := false
+	mockParser := func(content string) (string, *protocol.Position) {
+		called = true
+		return "changed", &protocol.Position{Line: 99, Character: 99}
+	}
+	fixture.ParseCursor(mockParser)
+	if called {
+		t.Error("Parser should not be called when Cursor is already set")
+	}
+	if fixture.InputContent != "original" {
+		t.Error("InputContent should not change")
+	}
+}

--- a/internal/platform/testutil/workspace/workspace.go
+++ b/internal/platform/testutil/workspace/workspace.go
@@ -64,6 +64,16 @@ func NewMapWorkspaceContext(t testing.TB, dir string) *MapWorkspaceContext {
 	}
 }
 
+// NewMapWorkspaceContextFromFS creates a MapWorkspaceContext from an existing MapFileSystem.
+// Use when building the filesystem directly with AddFile instead of loading from disk.
+func NewMapWorkspaceContextFromFS(mfs *platform.MapFileSystem, root string) *MapWorkspaceContext {
+	return &MapWorkspaceContext{
+		mfs:               mfs,
+		root:              root,
+		designTokensCache: &noopDesignTokensCache{},
+	}
+}
+
 // NewMapWorkspaceContextWithRoot loads dir into MapFS rooted at rootPath
 // and returns a WorkspaceContext backed by it. Use this when the test depends
 // on the workspace root directory name (e.g., workspace fallback logic that

--- a/lsp/methods/textDocument/completion/completion_test_helpers_test.go
+++ b/lsp/methods/textDocument/completion/completion_test_helpers_test.go
@@ -18,12 +18,12 @@ package completion_test
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"bennypowers.dev/cem/internal/platform/testutil"
 	"bennypowers.dev/cem/lsp/document"
 	"bennypowers.dev/cem/lsp/methods/textDocument/completion"
 	"bennypowers.dev/cem/lsp/types"
@@ -130,86 +130,26 @@ func completionTypeString(t types.CompletionContextType) string {
 	}
 }
 
-// CopyFixtureFiles copies files from the fixture directory to the target directory,
-// preserving directory structure
+// CopyFixtureFiles loads fixtures from fixtureDir via testutil and writes
+// them to targetDir, preserving directory structure.
 func CopyFixtureFiles(t *testing.T, fixtureDir, targetDir string) {
 	t.Helper()
-
-	err := filepath.Walk(fixtureDir, func(path string, info os.FileInfo, err error) error {
+	mfs := testutil.LoadTestdataFS(t, fixtureDir, "/")
+	entries := mfs.GetMapFS()
+	for path, file := range entries {
+		if file.Mode.IsDir() || strings.HasSuffix(path, "README.md") {
+			continue
+		}
+		data, err := mfs.ReadFile(path)
 		if err != nil {
-			return err
+			t.Fatalf("Failed to read fixture %s: %v", path, err)
 		}
-
-		// Skip README files
-		if strings.HasSuffix(path, "README.md") {
-			return nil
+		targetPath := filepath.Join(targetDir, path)
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+			t.Fatalf("Failed to create directory for %s: %v", targetPath, err)
 		}
-
-		// Get relative path from fixture directory
-		relPath, err := filepath.Rel(fixtureDir, path)
-		if err != nil {
-			return err
+		if err := os.WriteFile(targetPath, data, 0644); err != nil {
+			t.Fatalf("Failed to write %s: %v", targetPath, err)
 		}
-
-		targetPath := filepath.Join(targetDir, relPath)
-
-		if info.IsDir() {
-			return os.MkdirAll(targetPath, info.Mode())
-		}
-
-		// Copy file
-		src, err := os.Open(path)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = src.Close() }()
-
-		err = os.MkdirAll(filepath.Dir(targetPath), 0755)
-		if err != nil {
-			return err
-		}
-
-		dst, err := os.Create(targetPath)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = dst.Close() }()
-
-		_, err = io.Copy(dst, src)
-		return err
-	})
-
-	if err != nil {
-		t.Fatalf("Failed to copy fixture files: %v", err)
-	}
-}
-
-// CopyFixtureFile copies a single file from the fixture directory to the target location
-func CopyFixtureFile(t *testing.T, fixtureDir, filename, targetDir, targetFilename string) {
-	t.Helper()
-
-	src := filepath.Join(fixtureDir, filename)
-	dst := filepath.Join(targetDir, targetFilename)
-
-	srcFile, err := os.Open(src)
-	if err != nil {
-		t.Fatalf("Failed to open source file %s: %v", src, err)
-	}
-	defer func() { _ = srcFile.Close() }()
-
-	err = os.MkdirAll(filepath.Dir(dst), 0755)
-	if err != nil {
-		t.Fatalf("Failed to create target directory: %v", err)
-	}
-
-	dstFile, err := os.Create(dst)
-	if err != nil {
-		t.Fatalf("Failed to create target file %s: %v", dst, err)
-	}
-	defer func() { _ = dstFile.Close() }()
-
-	_, err = io.Copy(dstFile, srcFile)
-	if err != nil {
-		t.Fatalf("Failed to copy file content: %v", err)
 	}
 }

--- a/lsp/methods/textDocument/hover/hover_test.go
+++ b/lsp/methods/textDocument/hover/hover_test.go
@@ -30,6 +30,9 @@ import (
 
 func TestHover_Fixtures(t *testing.T) {
 	testutil.RunLSPFixtures(t, "testdata", func(t *testing.T, fixture *testutil.LSPFixture) {
+		if fixture.InputType == "ts" {
+			fixture.ParseCursor(testhelpers.TSCursorParser)
+		}
 		if fixture.Cursor == nil {
 			t.Fatalf("No cursor position in fixture %s (add <!-- ^cursor --> or frontmatter)", fixture.Name)
 		}

--- a/lsp/methods/textDocument/hover/hover_test.go
+++ b/lsp/methods/textDocument/hover/hover_test.go
@@ -28,28 +28,12 @@ import (
 	protocol "github.com/bennypowers/glsp/protocol_3_17"
 )
 
-// Cursor positions for each test fixture
-var cursorPositions = map[string]protocol.Position{
-	"element-hover-html":                     {Line: 6, Character: 5},
-	"element-hover-typescript":               {Line: 5, Character: 10},
-	"hover-attribute-html":                   {Line: 6, Character: 20},
-	"hover-boolean-binding-typescript":       {Line: 5, Character: 23},
-	"hover-dotted-attr-not-field-html":       {Line: 6, Character: 20},
-	"hover-dotted-attribute-html":            {Line: 6, Character: 20},
-	"hover-event-binding-typescript":         {Line: 5, Character: 23},
-	"hover-property-binding-typescript":      {Line: 5, Character: 23},
-	"hover-unknown-event-typescript":         {Line: 5, Character: 23},
-	"hover-unknown-property-typescript":      {Line: 5, Character: 23},
-	"multiline-attributes-hover-html":        {Line: 6, Character: 13},
-}
-
 func TestHover_Fixtures(t *testing.T) {
 	testutil.RunLSPFixtures(t, "testdata", func(t *testing.T, fixture *testutil.LSPFixture) {
-		// Get cursor position from map
-		cursor, ok := cursorPositions[fixture.Name]
-		if !ok {
-			t.Fatalf("No cursor position defined for fixture %s", fixture.Name)
+		if fixture.Cursor == nil {
+			t.Fatalf("No cursor position in fixture %s (add <!-- ^cursor --> or frontmatter)", fixture.Name)
 		}
+		cursor := *fixture.Cursor
 
 		// Parse manifest if present
 		ctx := testhelpers.NewMockServerContext()

--- a/lsp/methods/textDocument/hover/testdata/element-hover-html/input.html
+++ b/lsp/methods/textDocument/hover/testdata/element-hover-html/input.html
@@ -5,5 +5,6 @@
 </head>
 <body>
   <test-element test-attr="hello"></test-element>
+<!-- ^cursor -->
 </body>
 </html>

--- a/lsp/methods/textDocument/hover/testdata/element-hover-typescript/input.ts
+++ b/lsp/methods/textDocument/hover/testdata/element-hover-typescript/input.ts
@@ -1,3 +1,8 @@
+---
+cursor:
+  line: 5
+  character: 10
+---
 import { html } from 'lit';
 
 export class MyComponent {

--- a/lsp/methods/textDocument/hover/testdata/element-hover-typescript/input.ts
+++ b/lsp/methods/textDocument/hover/testdata/element-hover-typescript/input.ts
@@ -1,14 +1,10 @@
----
-cursor:
-  line: 5
-  character: 10
----
 import { html } from 'lit';
 
 export class MyComponent {
   render() {
     return html`
       <test-component prop="value"></test-component>
+      <!--^cursor -->
     `;
   }
 }

--- a/lsp/methods/textDocument/hover/testdata/hover-attribute-html/input.html
+++ b/lsp/methods/textDocument/hover/testdata/hover-attribute-html/input.html
@@ -5,5 +5,6 @@
 </head>
 <body>
   <test-element test-attr="hello"></test-element>
+<!--                ^cursor -->
 </body>
 </html>

--- a/lsp/methods/textDocument/hover/testdata/hover-boolean-binding-typescript/input.ts
+++ b/lsp/methods/textDocument/hover/testdata/hover-boolean-binding-typescript/input.ts
@@ -1,3 +1,8 @@
+---
+cursor:
+  line: 5
+  character: 23
+---
 import { html } from 'lit';
 
 export class MyComponent {

--- a/lsp/methods/textDocument/hover/testdata/hover-boolean-binding-typescript/input.ts
+++ b/lsp/methods/textDocument/hover/testdata/hover-boolean-binding-typescript/input.ts
@@ -1,14 +1,10 @@
----
-cursor:
-  line: 5
-  character: 23
----
 import { html } from 'lit';
 
 export class MyComponent {
   render() {
     return html`
       <test-component ?disabled=${this.disabled}></test-component>
+      <!--             ^cursor -->
     `;
   }
 }

--- a/lsp/methods/textDocument/hover/testdata/hover-dotted-attr-not-field-html/input.html
+++ b/lsp/methods/textDocument/hover/testdata/hover-dotted-attr-not-field-html/input.html
@@ -5,5 +5,6 @@
 </head>
 <body>
   <test-element .testAttr="hello"></test-element>
+<!--                ^cursor -->
 </body>
 </html>

--- a/lsp/methods/textDocument/hover/testdata/hover-dotted-attribute-html/input.html
+++ b/lsp/methods/textDocument/hover/testdata/hover-dotted-attribute-html/input.html
@@ -5,5 +5,6 @@
 </head>
 <body>
   <test-element .test-attr="hello"></test-element>
+<!--                ^cursor -->
 </body>
 </html>

--- a/lsp/methods/textDocument/hover/testdata/hover-event-binding-typescript/input.ts
+++ b/lsp/methods/textDocument/hover/testdata/hover-event-binding-typescript/input.ts
@@ -1,14 +1,10 @@
----
-cursor:
-  line: 5
-  character: 23
----
 import { html } from 'lit';
 
 export class MyComponent {
   render() {
     return html`
       <test-component @change=${this.onChange}></test-component>
+      <!--             ^cursor -->
     `;
   }
 }

--- a/lsp/methods/textDocument/hover/testdata/hover-event-binding-typescript/input.ts
+++ b/lsp/methods/textDocument/hover/testdata/hover-event-binding-typescript/input.ts
@@ -1,3 +1,8 @@
+---
+cursor:
+  line: 5
+  character: 23
+---
 import { html } from 'lit';
 
 export class MyComponent {

--- a/lsp/methods/textDocument/hover/testdata/hover-property-binding-typescript/input.ts
+++ b/lsp/methods/textDocument/hover/testdata/hover-property-binding-typescript/input.ts
@@ -1,3 +1,8 @@
+---
+cursor:
+  line: 5
+  character: 23
+---
 import { html } from 'lit';
 
 export class MyComponent {

--- a/lsp/methods/textDocument/hover/testdata/hover-property-binding-typescript/input.ts
+++ b/lsp/methods/textDocument/hover/testdata/hover-property-binding-typescript/input.ts
@@ -1,14 +1,10 @@
----
-cursor:
-  line: 5
-  character: 23
----
 import { html } from 'lit';
 
 export class MyComponent {
   render() {
     return html`
       <test-component .prop=${this.prop}></test-component>
+      <!--             ^cursor -->
     `;
   }
 }

--- a/lsp/methods/textDocument/hover/testdata/hover-unknown-event-typescript/input.ts
+++ b/lsp/methods/textDocument/hover/testdata/hover-unknown-event-typescript/input.ts
@@ -1,3 +1,8 @@
+---
+cursor:
+  line: 5
+  character: 23
+---
 import { html } from 'lit';
 
 export class MyComponent {

--- a/lsp/methods/textDocument/hover/testdata/hover-unknown-event-typescript/input.ts
+++ b/lsp/methods/textDocument/hover/testdata/hover-unknown-event-typescript/input.ts
@@ -1,14 +1,10 @@
----
-cursor:
-  line: 5
-  character: 23
----
 import { html } from 'lit';
 
 export class MyComponent {
   render() {
     return html`
       <test-component @unknownEvent=${this.handler}></test-component>
+      <!--             ^cursor -->
     `;
   }
 }

--- a/lsp/methods/textDocument/hover/testdata/hover-unknown-property-typescript/input.ts
+++ b/lsp/methods/textDocument/hover/testdata/hover-unknown-property-typescript/input.ts
@@ -1,3 +1,8 @@
+---
+cursor:
+  line: 5
+  character: 23
+---
 import { html } from 'lit';
 
 export class MyComponent {

--- a/lsp/methods/textDocument/hover/testdata/hover-unknown-property-typescript/input.ts
+++ b/lsp/methods/textDocument/hover/testdata/hover-unknown-property-typescript/input.ts
@@ -1,14 +1,10 @@
----
-cursor:
-  line: 5
-  character: 23
----
 import { html } from 'lit';
 
 export class MyComponent {
   render() {
     return html`
       <test-component .unknownProp=${this.x}></test-component>
+      <!--             ^cursor -->
     `;
   }
 }

--- a/lsp/methods/textDocument/hover/testdata/multiline-attributes-hover-html/input.html
+++ b/lsp/methods/textDocument/hover/testdata/multiline-attributes-hover-html/input.html
@@ -1,3 +1,8 @@
+---
+cursor:
+  line: 6
+  character: 13
+---
 <!DOCTYPE html>
 <html>
 <head>

--- a/lsp/methods/textDocument/references/references_test.go
+++ b/lsp/methods/textDocument/references/references_test.go
@@ -30,22 +30,12 @@ import (
 	protocol "github.com/bennypowers/glsp/protocol_3_17"
 )
 
-// Cursor positions for each test fixture (in Go code, not JSON)
-var cursorPositions = map[string]protocol.Position{
-	"basic-references":    {Line: 0, Character: 5},
-	"workspace-search":    {Line: 0, Character: 5},
-	"gitignore-filtering": {Line: 0, Character: 5},
-	"no-element":          {Line: 0, Character: 5},
-	"missing-document":    {Line: 0, Character: 0},
-}
-
 func TestReferences_Fixtures(t *testing.T) {
 	testutil.RunLSPFixtures(t, "testdata", func(t *testing.T, fixture *testutil.LSPFixture) {
-		// Get cursor position from map
-		cursor, ok := cursorPositions[fixture.Name]
-		if !ok {
-			t.Fatalf("No cursor position defined for fixture %s", fixture.Name)
+		if fixture.Cursor == nil {
+			t.Fatalf("No cursor position in fixture %s (add <!-- ^cursor --> or frontmatter)", fixture.Name)
 		}
+		cursor := *fixture.Cursor
 
 		// Create MockServerContext with proper DocumentManager
 		ctx := testhelpers.NewMockServerContext()

--- a/lsp/methods/textDocument/references/testdata/basic-references/input.html
+++ b/lsp/methods/textDocument/references/testdata/basic-references/input.html
@@ -1,1 +1,2 @@
 <rh-card>content</rh-card>
+<!-- ^cursor -->

--- a/lsp/methods/textDocument/references/testdata/gitignore-filtering/input.html
+++ b/lsp/methods/textDocument/references/testdata/gitignore-filtering/input.html
@@ -1,1 +1,2 @@
 <rh-card>test</rh-card>
+<!-- ^cursor -->

--- a/lsp/methods/textDocument/references/testdata/missing-document/input.html
+++ b/lsp/methods/textDocument/references/testdata/missing-document/input.html
@@ -1,1 +1,6 @@
+---
+cursor:
+  line: 0
+  character: 0
+---
 <my-card>Content</my-card>

--- a/lsp/methods/textDocument/references/testdata/no-element/input.html
+++ b/lsp/methods/textDocument/references/testdata/no-element/input.html
@@ -1,1 +1,2 @@
 <div>regular html</div>
+<!-- ^cursor -->

--- a/lsp/methods/textDocument/references/testdata/workspace-search/input.html
+++ b/lsp/methods/textDocument/references/testdata/workspace-search/input.html
@@ -1,1 +1,2 @@
 <rh-card>test</rh-card>
+<!-- ^cursor -->

--- a/lsp/server_integration_file_watch_test.go
+++ b/lsp/server_integration_file_watch_test.go
@@ -27,24 +27,21 @@ import (
 	"time"
 
 	"bennypowers.dev/cem/internal/platform"
+	"bennypowers.dev/cem/internal/platform/testutil"
 	"bennypowers.dev/cem/lsp"
-	"bennypowers.dev/cem/lsp/testhelpers"
 	W "bennypowers.dev/cem/internal/workspace"
 )
 
 func TestManifestFileWatchingIntegration(t *testing.T) {
 	// Create a temporary directory for test files
-	tempDir, err := os.MkdirTemp("", "lsp-file-watch-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tempDir) }()
+	tempDir := t.TempDir()
 
 	// Copy initial manifest fixture to temp directory
-	fixturePath := filepath.Join("testdata", "integration", "file-watch-integration", "initial-manifest.json")
+	fixturePath := filepath.Join("integration", "file-watch-integration", "initial-manifest.json")
 	manifestPath := filepath.Join(tempDir, "custom-elements.json")
 
-	err = testhelpers.CopyFile(platform.NewOSFileSystem(),fixturePath, manifestPath)
+	data := testutil.LoadFixtureFile(t, fixturePath)
+	err := os.WriteFile(manifestPath, data, 0644)
 	if err != nil {
 		t.Fatalf("Failed to copy initial manifest fixture: %v", err)
 	}
@@ -117,8 +114,9 @@ func TestManifestFileWatchingIntegration(t *testing.T) {
 		defer func() { _ = testRegistry.StopFileWatching() }()
 
 		// Copy updated manifest fixture to trigger file change
-		updatedFixturePath := filepath.Join("testdata", "integration", "file-watch-integration", "updated-manifest.json")
-		err = testhelpers.CopyFile(platform.NewOSFileSystem(),updatedFixturePath, manifestPath)
+		updatedFixturePath := filepath.Join("integration", "file-watch-integration", "updated-manifest.json")
+		updatedData := testutil.LoadFixtureFile(t, updatedFixturePath)
+		err = os.WriteFile(manifestPath, updatedData, 0644)
 		if err != nil {
 			t.Fatalf("Failed to copy updated manifest fixture: %v", err)
 		}
@@ -200,8 +198,9 @@ func TestManifestFileWatchingIntegration(t *testing.T) {
 
 			for i := 0; i < 3; i++ {
 				fixtureName := fixtures[i%2]
-				fixturePath := filepath.Join("testdata", "integration", "file-watch-integration", fixtureName)
-				err = testhelpers.CopyFile(platform.NewOSFileSystem(),fixturePath, manifestPath)
+				fixturePath := filepath.Join("integration", "file-watch-integration", fixtureName)
+				fixtureData := testutil.LoadFixtureFile(t, fixturePath)
+				err = os.WriteFile(manifestPath, fixtureData, 0644)
 				if err != nil {
 					t.Fatalf("Failed to copy manifest fixture %s: %v", fixtureName, err)
 				}
@@ -234,16 +233,13 @@ func TestManifestFileWatchingIntegration(t *testing.T) {
 
 func TestPackageJSONWatching(t *testing.T) {
 	// Create a temporary directory for test files
-	tempDir, err := os.MkdirTemp("", "lsp-package-watch-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tempDir) }()
+	tempDir := t.TempDir()
 
 	// Copy manifest to the referenced location
 	manifestPath := filepath.Join(tempDir, "custom-elements.json")
-	fixturePath := filepath.Join("testdata", "integration", "file-watch-integration", "initial-manifest.json")
-	err = testhelpers.CopyFile(platform.NewOSFileSystem(),fixturePath, manifestPath)
+	fixturePath := filepath.Join("integration", "file-watch-integration", "initial-manifest.json")
+	manifestData := testutil.LoadFixtureFile(t, fixturePath)
+	err := os.WriteFile(manifestPath, manifestData, 0644)
 	if err != nil {
 		t.Fatalf("Failed to copy manifest fixture: %v", err)
 	}
@@ -257,15 +253,16 @@ func TestPackageJSONWatching(t *testing.T) {
 
 	// Copy package.json fixture to the mock package
 	packagePath := filepath.Join(nodeModulesPath, "package.json")
-	packageFixturePath := filepath.Join("testdata", "integration", "file-watch-integration", "package.json")
-	err = testhelpers.CopyFile(platform.NewOSFileSystem(),packageFixturePath, packagePath)
+	packageFixturePath := filepath.Join("integration", "file-watch-integration", "package.json")
+	packageData := testutil.LoadFixtureFile(t, packageFixturePath)
+	err = os.WriteFile(packagePath, packageData, 0644)
 	if err != nil {
 		t.Fatalf("Failed to copy package.json fixture: %v", err)
 	}
 
 	// Copy the manifest to the location referenced by package.json
 	manifestInPackagePath := filepath.Join(nodeModulesPath, "custom-elements.json")
-	err = testhelpers.CopyFile(platform.NewOSFileSystem(),fixturePath, manifestInPackagePath)
+	err = os.WriteFile(manifestInPackagePath, manifestData, 0644)
 	if err != nil {
 		t.Fatalf("Failed to copy manifest to package location: %v", err)
 	}

--- a/lsp/server_integration_generate_watch_test.go
+++ b/lsp/server_integration_generate_watch_test.go
@@ -21,35 +21,28 @@ import (
 	"path/filepath"
 	"testing"
 
-	"bennypowers.dev/cem/internal/platform"
+	"bennypowers.dev/cem/internal/platform/testutil"
 	"bennypowers.dev/cem/lsp"
-	"bennypowers.dev/cem/lsp/testhelpers"
 	W "bennypowers.dev/cem/internal/workspace"
 )
 
 func TestGenerateWatcherIntegration(t *testing.T) {
 	// Create a temporary directory for test files
-	tempDir, err := os.MkdirTemp("", "lsp-generate-watch-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tempDir) }()
+	tempDir := t.TempDir()
 
-	// Copy fixture files to create a realistic project structure
-	fixtureDir := filepath.Join("testdata", "integration", "generate-watch-test")
+	// Load fixture files and write to temp dir for a realistic project structure
+	fixtureDir := filepath.Join("integration", "generate-watch-test")
 
-	sourceFixture := filepath.Join(fixtureDir, "test-element.ts")
-	sourceFile := filepath.Join(tempDir, "test-element.ts")
-	err = testhelpers.CopyFile(platform.NewOSFileSystem(),sourceFixture, sourceFile)
+	sourceBytes := testutil.LoadFixtureFile(t, filepath.Join(fixtureDir, "test-element.ts"))
+	err := os.WriteFile(filepath.Join(tempDir, "test-element.ts"), sourceBytes, 0644)
 	if err != nil {
-		t.Fatalf("Failed to copy source fixture: %v", err)
+		t.Fatalf("Failed to write source fixture: %v", err)
 	}
 
-	packageFixture := filepath.Join(fixtureDir, "package.json")
-	packageJSON := filepath.Join(tempDir, "package.json")
-	err = testhelpers.CopyFile(platform.NewOSFileSystem(),packageFixture, packageJSON)
+	packageBytes := testutil.LoadFixtureFile(t, filepath.Join(fixtureDir, "package.json"))
+	err = os.WriteFile(filepath.Join(tempDir, "package.json"), packageBytes, 0644)
 	if err != nil {
-		t.Fatalf("Failed to copy package.json fixture: %v", err)
+		t.Fatalf("Failed to write package.json fixture: %v", err)
 	}
 
 	t.Run("generate watcher starts for local project", func(t *testing.T) {

--- a/lsp/testhelpers/cursor.go
+++ b/lsp/testhelpers/cursor.go
@@ -19,6 +19,7 @@ package testhelpers
 import (
 	"strings"
 
+	"bennypowers.dev/cem/internal/textutil"
 	protocol "github.com/bennypowers/glsp/protocol_3_17"
 	ts "github.com/tree-sitter/go-tree-sitter"
 	tsCss "github.com/tree-sitter/tree-sitter-css/bindings/go"
@@ -64,16 +65,18 @@ func treeSitterCursorParser(content string, lang *ts.Language) (string, *protoco
 	}
 
 	caretRow := node.StartPosition().Row
-	caretCol := node.StartPosition().Column + uint(caretInNode)
 	if caretRow == 0 {
 		return content, nil
 	}
 
-	// Strip the entire line containing the comment
+	// Find the start of the line containing the comment for UTF-16 conversion
 	lineStart := int(node.StartByte())
 	for lineStart > 0 && content[lineStart-1] != '\n' {
 		lineStart--
 	}
+	caretByteCol := int(node.StartByte()) - lineStart + caretInNode
+	caretChar := textutil.ByteOffsetToUTF16(content[lineStart:], uint(caretByteCol))
+
 	lineEnd := int(node.EndByte())
 	if lineEnd < len(content) && content[lineEnd] == '\n' {
 		lineEnd++
@@ -82,7 +85,7 @@ func treeSitterCursorParser(content string, lang *ts.Language) (string, *protoco
 
 	return cleaned, &protocol.Position{
 		Line:      uint32(caretRow - 1),
-		Character: uint32(caretCol),
+		Character: caretChar,
 	}
 }
 

--- a/lsp/testhelpers/cursor.go
+++ b/lsp/testhelpers/cursor.go
@@ -102,12 +102,15 @@ func findCursorInTemplateStrings(root *ts.Node, content string) (string, *protoc
 					htmlOffset += len(raw)
 					continue
 				}
-				// Strip the entire line containing the comment
+				// Strip the entire line containing the comment (LF and CRLF)
 				lineStart := fragStart + htmlOffset
 				for lineStart > 0 && content[lineStart-1] != '\n' {
 					lineStart--
 				}
 				lineEnd := fragStart + htmlOffset + len(raw)
+				if lineEnd < len(content) && content[lineEnd] == '\r' {
+					lineEnd++
+				}
 				if lineEnd < len(content) && content[lineEnd] == '\n' {
 					lineEnd++
 				}
@@ -163,6 +166,9 @@ func treeSitterCursorParser(content string, tree *ts.Tree) (string, *protocol.Po
 	caretChar := textutil.ByteOffsetToUTF16(content[lineStart:], uint(caretByteCol))
 
 	lineEnd := int(node.EndByte())
+	if lineEnd < len(content) && content[lineEnd] == '\r' {
+		lineEnd++
+	}
 	if lineEnd < len(content) && content[lineEnd] == '\n' {
 		lineEnd++
 	}

--- a/lsp/testhelpers/cursor.go
+++ b/lsp/testhelpers/cursor.go
@@ -24,35 +24,121 @@ import (
 	ts "github.com/tree-sitter/go-tree-sitter"
 	tsCss "github.com/tree-sitter/tree-sitter-css/bindings/go"
 	tsTypescript "github.com/tree-sitter/tree-sitter-typescript/bindings/go"
+	"golang.org/x/net/html"
 )
 
-// TSCursorParser extracts cursor position from /* ^cursor */ comments in TypeScript.
-// Compatible with testutil.CursorParser.
+// TSCursorParser extracts cursor position from <!-- ^cursor --> comments
+// inside tagged template literals in TypeScript, or /* ^cursor */ comments
+// in regular TS code. Compatible with testutil.CursorParser.
 func TSCursorParser(content string) (string, *protocol.Position) {
 	lang := ts.NewLanguage(tsTypescript.LanguageTypescript())
-	return treeSitterCursorParser(content, lang)
-}
-
-// CSSCursorParser extracts cursor position from /* ^cursor */ comments in CSS.
-// Compatible with testutil.CursorParser.
-func CSSCursorParser(content string) (string, *protocol.Position) {
-	lang := ts.NewLanguage(tsCss.Language())
-	return treeSitterCursorParser(content, lang)
-}
-
-func treeSitterCursorParser(content string, lang *ts.Language) (string, *protocol.Position) {
 	parser := ts.NewParser()
 	defer parser.Close()
 	if err := parser.SetLanguage(lang); err != nil {
 		return content, nil
 	}
-
 	tree := parser.Parse([]byte(content), nil)
 	if tree == nil {
 		return content, nil
 	}
 	defer tree.Close()
 
+	// Try HTML comments inside template string fragments first
+	cleaned, cursor := findCursorInTemplateStrings(tree.RootNode(), content)
+	if cursor != nil {
+		return cleaned, cursor
+	}
+	// Fall back to /* ^cursor */ comments in regular TS code
+	return treeSitterCursorParser(content, tree)
+}
+
+// CSSCursorParser extracts cursor position from /* ^cursor */ comments in CSS.
+// Compatible with testutil.CursorParser.
+func CSSCursorParser(content string) (string, *protocol.Position) {
+	lang := ts.NewLanguage(tsCss.Language())
+	parser := ts.NewParser()
+	defer parser.Close()
+	if err := parser.SetLanguage(lang); err != nil {
+		return content, nil
+	}
+	tree := parser.Parse([]byte(content), nil)
+	if tree == nil {
+		return content, nil
+	}
+	defer tree.Close()
+	return treeSitterCursorParser(content, tree)
+}
+
+// findCursorInTemplateStrings searches template_string nodes for HTML
+// <!-- ^cursor --> comments. Uses the Go HTML tokenizer on each
+// string_fragment's content to find comment nodes.
+func findCursorInTemplateStrings(root *ts.Node, content string) (string, *protocol.Position) {
+	var fragments []*ts.Node
+	collectStringFragments(root, &fragments)
+
+	for _, frag := range fragments {
+		fragStart := int(frag.StartByte())
+		fragEnd := int(frag.EndByte())
+		fragContent := content[fragStart:fragEnd]
+
+		tokenizer := html.NewTokenizer(strings.NewReader(fragContent))
+		htmlOffset := 0
+		for {
+			tt := tokenizer.Next()
+			if tt == html.ErrorToken {
+				break
+			}
+			raw := string(tokenizer.Raw())
+			if tt == html.CommentToken && strings.Contains(raw, "^cursor") {
+				caretInRaw := strings.Index(raw, "^")
+				if caretInRaw < 0 {
+					htmlOffset += len(raw)
+					continue
+				}
+				// Map back to original source position
+				globalOffset := fragStart + htmlOffset + caretInRaw
+				caretLine, caretChar := byteOffsetToPosition(content, globalOffset)
+				if caretLine == 0 {
+					htmlOffset += len(raw)
+					continue
+				}
+				// Strip the entire line containing the comment
+				lineStart := fragStart + htmlOffset
+				for lineStart > 0 && content[lineStart-1] != '\n' {
+					lineStart--
+				}
+				lineEnd := fragStart + htmlOffset + len(raw)
+				if lineEnd < len(content) && content[lineEnd] == '\n' {
+					lineEnd++
+				}
+				cleaned := content[:lineStart] + content[lineEnd:]
+				return cleaned, &protocol.Position{
+					Line:      uint32(caretLine - 1),
+					Character: caretChar,
+				}
+			}
+			htmlOffset += len(raw)
+		}
+	}
+	return content, nil
+}
+
+func collectStringFragments(node *ts.Node, out *[]*ts.Node) {
+	if node.Kind() == "string_fragment" {
+		parent := node.Parent()
+		if parent != nil && parent.Kind() == "template_string" {
+			*out = append(*out, node)
+		}
+	}
+	for i := range int(node.ChildCount()) {
+		child := node.Child(uint(i))
+		if child != nil {
+			collectStringFragments(child, out)
+		}
+	}
+}
+
+func treeSitterCursorParser(content string, tree *ts.Tree) (string, *protocol.Position) {
 	node := findCursorComment(tree.RootNode(), []byte(content))
 	if node == nil {
 		return content, nil
@@ -69,7 +155,6 @@ func treeSitterCursorParser(content string, lang *ts.Language) (string, *protoco
 		return content, nil
 	}
 
-	// Find the start of the line containing the comment for UTF-16 conversion
 	lineStart := int(node.StartByte())
 	for lineStart > 0 && content[lineStart-1] != '\n' {
 		lineStart--
@@ -87,6 +172,24 @@ func treeSitterCursorParser(content string, lang *ts.Language) (string, *protoco
 		Line:      uint32(caretRow - 1),
 		Character: caretChar,
 	}
+}
+
+// byteOffsetToPosition converts a byte offset to an LSP-compatible
+// (line, character) pair where character is in UTF-16 code units.
+func byteOffsetToPosition(content string, offset int) (line int, character uint32) {
+	lineStart := 0
+	for i := range offset {
+		if i >= len(content) {
+			break
+		}
+		if content[i] == '\n' {
+			line++
+			lineStart = i + 1
+		}
+	}
+	byteCol := uint(offset - lineStart)
+	character = textutil.ByteOffsetToUTF16(content[lineStart:], byteCol)
+	return line, character
 }
 
 func findCursorComment(node *ts.Node, source []byte) *ts.Node {

--- a/lsp/testhelpers/cursor.go
+++ b/lsp/testhelpers/cursor.go
@@ -1,0 +1,106 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package testhelpers
+
+import (
+	"strings"
+
+	protocol "github.com/bennypowers/glsp/protocol_3_17"
+	ts "github.com/tree-sitter/go-tree-sitter"
+	tsCss "github.com/tree-sitter/tree-sitter-css/bindings/go"
+	tsTypescript "github.com/tree-sitter/tree-sitter-typescript/bindings/go"
+)
+
+// TSCursorParser extracts cursor position from /* ^cursor */ comments in TypeScript.
+// Compatible with testutil.CursorParser.
+func TSCursorParser(content string) (string, *protocol.Position) {
+	lang := ts.NewLanguage(tsTypescript.LanguageTypescript())
+	return treeSitterCursorParser(content, lang)
+}
+
+// CSSCursorParser extracts cursor position from /* ^cursor */ comments in CSS.
+// Compatible with testutil.CursorParser.
+func CSSCursorParser(content string) (string, *protocol.Position) {
+	lang := ts.NewLanguage(tsCss.Language())
+	return treeSitterCursorParser(content, lang)
+}
+
+func treeSitterCursorParser(content string, lang *ts.Language) (string, *protocol.Position) {
+	parser := ts.NewParser()
+	defer parser.Close()
+	if err := parser.SetLanguage(lang); err != nil {
+		return content, nil
+	}
+
+	tree := parser.Parse([]byte(content), nil)
+	if tree == nil {
+		return content, nil
+	}
+	defer tree.Close()
+
+	node := findCursorComment(tree.RootNode(), []byte(content))
+	if node == nil {
+		return content, nil
+	}
+
+	nodeText := content[node.StartByte():node.EndByte()]
+	caretInNode := strings.Index(nodeText, "^")
+	if caretInNode < 0 {
+		return content, nil
+	}
+
+	caretRow := node.StartPosition().Row
+	caretCol := node.StartPosition().Column + uint(caretInNode)
+	if caretRow == 0 {
+		return content, nil
+	}
+
+	// Strip the entire line containing the comment
+	lineStart := int(node.StartByte())
+	for lineStart > 0 && content[lineStart-1] != '\n' {
+		lineStart--
+	}
+	lineEnd := int(node.EndByte())
+	if lineEnd < len(content) && content[lineEnd] == '\n' {
+		lineEnd++
+	}
+	cleaned := content[:lineStart] + content[lineEnd:]
+
+	return cleaned, &protocol.Position{
+		Line:      uint32(caretRow - 1),
+		Character: uint32(caretCol),
+	}
+}
+
+func findCursorComment(node *ts.Node, source []byte) *ts.Node {
+	if node.Kind() == "comment" {
+		text := string(source[node.StartByte():node.EndByte()])
+		if strings.Contains(text, "^cursor") {
+			return node
+		}
+	}
+	for i := range int(node.ChildCount()) {
+		child := node.Child(uint(i))
+		if child == nil {
+			continue
+		}
+		if found := findCursorComment(child, source); found != nil {
+			return found
+		}
+	}
+	return nil
+}

--- a/lsp/testhelpers/cursor_test.go
+++ b/lsp/testhelpers/cursor_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package testhelpers
+
+import (
+	"testing"
+)
+
+func TestTSCursorParser(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		wantLine uint32
+		wantChar uint32
+		wantNil  bool
+	}{
+		{
+			name: "caret under property binding",
+			content: "const tpl = html`<test-element .prop>`;\n" +
+				"/*                              ^cursor */\n",
+			wantLine: 0,
+			wantChar: 32,
+		},
+		{
+			name:    "caret under import",
+			content: "import { html } from 'lit';\n/*        ^cursor */\nconst x = 1;\n",
+			wantLine: 0,
+			wantChar: 10,
+		},
+		{
+			name:    "no marker",
+			content: "const x = 1;\n",
+			wantNil: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleaned, cursor := TSCursorParser(tt.content)
+			if tt.wantNil {
+				if cursor != nil {
+					t.Errorf("Expected nil cursor, got %+v", cursor)
+				}
+				return
+			}
+			if cursor == nil {
+				t.Fatal("Expected cursor, got nil")
+			}
+			if cursor.Line != tt.wantLine {
+				t.Errorf("Line: want %d, got %d", tt.wantLine, cursor.Line)
+			}
+			if cursor.Character != tt.wantChar {
+				t.Errorf("Character: want %d, got %d", tt.wantChar, cursor.Character)
+			}
+			_ = cleaned
+		})
+	}
+}
+
+func TestCSSCursorParser(t *testing.T) {
+	content := `my-element::part(button) {
+/*                ^cursor */
+  color: red;
+}
+`
+	cleaned, cursor := CSSCursorParser(content)
+	if cursor == nil {
+		t.Fatal("Expected cursor, got nil")
+	}
+	if cursor.Line != 0 {
+		t.Errorf("Line: want 0, got %d", cursor.Line)
+	}
+	if cursor.Character != 18 {
+		t.Errorf("Character: want 18, got %d", cursor.Character)
+	}
+	_ = cleaned
+}

--- a/lsp/testhelpers/cursor_test.go
+++ b/lsp/testhelpers/cursor_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 )
 
+// Inline: these test the cursor parser itself, which is a pure function.
+// Fixture/golden pattern would be circular since the parser is part of the fixture loader.
 func TestTSCursorParser(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -209,6 +211,18 @@ func TestTSCursorParser(t *testing.T) {
 			wantClean: "const tpl = html`\n" +
 				"  <my-element attr=\"value\"></my-element>\n" +
 				"`;\n",
+		},
+		{
+			name: "CRLF line endings",
+			content: "const tpl = html`\r\n" +
+				"  <my-element attr=\"v\"></my-element>\r\n" +
+				"  <!-- ^cursor -->\r\n" +
+				"`;\r\n",
+			wantLine: 1,
+			wantChar: 7,
+			wantClean: "const tpl = html`\r\n" +
+				"  <my-element attr=\"v\"></my-element>\r\n" +
+				"`;\r\n",
 		},
 		{
 			name:    "no marker",

--- a/lsp/testhelpers/cursor_test.go
+++ b/lsp/testhelpers/cursor_test.go
@@ -30,7 +30,7 @@ func TestTSCursorParser(t *testing.T) {
 		wantNil   bool
 	}{
 		{
-			name: "caret under property binding",
+			name: "JS comment in regular code",
 			content: "const tpl = html`<test-element .prop>`;\n" +
 				"/*                              ^cursor */\n",
 			wantLine:  0,
@@ -38,11 +38,177 @@ func TestTSCursorParser(t *testing.T) {
 			wantClean: "const tpl = html`<test-element .prop>`;\n",
 		},
 		{
-			name:      "caret under import",
+			name:      "JS comment under import",
 			content:   "import { html } from 'lit';\n/*        ^cursor */\nconst x = 1;\n",
 			wantLine:  0,
 			wantChar:  10,
 			wantClean: "import { html } from 'lit';\nconst x = 1;\n",
+		},
+		{
+			name: "HTML comment inside template literal",
+			content: "import { html } from 'lit';\n" +
+				"\n" +
+				"export class MyComponent {\n" +
+				"  render() {\n" +
+				"    return html`\n" +
+				"      <test-component prop=\"value\"></test-component>\n" +
+				"      <!-- ^cursor -->\n" +
+				"    `;\n" +
+				"  }\n" +
+				"}\n",
+			wantLine: 5,
+			wantChar: 11,
+			wantClean: "import { html } from 'lit';\n" +
+				"\n" +
+				"export class MyComponent {\n" +
+				"  render() {\n" +
+				"    return html`\n" +
+				"      <test-component prop=\"value\"></test-component>\n" +
+				"    `;\n" +
+				"  }\n" +
+				"}\n",
+		},
+		{
+			name: "HTML comment in template with interpolation",
+			content: "const tpl = html`\n" +
+				"  <my-el .prop=${this.val}>\n" +
+				"    <span>${this.text}</span>\n" +
+				"  </my-el>\n" +
+				"  <!-- ^cursor -->\n" +
+				"`;\n",
+			wantLine: 3,
+			wantChar: 7,
+			wantClean: "const tpl = html`\n" +
+				"  <my-el .prop=${this.val}>\n" +
+				"    <span>${this.text}</span>\n" +
+				"  </my-el>\n" +
+				"`;\n",
+		},
+		{
+			name: "cursor on child element inside slot",
+			content: "const tpl = html`\n" +
+				"  <my-card>\n" +
+				"    <span slot=\"header\">Title</span>\n" +
+				"    <!-- ^cursor -->\n" +
+				"  </my-card>\n" +
+				"`;\n",
+			wantLine: 2,
+			wantChar: 9,
+			wantClean: "const tpl = html`\n" +
+				"  <my-card>\n" +
+				"    <span slot=\"header\">Title</span>\n" +
+				"  </my-card>\n" +
+				"`;\n",
+		},
+		{
+			name: "cursor on element with slot attribute",
+			content: "const tpl = html`\n" +
+				"  <my-card>\n" +
+				"    <h2 slot=\"header\">Title</h2>\n" +
+				"    <!--     ^cursor -->\n" +
+				"  </my-card>\n" +
+				"`;\n",
+			wantLine: 2,
+			wantChar: 13,
+			wantClean: "const tpl = html`\n" +
+				"  <my-card>\n" +
+				"    <h2 slot=\"header\">Title</h2>\n" +
+				"  </my-card>\n" +
+				"`;\n",
+		},
+		{
+			name: "cursor after property binding with interpolation",
+			content: "const tpl = html`\n" +
+				"  <my-el .items=${this.data}>\n" +
+				"  <!--          ^cursor -->\n" +
+				"    ${this.data.map(item => html`<li>${item}</li>`)}\n" +
+				"  </my-el>\n" +
+				"`;\n",
+			wantLine: 1,
+			wantChar: 16,
+			wantClean: "const tpl = html`\n" +
+				"  <my-el .items=${this.data}>\n" +
+				"    ${this.data.map(item => html`<li>${item}</li>`)}\n" +
+				"  </my-el>\n" +
+				"`;\n",
+		},
+		{
+			name: "cursor on event binding",
+			content: "const tpl = html`\n" +
+				"  <my-button @click=${this.onClick}>\n" +
+				"  <!--       ^cursor -->\n" +
+				"    Click me\n" +
+				"  </my-button>\n" +
+				"`;\n",
+			wantLine: 1,
+			wantChar: 13,
+			wantClean: "const tpl = html`\n" +
+				"  <my-button @click=${this.onClick}>\n" +
+				"    Click me\n" +
+				"  </my-button>\n" +
+				"`;\n",
+		},
+		{
+			name: "cursor on boolean binding",
+			content: "const tpl = html`\n" +
+				"  <my-input ?disabled=${this.isDisabled}\n" +
+				"  <!--      ^cursor -->\n" +
+				"            type=\"text\">\n" +
+				"`;\n",
+			wantLine: 1,
+			wantChar: 12,
+			wantClean: "const tpl = html`\n" +
+				"  <my-input ?disabled=${this.isDisabled}\n" +
+				"            type=\"text\">\n" +
+				"`;\n",
+		},
+		{
+			name: "cursor between two interpolations",
+			content: "const tpl = html`\n" +
+				"  <div class=${this.cls}>\n" +
+				"    <my-el .val=${this.v}></my-el>\n" +
+				"    <!--   ^cursor -->\n" +
+				"  </div>\n" +
+				"`;\n",
+			wantLine: 2,
+			wantChar: 11,
+			wantClean: "const tpl = html`\n" +
+				"  <div class=${this.cls}>\n" +
+				"    <my-el .val=${this.v}></my-el>\n" +
+				"  </div>\n" +
+				"`;\n",
+		},
+		{
+			name: "nested template literals",
+			content: "const tpl = html`\n" +
+				"  <ul>\n" +
+				"    ${items.map(i => html`\n" +
+				"      <li>${i.name}</li>\n" +
+				"      <!-- ^cursor -->\n" +
+				"    `)}\n" +
+				"  </ul>\n" +
+				"`;\n",
+			wantLine: 3,
+			wantChar: 11,
+			wantClean: "const tpl = html`\n" +
+				"  <ul>\n" +
+				"    ${items.map(i => html`\n" +
+				"      <li>${i.name}</li>\n" +
+				"    `)}\n" +
+				"  </ul>\n" +
+				"`;\n",
+		},
+		{
+			name: "template with no interpolations",
+			content: "const tpl = html`\n" +
+				"  <my-element attr=\"value\"></my-element>\n" +
+				"  <!--        ^cursor -->\n" +
+				"`;\n",
+			wantLine: 1,
+			wantChar: 14,
+			wantClean: "const tpl = html`\n" +
+				"  <my-element attr=\"value\"></my-element>\n" +
+				"`;\n",
 		},
 		{
 			name:    "no marker",
@@ -70,6 +236,50 @@ func TestTSCursorParser(t *testing.T) {
 			}
 			if cleaned != tt.wantClean {
 				t.Errorf("Cleaned content mismatch.\nWant:\n%q\nGot:\n%q", tt.wantClean, cleaned)
+			}
+		})
+	}
+}
+
+func TestTSCursorParser_NonASCII(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		wantLine uint32
+		wantChar uint32
+	}{
+		{
+			name: "emoji in attribute value",
+			content: "const tpl = html`\n" +
+				"  <my-el label=\"\U0001F600 hello\"></my-el>\n" +
+				"  <!--                   ^cursor -->\n" +
+				"`;\n",
+			wantLine: 1,
+			wantChar: 25,
+		},
+		{
+			name: "emoji in tag name cursor after emoji",
+			// x-\U0001F600el is a legal custom element name (emoji not first char)
+			// cursor points at the attribute after the emoji tag
+			content: "const tpl = html`\n" +
+				"  <x-\U0001F600el attr=\"v\"></x-\U0001F600el>\n" +
+				"  <!--       ^cursor -->\n" +
+				"`;\n",
+			wantLine: 1,
+			wantChar: 13,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, cursor := TSCursorParser(tt.content)
+			if cursor == nil {
+				t.Fatal("Expected cursor, got nil")
+			}
+			if cursor.Line != tt.wantLine {
+				t.Errorf("Line: want %d, got %d", tt.wantLine, cursor.Line)
+			}
+			if cursor.Character != tt.wantChar {
+				t.Errorf("Character: want %d, got %d", tt.wantChar, cursor.Character)
 			}
 		})
 	}

--- a/lsp/testhelpers/cursor_test.go
+++ b/lsp/testhelpers/cursor_test.go
@@ -22,24 +22,27 @@ import (
 
 func TestTSCursorParser(t *testing.T) {
 	tests := []struct {
-		name     string
-		content  string
-		wantLine uint32
-		wantChar uint32
-		wantNil  bool
+		name      string
+		content   string
+		wantLine  uint32
+		wantChar  uint32
+		wantClean string
+		wantNil   bool
 	}{
 		{
 			name: "caret under property binding",
 			content: "const tpl = html`<test-element .prop>`;\n" +
 				"/*                              ^cursor */\n",
-			wantLine: 0,
-			wantChar: 32,
+			wantLine:  0,
+			wantChar:  32,
+			wantClean: "const tpl = html`<test-element .prop>`;\n",
 		},
 		{
-			name:    "caret under import",
-			content: "import { html } from 'lit';\n/*        ^cursor */\nconst x = 1;\n",
-			wantLine: 0,
-			wantChar: 10,
+			name:      "caret under import",
+			content:   "import { html } from 'lit';\n/*        ^cursor */\nconst x = 1;\n",
+			wantLine:  0,
+			wantChar:  10,
+			wantClean: "import { html } from 'lit';\nconst x = 1;\n",
 		},
 		{
 			name:    "no marker",
@@ -65,7 +68,9 @@ func TestTSCursorParser(t *testing.T) {
 			if cursor.Character != tt.wantChar {
 				t.Errorf("Character: want %d, got %d", tt.wantChar, cursor.Character)
 			}
-			_ = cleaned
+			if cleaned != tt.wantClean {
+				t.Errorf("Cleaned content mismatch.\nWant:\n%q\nGot:\n%q", tt.wantClean, cleaned)
+			}
 		})
 	}
 }
@@ -86,5 +91,8 @@ func TestCSSCursorParser(t *testing.T) {
 	if cursor.Character != 18 {
 		t.Errorf("Character: want 18, got %d", cursor.Character)
 	}
-	_ = cleaned
+	wantClean := "my-element::part(button) {\n  color: red;\n}\n"
+	if cleaned != wantClean {
+		t.Errorf("Cleaned content mismatch.\nWant:\n%q\nGot:\n%q", wantClean, cleaned)
+	}
 }

--- a/mcp/context_race_test.go
+++ b/mcp/context_race_test.go
@@ -32,7 +32,7 @@ func TestMCPContext_ConcurrentCacheAccess(t *testing.T) {
 		t.Fatalf("Failed to initialize workspace: %v", err)
 	}
 
-	ctx, err := NewMCPContext(workspace, nil)
+	ctx, err := NewMCPContext(workspace, workspace.FileSystem())
 	if err != nil {
 		t.Fatalf("Failed to create MCP context: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestMCPContext_ConcurrentLoadManifestsAndCacheAccess(t *testing.T) {
 		t.Fatalf("Failed to initialize workspace: %v", err)
 	}
 
-	ctx, err := NewMCPContext(workspace, nil)
+	ctx, err := NewMCPContext(workspace, workspace.FileSystem())
 	if err != nil {
 		t.Fatalf("Failed to create MCP context: %v", err)
 	}
@@ -167,7 +167,7 @@ func TestMCPContext_SnapshotConsistency(t *testing.T) {
 		t.Fatalf("Failed to initialize workspace: %v", err)
 	}
 
-	ctx, err := NewMCPContext(workspace, nil)
+	ctx, err := NewMCPContext(workspace, workspace.FileSystem())
 	if err != nil {
 		t.Fatalf("Failed to create MCP context: %v", err)
 	}
@@ -215,7 +215,7 @@ func TestMCPContext_CacheInvalidationRace(t *testing.T) {
 		t.Fatalf("Failed to initialize workspace: %v", err)
 	}
 
-	ctx, err := NewMCPContext(workspace, nil)
+	ctx, err := NewMCPContext(workspace, workspace.FileSystem())
 	if err != nil {
 		t.Fatalf("Failed to create MCP context: %v", err)
 	}

--- a/mcp/context_test.go
+++ b/mcp/context_test.go
@@ -31,7 +31,7 @@ import (
 func TestMCPContext_NewRegistry(t *testing.T) {
 	workspace := testworkspace.NewMapWorkspaceContext(t, "./testdata/fixtures/multiple-elements-integration")
 
-	registry, err := mcp.NewMCPContext(workspace, nil)
+	registry, err := mcp.NewMCPContext(workspace, workspace.FileSystem())
 	require.NoError(t, err, "Failed to create registry")
 	assert.NotNil(t, registry, "Registry should not be nil")
 }
@@ -41,7 +41,7 @@ func TestMCPContext_LoadManifests(t *testing.T) {
 	err := workspace.Init()
 	require.NoError(t, err)
 
-	registry, err := mcp.NewMCPContext(workspace, nil)
+	registry, err := mcp.NewMCPContext(workspace, workspace.FileSystem())
 	require.NoError(t, err, "Failed to create registry")
 
 	err = registry.LoadManifests()
@@ -53,7 +53,7 @@ func TestMCPContext_GetElementInfo(t *testing.T) {
 	err := workspace.Init()
 	require.NoError(t, err)
 
-	registry, err := mcp.NewMCPContext(workspace, nil)
+	registry, err := mcp.NewMCPContext(workspace, workspace.FileSystem())
 	require.NoError(t, err, "Failed to create registry")
 
 	err = registry.LoadManifests()
@@ -212,7 +212,7 @@ func TestMCPContext_GetAllElements(t *testing.T) {
 	err := workspace.Init()
 	require.NoError(t, err)
 
-	registry, err := mcp.NewMCPContext(workspace, nil)
+	registry, err := mcp.NewMCPContext(workspace, workspace.FileSystem())
 	require.NoError(t, err, "Failed to create registry")
 
 	err = registry.LoadManifests()
@@ -239,7 +239,7 @@ func TestMCPContext_GetManifestSchema(t *testing.T) {
 	err := workspace.Init()
 	require.NoError(t, err)
 
-	registry, err := mcp.NewMCPContext(workspace, nil)
+	registry, err := mcp.NewMCPContext(workspace, workspace.FileSystem())
 	require.NoError(t, err, "Failed to create registry")
 
 	schema, err := registry.GetManifestSchema()
@@ -299,7 +299,7 @@ func TestMCPContext_AttributeConversion(t *testing.T) {
 	err := workspace.Init()
 	require.NoError(t, err)
 
-	registry, err := mcp.NewMCPContext(workspace, nil)
+	registry, err := mcp.NewMCPContext(workspace, workspace.FileSystem())
 	require.NoError(t, err)
 
 	err = registry.LoadManifests()
@@ -388,7 +388,7 @@ func TestMCPContext_SlotConversion(t *testing.T) {
 	err := workspace.Init()
 	require.NoError(t, err)
 
-	registry, err := mcp.NewMCPContext(workspace, nil)
+	registry, err := mcp.NewMCPContext(workspace, workspace.FileSystem())
 	require.NoError(t, err)
 
 	err = registry.LoadManifests()
@@ -457,7 +457,7 @@ func TestMCPContext_CssPropertyConversion(t *testing.T) {
 	err := workspace.Init()
 	require.NoError(t, err)
 
-	registry, err := mcp.NewMCPContext(workspace, nil)
+	registry, err := mcp.NewMCPContext(workspace, workspace.FileSystem())
 	require.NoError(t, err)
 
 	err = registry.LoadManifests()
@@ -527,7 +527,7 @@ func TestMCPContext_CssPartConversion(t *testing.T) {
 	err := workspace.Init()
 	require.NoError(t, err)
 
-	registry, err := mcp.NewMCPContext(workspace, nil)
+	registry, err := mcp.NewMCPContext(workspace, workspace.FileSystem())
 	require.NoError(t, err)
 
 	err = registry.LoadManifests()

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -74,7 +74,7 @@ func TestDynamicSchemaVersionDetection(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create registry and load manifests
-	registry, err := NewMCPContext(workspace, nil)
+	registry, err := NewMCPContext(workspace, workspace.FileSystem())
 	require.NoError(t, err)
 
 	err = registry.LoadManifests()

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -27,19 +27,12 @@ import (
 	"github.com/adrg/xdg"
 )
 
-// loadValidateFixtureMapFS loads a fixture manifest into a MapFileSystem at a virtual path
+// loadValidateFixtureMapFS loads a fixture manifest into a MapFileSystem
 // and returns the MapFileSystem and virtual path.
 func loadValidateFixtureMapFS(t *testing.T, fixture string) (*platform.MapFileSystem, string) {
 	t.Helper()
-	fixturePath := filepath.Join("..", "cmd", "testdata", "fixtures", fixture, "custom-elements.json")
-	data, err := os.ReadFile(fixturePath)
-	if err != nil {
-		t.Fatalf("Failed to read fixture %s: %v", fixturePath, err)
-	}
-	mfs := platform.NewMapFileSystem(nil)
-	virtualPath := filepath.Join(fixture, "custom-elements.json")
-	mfs.AddFile(virtualPath, string(data), 0644)
-	return mfs, virtualPath
+	mfs := testutil.LoadTestdataFS(t, filepath.Join("..", "cmd", "testdata", "fixtures", fixture), "/")
+	return mfs, "custom-elements.json"
 }
 
 func TestValidateGolden(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #399. Improves test isolation and MapFS coverage across the codebase.

- Add `Cursor *protocol.Position` to `LSPFixture`, extracted from `<!-- ^cursor -->` markers (HTML, via `golang.org/x/net/html` tokenizer) or `/* ^cursor */` comments (TS/CSS, via tree-sitter in `lsp/testhelpers`), with YAML frontmatter fallback. Character positions use UTF-16 code units per LSP spec.
- Migrate hover and references tests from Go `cursorPositions` maps to in-fixture markers
- Replace direct `os.ReadFile`/`os.WriteFile` calls with `testutil.LoadTestdataFS` and `testutil.LoadFixtureFile` in validate, demodiscovery, file watch, generate watch, and completion test helpers
- Add `NewMapWorkspaceContextFromFS` for building workspace contexts from pre-populated MapFS instances
- Add error-injecting `FileSystem` wrapper for the `TestGenerateWithFileReadError` MapFS variant (previously skipped)
- Pass `workspace.FileSystem()` instead of `nil` to `NewMCPContext` in all MCP tests
- Replace blanket `_test.go` forbidigo exclusion with per-file rules so new test files get lint violations when using `os.*` directly

## Test plan

- [x] `make lint` -- 0 issues
- [x] `make test-unit` -- 4597 tests pass, 2 skipped (pre-existing filewatcher skips)
- [x] Previously-skipped `TestGenerateWithFileReadError/mapfs` now passes
- [x] All hover and references fixture tests pass with cursor markers
- [x] Cursor extraction tests cover HTML tokenizer, tree-sitter (TS/CSS), YAML frontmatter, edge cases

@coderabbitai ignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved editor test fixtures to support explicit cursor markers in HTML, TypeScript, and CSS for more accurate hover and references checks.
  * Added support for loading test workspaces/fixtures directly from in-memory filesystems.

* **Bug Fixes**
  * Improved test reliability by simulating file read-permission failures and reducing reliance on disk staging.
  * Updated hover/references tests to derive cursor positions from each fixture.

* **Tests**
  * Added unit test coverage for cursor marker extraction and cursor parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->