### PR TITLE
docs: update documentation for changes since v0.10.6

### DIFF
--- a/docs/content/docs/installation/mcp.md
+++ b/docs/content/docs/installation/mcp.md
@@ -144,13 +144,13 @@ The inspector provides a web UI for:
 Enable detailed logging to troubleshoot issues:
 
 ```bash
-cem mcp --verbose
+cem mcp -vv
 ```
 
 Or with the inspector:
 
 ```bash
-mcp-inspector cem mcp --verbose
+mcp-inspector cem mcp -vv
 ```
 
 ### Debug Specific Projects

--- a/docs/content/docs/reference/commands/_index.md
+++ b/docs/content/docs/reference/commands/_index.md
@@ -33,5 +33,9 @@ The `cem` command-line tool has several commands to help you generate and query 
   {{< card title="Health" href="health" icon="/images/sections/health.svg" >}}
   Score documentation quality in your custom elements manifest and get actionable recommendations for improvement.
   {{< /card >}}
+
+  {{< card title="Config" href="config" icon="/images/sections/configuration.svg" >}}
+  Create, inspect, and validate CEM configuration files, and generate MCP snippets for AI tools.
+  {{< /card >}}
 {{< /card-grid >}}
 

--- a/docs/content/docs/reference/commands/config.md
+++ b/docs/content/docs/reference/commands/config.md
@@ -1,0 +1,86 @@
+---
+title: Config
+description: Inspect and manage CEM configuration
+weight: 80
+---
+
+{{< tip >}}
+**TL;DR**: Use `cem config init` to set up a new project, `cem config show` to see your resolved config, `cem config validate` to check for problems, and `cem config mcp` to generate MCP snippets for your AI tools.
+{{< /tip >}}
+
+The `cem config` command group helps you create, inspect, and validate CEM configuration files.
+
+## Subcommands
+
+### `cem config init`
+
+Interactive wizard that detects your project's settings and generates a `.config/cem.yaml` file.
+
+```bash
+cem config init
+```
+
+The wizard inspects your project for TypeScript source files, existing manifests, demo HTML files, `tsconfig.json` settings, and git remote URLs, then pre-fills sensible defaults. You can review and adjust each setting before the config file is written.
+
+| Flag | Description |
+| ---- | ----------- |
+| `--format` | Output format: `yaml` (default), `json`, or `jsonc` |
+| `-y`, `--yes` | Accept detected defaults without prompting |
+
+### `cem config show`
+
+Print the fully resolved configuration, including workspace inheritance.
+
+```bash
+cem config show
+cem config show --format json
+```
+
+This shows the merged result after config file loading and workspace cascade, so you can verify exactly what `cem` will use.
+
+| Flag | Description |
+| ---- | ----------- |
+| `--format` | Output format: `yaml` (default) or `json` |
+
+### `cem config validate`
+
+Check the config file for invalid values, unreachable glob patterns, and missing files.
+
+```bash
+cem config validate
+```
+
+Runs both schema validation (correct field names and types) and semantic checks (do your glob patterns match any files? does your output directory exist? are URL rewrites valid?). Reports errors with file, line, and column positions.
+
+| Flag | Description |
+| ---- | ----------- |
+| `--format` | Output format: `text` (default) or `json` |
+
+### `cem config mcp`
+
+Generate MCP configuration snippets for AI tools.
+
+```bash
+cem config mcp
+```
+
+In interactive mode (TTY), presents a menu to select your tools and configure options. In non-interactive mode, use `--tool` to specify tools directly:
+
+```bash
+cem config mcp --tool "Claude Code" --tool "Cursor"
+```
+
+Supported tools: Claude Code, Claude Desktop, Cursor, VS Code (Copilot), Zed, and Other.
+
+| Flag | Description |
+| ---- | ----------- |
+| `--tool` | AI tool(s) to configure (repeatable) |
+| `-a`, `--additional-packages` | Additional packages to include in MCP args (npm:, jsr:, or URL specifiers) |
+
+### `cem config path`
+
+Print the resolved config file path. Useful for scripting:
+
+```bash
+$EDITOR $(cem config path)
+```

--- a/docs/content/docs/reference/commands/search.md
+++ b/docs/content/docs/reference/commands/search.md
@@ -151,7 +151,7 @@ The search command also supports all global `cem` options:
 
 - `-p, --package string` - Package specifier or path
 - `--config string` - Config file path
-- `-v, --verbose` - Verbose output
+- `-v, --verbose` - Increase verbosity (`-v` info, `-vv` debug, `-vvv` trace)
 
 ## Workspace Mode
 

--- a/docs/content/docs/reference/commands/serve.md
+++ b/docs/content/docs/reference/commands/serve.md
@@ -39,8 +39,8 @@ cem serve [flags]
 | `--config` | Path to config file (auto-discovers `.config/cem.yaml`, `.cem.yaml`, etc.) |
 | `--package`, `-p` | Deno-style package specifier (e.g., `npm:@scope/package`) or path to package directory |
 | `--source-control-root-url` | Canonical public source control URL for primary branch (e.g., `https://github.com/user/repo/tree/main/`) |
-| `--quiet`, `-q` | Quiet output (only warnings and errors) |
-| `--verbose`, `-v` | Verbose logging output |
+| `--quiet`, `-q` | Quiet output (warnings and errors only) |
+| `--verbose`, `-v` | Increase verbosity (`-v` info, `-vv` debug, `-vvv` trace) |
 
 ## Examples
 

--- a/docs/content/docs/reference/commands/validate.md
+++ b/docs/content/docs/reference/commands/validate.md
@@ -17,7 +17,7 @@ By default, `cem validate` will look for a `custom-elements.json` file in the cu
 
 ## Options
 
-- `--verbose`, `-v`: Show detailed information including schema version
+- `--verbose`, `-v`: Increase verbosity (`-v` info, `-vv` debug, `-vvv` trace)
 - `--disable`: Disable specific warning rules or categories (can be used multiple times)
 - `--format`: Output format, either `text` (default) or `json`
 
@@ -130,6 +130,9 @@ that has a `customElements` field. Results are reported per-package.
 cem validate           # validate all packages
 cem validate -p pkg/a  # validate one package
 ```
+
+With `--format json`, workspace mode emits a single JSON document containing
+results for all packages, rather than separate JSON objects per package.
 
 ### Available Warning Categories
 

--- a/docs/content/docs/reference/configuration.md
+++ b/docs/content/docs/reference/configuration.md
@@ -508,10 +508,10 @@ serve:
 
 ### Debugging URL Rewrites
 
-Use verbose logging to see path resolution in action:
+Use debug logging to see path resolution in action:
 
 ```sh
-cem serve --verbose
+cem serve -vv
 ```
 
 Look for log messages like:
@@ -682,8 +682,9 @@ These flags can be used with any `cem` command.
 | --------------- | --------------------------------------------------------------------- |
 | `--config`      | Path to a custom config file.                                         |
 | `--package`     | Package specifier: `npm:@scope/package`, URL (`https://cdn.example.com/pkg/`), or local path. |
-| `--verbose`, -v | Enable verbose logging output.                                        |
-| `--help`, -h    | Show help for a command.                                              |
+| `--verbose`, `-v` | Increase verbosity (`-v` info, `-vv` debug, `-vvv` trace).          |
+| `--quiet`, `-q`   | Quiet output (warnings and errors only).                             |
+| `--help`, `-h`    | Show help for a command.                                             |
 
 ### Package Specifier Examples
 

--- a/docs/content/docs/reference/mcp/_index.md
+++ b/docs/content/docs/reference/mcp/_index.md
@@ -21,6 +21,9 @@ Model Context Protocol server for custom elements. See [MCP Integration](/docs/i
 | `cem://element/{tagName}/css/states`            | CSS custom states documentation                                                                  |
 | `cem://guidelines`                              | Design system guidelines and best practices                                                            |
 | `cem://accessibility`                           | Accessibility patterns and validation rules                                                         |
+| `cem://config`                                  | Current resolved configuration (merged from file + workspace cascade)                               |
+| `cem://config/schema`                           | Overview of all config schema sections with links to per-section detail                             |
+| `cem://config/schema/{section}`                 | JSON schema for a specific config section (generate, serve, health, mcp, export, warnings)          |
 
 ## MCP Tools
 
@@ -49,6 +52,20 @@ Validates custom element usage based on manifest guidelines.
 - Attribute conflicts (e.g., `loading="eager"` + `lazy="true"`)
 - Content/attribute redundancy
 - Manifest compliance
+
+### `generate_config`
+
+Generate or update CEM configuration for a project. Returns the current config, config file path, full JSON schema, and guidance for each config section. Use with an optional `focus` parameter to narrow to a specific section.
+
+| Parameter | Type   | Required | Description                                                                                              |
+| --------- | ------ | -------- | -------------------------------------------------------------------------------------------------------- |
+| `focus`   | string |          | Config section to focus on: `generate`, `serve`, `health`, `mcp`, `export`, or `warnings`. Omit for all sections. |
+
+### `validate_config`
+
+Validate the current CEM configuration file. Runs schema validation and semantic checks (glob reachability, output path existence, URL rewrite validation). Returns structured JSON with errors and warnings, each with field path and source position.
+
+No parameters required.
 
 ## Configuration
 
@@ -79,7 +96,8 @@ cem mcp [flags]
 - `--package <path>` - Specify project directory or package specifier (npm:, jsr:, or URL)
 - `--additional-packages <specs>` - Load additional packages alongside local project (repeatable)
 - `--max-description-length <num>` - Override 2000 character description limit
-- `--verbose` - Enable detailed logging
+- `--verbose`, `-v` - Increase verbosity (`-v` info, `-vv` debug, `-vvv` trace)
+- `--quiet`, `-q` - Quiet output (warnings and errors only)
 
 ### Loading Additional Packages
 

--- a/docs/content/docs/usage/buildless-development.md
+++ b/docs/content/docs/usage/buildless-development.md
@@ -184,7 +184,11 @@ serve:
 ```
 
 {{<tip "warning">}}
-Without glob patterns, plain CSS imports won't transform—only imports with `with { type: 'css' }` work. This prevents `<link rel="stylesheet">` tags from breaking unexpectedly.
+Without glob patterns, plain CSS imports won't transform -- only imports with `with { type: 'css' }` work. This prevents `<link rel="stylesheet">` tags from breaking unexpectedly.
+{{</tip>}}
+
+{{<tip>}}
+The dev server warns when it detects a CSS import without `with { type: 'css' }` that is not covered by your glob patterns. If you see this warning, either add the import attribute or configure `serve.transforms.css.include` to cover the file.
 {{</tip>}}
 
 ## Debugging

--- a/docs/content/docs/usage/import-maps.md
+++ b/docs/content/docs/usage/import-maps.md
@@ -103,10 +103,10 @@ Look in the HTML source of any demo page:
 
 ### Check server logs
 
-With `--verbose` flag, see import map generation:
+With verbose flags, see import map generation:
 
 ```sh
-cem serve --verbose
+cem serve -vv
 ```
 
 Look for log entries like:

--- a/docs/content/docs/usage/troubleshooting.md
+++ b/docs/content/docs/usage/troubleshooting.md
@@ -9,7 +9,7 @@ Common issues and solutions when working with CEM.
 
 Make sure your glob pattern matches your files:
 ```sh
-cem generate --verbose
+cem generate -v
 ```
 
 Check the `.config/cem.yaml` `generate.files` glob pattern matches your source files.


### PR DESCRIPTION
## Summary

- Add new `cem config` command group docs page (init, show, validate, mcp, path)
- Add config card to commands index
- Add MCP config resources (`cem://config`, `cem://config/schema`, `cem://config/schema/{section}`) and tools (`generate_config`, `validate_config`) to MCP reference
- Update verbosity flag docs across all pages to reflect 5-level model (`-q`, default, `-v`, `-vv`, `-vvv`)
- Add CSS import attribute warning to buildless development page
- Document workspace-mode single JSON output for `cem validate --format json`

Closes #392