### PR TITLE
feat(cli): add `cem breaking` command for API breaking change detection

### DIFF
--- a/.github/actions/pr-breaking-report/action.yml
+++ b/.github/actions/pr-breaking-report/action.yml
@@ -8,6 +8,9 @@ inputs:
   breaking-args:
     description: "Additional arguments for cem breaking"
     default: ""
+  fail-on:
+    description: "Severity threshold for exit code (breaking or dangerous)"
+    default: ""
 
 runs:
   using: composite
@@ -17,4 +20,5 @@ runs:
       env:
         PACKAGE_PATH: ${{ inputs.package-path }}
         BREAKING_ARGS: ${{ inputs.breaking-args }}
+        FAIL_ON: ${{ inputs.fail-on }}
       run: ${{ github.action_path }}/pr-breaking-report.sh

--- a/.github/actions/pr-breaking-report/action.yml
+++ b/.github/actions/pr-breaking-report/action.yml
@@ -1,0 +1,20 @@
+name: PR Breaking Change Report
+description: Generate a breaking change report comparing against the PR base ref
+
+inputs:
+  package-path:
+    description: "Path to the package"
+    default: "."
+  breaking-args:
+    description: "Additional arguments for cem breaking"
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Generate breaking change report
+      shell: bash
+      env:
+        PACKAGE_PATH: ${{ inputs.package-path }}
+        BREAKING_ARGS: ${{ inputs.breaking-args }}
+      run: ${{ github.action_path }}/pr-breaking-report.sh

--- a/.github/actions/pr-breaking-report/pr-breaking-report.sh
+++ b/.github/actions/pr-breaking-report/pr-breaking-report.sh
@@ -3,17 +3,26 @@ set -euo pipefail
 
 # Generate a breaking change report comparing against the PR base ref.
 # Expects env vars: PACKAGE_PATH, BREAKING_ARGS
+# Optional: FAIL_ON (breaking severity threshold, passed through from workflow)
 
 BASE_REF="${GITHUB_BASE_REF:-main}"
 
 # Ensure the base ref is available locally for git show
 git fetch origin "$BASE_REF" --depth=1 2>/dev/null || true
 
-# shellcheck disable=SC2086
+fail_on_args=""
+if [ -n "${FAIL_ON:-}" ]; then
+  fail_on_args="--fail-on $FAIL_ON"
+fi
+
 rc=0
+# shellcheck disable=SC2086
 cem breaking -p "$PACKAGE_PATH" \
   --base "origin/${BASE_REF}" \
-  --format markdown $BREAKING_ARGS > breaking_report.md || rc=$?
+  --format markdown $fail_on_args $BREAKING_ARGS > breaking_report.md || rc=$?
+
+# Persist exit code so the workflow gate step can reuse it
+echo "$rc" > breaking_exitcode.txt
 
 if [ "$rc" -ne 0 ]; then
   if [ -s breaking_report.md ] && grep -q '### Breaking Change Report' breaking_report.md; then

--- a/.github/actions/pr-breaking-report/pr-breaking-report.sh
+++ b/.github/actions/pr-breaking-report/pr-breaking-report.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate a breaking change report comparing against the PR base ref.
+# Expects env vars: PACKAGE_PATH, BREAKING_ARGS
+
+BASE_REF="${GITHUB_BASE_REF:-main}"
+
+# Ensure the base ref is available locally for git show
+git fetch origin "$BASE_REF" --depth=1 2>/dev/null || true
+
+# shellcheck disable=SC2086
+if cem breaking -p "$PACKAGE_PATH" \
+  --base "origin/${BASE_REF}" \
+  --format markdown $BREAKING_ARGS > breaking_report.md; then
+  # No breaking changes -- check if the report is empty/trivial
+  if grep -q 'No breaking changes detected' breaking_report.md; then
+    printf '### Breaking Change Report\n\nNo breaking changes detected.\n' > breaking_report.md
+  fi
+else
+  # cem breaking may exit non-zero from --fail-on; the report is still valid
+  true
+fi

--- a/.github/actions/pr-breaking-report/pr-breaking-report.sh
+++ b/.github/actions/pr-breaking-report/pr-breaking-report.sh
@@ -10,14 +10,21 @@ BASE_REF="${GITHUB_BASE_REF:-main}"
 git fetch origin "$BASE_REF" --depth=1 2>/dev/null || true
 
 # shellcheck disable=SC2086
-if cem breaking -p "$PACKAGE_PATH" \
+rc=0
+cem breaking -p "$PACKAGE_PATH" \
   --base "origin/${BASE_REF}" \
-  --format markdown $BREAKING_ARGS > breaking_report.md; then
-  # No breaking changes -- check if the report is empty/trivial
-  if grep -q 'No breaking changes detected' breaking_report.md; then
-    printf '### Breaking Change Report\n\nNo breaking changes detected.\n' > breaking_report.md
+  --format markdown $BREAKING_ARGS > breaking_report.md || rc=$?
+
+if [ "$rc" -ne 0 ]; then
+  if [ -s breaking_report.md ] && grep -q '### Breaking Change Report' breaking_report.md; then
+    # --fail-on threshold hit: report was generated, non-zero exit is expected
+    true
+  else
+    echo "cem breaking failed with exit code $rc" >&2
+    exit "$rc"
   fi
-else
-  # cem breaking may exit non-zero from --fail-on; the report is still valid
-  true
+fi
+
+if grep -q 'No breaking changes detected' breaking_report.md; then
+  printf '### Breaking Change Report\n\nNo breaking changes detected.\n' > breaking_report.md
 fi

--- a/.github/workflows/cem-breaking-report.yml
+++ b/.github/workflows/cem-breaking-report.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup cem
         uses: bennypowers/cem/.github/actions/setup-cem@main
@@ -46,6 +47,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Generate breaking change report
+        id: breaking
         uses: bennypowers/cem/.github/actions/pr-breaking-report@main
         with:
           package-path: ${{ inputs.package-path || '.' }}

--- a/.github/workflows/cem-breaking-report.yml
+++ b/.github/workflows/cem-breaking-report.yml
@@ -47,11 +47,11 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Generate breaking change report
-        id: breaking
         uses: bennypowers/cem/.github/actions/pr-breaking-report@main
         with:
           package-path: ${{ inputs.package-path || '.' }}
           breaking-args: ${{ inputs.breaking-args }}
+          fail-on: ${{ inputs.fail-on }}
 
       - name: Log breaking report
         run: cat breaking_report.md
@@ -74,13 +74,9 @@ jobs:
 
       - name: Check fail-on threshold
         if: inputs.fail-on != ''
-        env:
-          PKG_PATH: ${{ inputs.package-path || '.' }}
-          FAIL_ON: ${{ inputs.fail-on }}
-          BREAKING_ARGS: ${{ inputs.breaking-args }}
         run: |
-          # shellcheck disable=SC2086
-          cem breaking -p "$PKG_PATH" \
-            --base "origin/${GITHUB_BASE_REF:-main}" \
-            --fail-on "$FAIL_ON" \
-            --format text $BREAKING_ARGS > /dev/null
+          rc=$(cat breaking_exitcode.txt 2>/dev/null || echo "0")
+          if [ "$rc" -ne 0 ]; then
+            echo "Breaking change threshold exceeded (exit code $rc)"
+            exit "$rc"
+          fi

--- a/.github/workflows/cem-breaking-report.yml
+++ b/.github/workflows/cem-breaking-report.yml
@@ -1,0 +1,84 @@
+name: Breaking Change Report
+
+on:
+  workflow_call:
+    inputs:
+      package-path:
+        description: "Path to the package"
+        type: string
+        default: "."
+      cem-version:
+        description: "cem version to install (semver, without v prefix). If empty, reads from package.json or uses latest."
+        type: string
+        default: ""
+      fail-on:
+        description: "Exit 1 if changes at this severity or above: breaking or dangerous"
+        type: string
+        default: ""
+      generate-args:
+        description: "Additional arguments for cem generate"
+        type: string
+        default: ""
+      breaking-args:
+        description: "Additional arguments for cem breaking"
+        type: string
+        default: ""
+
+jobs:
+  breaking:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup cem
+        uses: bennypowers/cem/.github/actions/setup-cem@main
+        with:
+          package-path: ${{ inputs.package-path || '.' }}
+          cem-version: ${{ inputs.cem-version }}
+          generate-args: ${{ inputs.generate-args }}
+          github-token: ${{ github.token }}
+
+      - name: Generate breaking change report
+        uses: bennypowers/cem/.github/actions/pr-breaking-report@main
+        with:
+          package-path: ${{ inputs.package-path || '.' }}
+          breaking-args: ${{ inputs.breaking-args }}
+
+      - name: Log breaking report
+        run: cat breaking_report.md
+
+      - name: Find previous breaking comment
+        id: find-comment
+        uses: peter-evans/find-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "### Breaking Change Report"
+
+      - name: Post or update breaking comment
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-file: breaking_report.md
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: replace
+
+      - name: Check fail-on threshold
+        if: inputs.fail-on != ''
+        env:
+          PKG_PATH: ${{ inputs.package-path || '.' }}
+          FAIL_ON: ${{ inputs.fail-on }}
+          BREAKING_ARGS: ${{ inputs.breaking-args }}
+        run: |
+          # shellcheck disable=SC2086
+          cem breaking -p "$PKG_PATH" \
+            --base "origin/${GITHUB_BASE_REF:-main}" \
+            --fail-on "$FAIL_ON" \
+            --format text $BREAKING_ARGS > /dev/null

--- a/.github/workflows/cem-breaking-report.yml
+++ b/.github/workflows/cem-breaking-report.yml
@@ -36,7 +36,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - name: Setup cem
         uses: bennypowers/cem/.github/actions/setup-cem@main

--- a/breaking/breaking.go
+++ b/breaking/breaking.go
@@ -1,0 +1,151 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package breaking
+
+import (
+	"cmp"
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	M "bennypowers.dev/cem/manifest"
+)
+
+type Severity int
+
+const (
+	Safe Severity = iota
+	Dangerous
+	Breaking
+)
+
+func (s Severity) String() string {
+	switch s {
+	case Breaking:
+		return "breaking"
+	case Dangerous:
+		return "dangerous"
+	case Safe:
+		return "safe"
+	default:
+		return "unknown"
+	}
+}
+
+func (s Severity) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + s.String() + `"`), nil
+}
+
+func (s *Severity) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return err
+	}
+	switch str {
+	case "breaking":
+		*s = Breaking
+	case "dangerous":
+		*s = Dangerous
+	case "safe":
+		*s = Safe
+	default:
+		return fmt.Errorf("unknown severity: %s", str)
+	}
+	return nil
+}
+
+type Change struct {
+	Rule     string   `json:"rule"`
+	Severity Severity `json:"severity"`
+	Element  string   `json:"element"`
+	Subject  string   `json:"subject,omitempty"`
+	Message  string   `json:"message"`
+}
+
+type Result struct {
+	Changes   []Change `json:"changes"`
+	Breaking  int      `json:"breaking"`
+	Dangerous int      `json:"dangerous"`
+	Safe      int      `json:"safe"`
+}
+
+type Options struct {
+	Disable []string
+}
+
+func Compare(base, head *M.Package, opts Options) *Result {
+	disabled := make(map[string]bool, len(opts.Disable))
+	for _, id := range opts.Disable {
+		disabled[id] = true
+	}
+
+	rules := AllRules()
+
+	baseElements := indexElements(base)
+	headElements := indexElements(head)
+
+	var changes []Change
+
+	for _, rule := range rules {
+		if disabled[rule.ID()] {
+			continue
+		}
+		changes = append(changes, rule.Check(baseElements, headElements)...)
+	}
+
+	slices.SortFunc(changes, func(a, b Change) int {
+		if c := cmp.Compare(b.Severity, a.Severity); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.Element, b.Element); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.Rule, b.Rule); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Subject, b.Subject)
+	})
+
+	result := &Result{Changes: changes}
+	for _, c := range changes {
+		switch c.Severity {
+		case Breaking:
+			result.Breaking++
+		case Dangerous:
+			result.Dangerous++
+		case Safe:
+			result.Safe++
+		}
+	}
+
+	return result
+}
+
+func indexElements(pkg *M.Package) map[string]*M.CustomElementDeclaration {
+	elements := make(map[string]*M.CustomElementDeclaration)
+	if pkg == nil {
+		return elements
+	}
+	for i := range pkg.Modules {
+		for _, decl := range pkg.Modules[i].Declarations {
+			if ced, ok := decl.(*M.CustomElementDeclaration); ok && ced.TagName != "" {
+				elements[ced.TagName] = ced
+			}
+		}
+	}
+	return elements
+}

--- a/breaking/breaking_test.go
+++ b/breaking/breaking_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package breaking_test
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"bennypowers.dev/cem/breaking"
+	"bennypowers.dev/cem/internal/platform"
+	"bennypowers.dev/cem/internal/platform/testutil"
+	M "bennypowers.dev/cem/manifest"
+	"github.com/stretchr/testify/require"
+)
+
+var fixtureNames = []string{
+	"element-removed",
+	"attribute-changes",
+	"mixed-changes",
+	"no-changes",
+}
+
+func loadManifest(t *testing.T, mfs *platform.MapFileSystem, path string) *M.Package {
+	t.Helper()
+	data, err := mfs.ReadFile(path)
+	require.NoError(t, err)
+	var pkg M.Package
+	require.NoError(t, json.Unmarshal(data, &pkg))
+	return &pkg
+}
+
+func TestCompare(t *testing.T) {
+	mfs := testutil.LoadTestdataFS(t, "testdata/fixtures", "/fixtures")
+
+	for _, name := range fixtureNames {
+		t.Run(name, func(t *testing.T) {
+			base := loadManifest(t, mfs, filepath.Join("/fixtures", name, "base.json"))
+			head := loadManifest(t, mfs, filepath.Join("/fixtures", name, "head.json"))
+			result := breaking.Compare(base, head, breaking.Options{})
+			actual, err := json.MarshalIndent(result, "", "  ")
+			require.NoError(t, err)
+			actual = append(actual, '\n')
+			testutil.CheckGolden(t, name, actual, testutil.GoldenOptions{
+				Dir:         "testdata/goldens",
+				Extension:   ".json",
+				UseJSONDiff: true,
+			})
+		})
+	}
+}
+
+func TestCompareWithDisable(t *testing.T) {
+	mfs := testutil.LoadTestdataFS(t, "testdata/fixtures", "/fixtures")
+	base := loadManifest(t, mfs, "/fixtures/mixed-changes/base.json")
+	head := loadManifest(t, mfs, "/fixtures/mixed-changes/head.json")
+	result := breaking.Compare(base, head, breaking.Options{
+		Disable: []string{"element-added", "css-custom-property-added", "css-part-added", "event-added", "method-added"},
+	})
+
+	for _, c := range result.Changes {
+		switch c.Rule {
+		case "element-added", "css-custom-property-added", "css-part-added", "event-added", "method-added":
+			t.Errorf("disabled rule %q should not appear in results", c.Rule)
+		}
+	}
+}

--- a/breaking/display.go
+++ b/breaking/display.go
@@ -1,0 +1,132 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package breaking
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"io"
+	"text/template"
+
+	lipgloss "charm.land/lipgloss/v2"
+
+	"bennypowers.dev/cem/internal/tui"
+)
+
+//go:embed templates/report.md.tmpl
+var reportTemplate string
+
+type DisplayOptions struct {
+	Format string
+}
+
+func PrintResult(w io.Writer, result *Result, opts DisplayOptions) error {
+	switch opts.Format {
+	case "json":
+		return printResultJSON(w, result)
+	case "markdown":
+		return printResultMarkdown(w, result)
+	case "text", "":
+		return printResultText(w, result)
+	default:
+		return fmt.Errorf("invalid format: %s. Use 'text', 'json', or 'markdown'", opts.Format)
+	}
+}
+
+func printResultJSON(w io.Writer, result *Result) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(result)
+}
+
+func printResultText(w io.Writer, result *Result) error {
+	if len(result.Changes) == 0 {
+		_, err := lipgloss.Fprintln(w, tui.SuccessStyle.Render("No breaking changes detected"))
+		return err
+	}
+
+	sections := []struct {
+		severity Severity
+		title    string
+		style    lipgloss.Style
+		icon     string
+	}{
+		{Breaking, "Breaking Changes", tui.ErrorStyle, "✗"},
+		{Dangerous, "Dangerous Changes", tui.WarnStyle, "⚠"},
+		{Safe, "Safe Changes", tui.SuccessStyle, "✓"},
+	}
+
+	for _, sec := range sections {
+		var items []Change
+		for _, c := range result.Changes {
+			if c.Severity == sec.severity {
+				items = append(items, c)
+			}
+		}
+		if len(items) == 0 {
+			continue
+		}
+
+		header := fmt.Sprintf("%s (%d)", sec.title, len(items))
+		if _, err := lipgloss.Fprintln(w, tui.SectionStyle.Render(header)); err != nil {
+			return err
+		}
+		for _, c := range items {
+			icon := sec.style.Render(sec.icon)
+			if _, err := lipgloss.Fprintf(w, "  %s %s\n", icon, c.Message); err != nil {
+				return err
+			}
+		}
+		if _, err := lipgloss.Fprintln(w); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+var markdownTmpl = template.Must(template.New("report").Funcs(template.FuncMap{
+	"severities": func() []Severity {
+		return []Severity{Breaking, Dangerous, Safe}
+	},
+	"severityTitle": func(s Severity) string {
+		switch s {
+		case Breaking:
+			return "Breaking"
+		case Dangerous:
+			return "Dangerous"
+		case Safe:
+			return "Safe"
+		default:
+			return "Unknown"
+		}
+	},
+	"filterBySeverity": func(changes []Change, s Severity) []Change {
+		var filtered []Change
+		for _, c := range changes {
+			if c.Severity == s {
+				filtered = append(filtered, c)
+			}
+		}
+		return filtered
+	},
+}).Parse(reportTemplate))
+
+func printResultMarkdown(w io.Writer, result *Result) error {
+	return markdownTmpl.Execute(w, result)
+}

--- a/breaking/display.go
+++ b/breaking/display.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"text/template"
 
 	lipgloss "charm.land/lipgloss/v2"
@@ -101,6 +102,9 @@ func printResultText(w io.Writer, result *Result) error {
 }
 
 var markdownTmpl = template.Must(template.New("report").Funcs(template.FuncMap{
+	"escapeCell": func(s string) string {
+		return strings.ReplaceAll(s, "|", "\\|")
+	},
 	"severities": func() []Severity {
 		return []Severity{Breaking, Dangerous, Safe}
 	},

--- a/breaking/display_test.go
+++ b/breaking/display_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package breaking_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"bennypowers.dev/cem/breaking"
+	"bennypowers.dev/cem/internal/platform/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintResultText(t *testing.T) {
+	mfs := testutil.LoadTestdataFS(t, "testdata/fixtures", "/fixtures")
+
+	for _, name := range fixtureNames {
+		t.Run(name, func(t *testing.T) {
+			base := loadManifest(t, mfs, filepath.Join("/fixtures", name, "base.json"))
+			head := loadManifest(t, mfs, filepath.Join("/fixtures", name, "head.json"))
+			result := breaking.Compare(base, head, breaking.Options{})
+
+			var buf bytes.Buffer
+			err := breaking.PrintResult(&buf, result, breaking.DisplayOptions{Format: "text"})
+			require.NoError(t, err)
+
+			testutil.CheckGolden(t, "text-"+name, buf.Bytes(), testutil.GoldenOptions{
+				Dir:       "testdata/goldens",
+				Extension: ".txt",
+				StripANSI: true,
+			})
+		})
+	}
+}
+
+func TestPrintResultMarkdown(t *testing.T) {
+	mfs := testutil.LoadTestdataFS(t, "testdata/fixtures", "/fixtures")
+
+	for _, name := range fixtureNames {
+		t.Run(name, func(t *testing.T) {
+			base := loadManifest(t, mfs, filepath.Join("/fixtures", name, "base.json"))
+			head := loadManifest(t, mfs, filepath.Join("/fixtures", name, "head.json"))
+			result := breaking.Compare(base, head, breaking.Options{})
+
+			var buf bytes.Buffer
+			err := breaking.PrintResult(&buf, result, breaking.DisplayOptions{Format: "markdown"})
+			require.NoError(t, err)
+
+			testutil.CheckGolden(t, "markdown-"+name, buf.Bytes(), testutil.GoldenOptions{
+				Dir:       "testdata/goldens",
+				Extension: ".md",
+			})
+		})
+	}
+}
+
+func TestPrintResultJSON(t *testing.T) {
+	mfs := testutil.LoadTestdataFS(t, "testdata/fixtures", "/fixtures")
+	base := loadManifest(t, mfs, "/fixtures/mixed-changes/base.json")
+	head := loadManifest(t, mfs, "/fixtures/mixed-changes/head.json")
+	result := breaking.Compare(base, head, breaking.Options{})
+
+	var buf bytes.Buffer
+	err := breaking.PrintResult(&buf, result, breaking.DisplayOptions{Format: "json"})
+	require.NoError(t, err)
+
+	// inline assertions: verifying JSON round-trip serialization correctness
+	var parsed breaking.Result
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &parsed))
+	require.Equal(t, result.Breaking, parsed.Breaking)
+	require.Equal(t, result.Dangerous, parsed.Dangerous)
+	require.Equal(t, result.Safe, parsed.Safe)
+	require.Len(t, parsed.Changes, len(result.Changes))
+}
+
+func TestSeverityUnmarshal(t *testing.T) {
+	// inline assertions: verifying JSON round-trip for enum type
+	data := []byte(`"breaking"`)
+	var s breaking.Severity
+	require.NoError(t, json.Unmarshal(data, &s))
+	require.Equal(t, breaking.Breaking, s)
+}

--- a/breaking/helpers.go
+++ b/breaking/helpers.go
@@ -1,0 +1,45 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package breaking
+
+import M "bennypowers.dev/cem/manifest"
+
+func indexByName[T any](items []T, name func(T) string) map[string]T {
+	m := make(map[string]T, len(items))
+	for _, item := range items {
+		m[name(item)] = item
+	}
+	return m
+}
+
+func attrName(a M.Attribute) string           { return a.Name }
+func slotName(s M.Slot) string                { return s.Name }
+func eventName(e M.Event) string              { return e.Name }
+func cssPropertyName(p M.CssCustomProperty) string { return p.Name }
+func cssPartName(p M.CssPart) string          { return p.Name }
+func cssStateName(s M.CssCustomState) string  { return s.Name }
+
+func typeText(t *M.Type) string {
+	if t == nil {
+		return ""
+	}
+	return t.Text
+}
+
+func isPublic(privacy M.Privacy) bool {
+	return privacy == "" || privacy == M.Public
+}

--- a/breaking/helpers.go
+++ b/breaking/helpers.go
@@ -40,6 +40,13 @@ func typeText(t *M.Type) string {
 	return t.Text
 }
 
+func returnTypeText(m *M.ClassMethod) string {
+	if m.Return == nil {
+		return ""
+	}
+	return typeText(m.Return.Type)
+}
+
 func isPublic(privacy M.Privacy) bool {
 	return privacy == "" || privacy == M.Public
 }

--- a/breaking/resolve.go
+++ b/breaking/resolve.go
@@ -17,30 +17,31 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package breaking
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	M "bennypowers.dev/cem/manifest"
 )
 
 func ResolveManifestFromGit(ref, manifestPath, workDir string) (*M.Package, error) {
-	gitPath := manifestPath
-	if workDir != "" {
-		rel, err := relativeToGitRoot(workDir, manifestPath)
-		if err == nil && rel != "" {
-			gitPath = rel
-		}
+	gitPath, err := resolveGitPath(workDir, manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve manifest path: %w", err)
 	}
 
-	gitCmd := exec.Command("git", "show", ref+":"+gitPath)
+	var stderr bytes.Buffer
+	gitCmd := exec.Command("git", "show", "--", ref+":"+gitPath)
+	gitCmd.Stderr = &stderr
 	if workDir != "" {
 		gitCmd.Dir = workDir
 	}
 	out, err := gitCmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("failed to read manifest at %s from git ref %q: %w", gitPath, ref, err)
+		return nil, fmt.Errorf("failed to read manifest at %s from git ref %q: %w\n%s", gitPath, ref, err, stderr.String())
 	}
 
 	var pkg M.Package
@@ -52,13 +53,15 @@ func ResolveManifestFromGit(ref, manifestPath, workDir string) (*M.Package, erro
 }
 
 func FindLatestSemverTag(workDir string) (string, error) {
+	var stderr bytes.Buffer
 	gitCmd := exec.Command("git", "tag", "--list", "--sort=-v:refname")
+	gitCmd.Stderr = &stderr
 	if workDir != "" {
 		gitCmd.Dir = workDir
 	}
 	out, err := gitCmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("failed to list git tags: %w", err)
+		return "", fmt.Errorf("failed to list git tags: %w\n%s", err, stderr.String())
 	}
 
 	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
@@ -94,16 +97,45 @@ func isSemverTag(tag string) bool {
 	return true
 }
 
+func resolveGitPath(workDir, manifestPath string) (string, error) {
+	if !filepath.IsAbs(manifestPath) {
+		return relativeToGitRoot(workDir, manifestPath)
+	}
+	root, err := gitTopLevel(workDir)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(root, manifestPath)
+	if err != nil {
+		return "", fmt.Errorf("manifest path %s is outside git root %s", manifestPath, root)
+	}
+	return filepath.ToSlash(rel), nil
+}
+
 func relativeToGitRoot(workDir, path string) (string, error) {
+	var stderr bytes.Buffer
 	gitCmd := exec.Command("git", "rev-parse", "--show-prefix")
+	gitCmd.Stderr = &stderr
 	gitCmd.Dir = workDir
 	out, err := gitCmd.Output()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to get git prefix: %w\n%s", err, stderr.String())
 	}
 	prefix := strings.TrimSpace(string(out))
 	if prefix == "" {
 		return path, nil
 	}
 	return prefix + path, nil
+}
+
+func gitTopLevel(workDir string) (string, error) {
+	gitCmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	if workDir != "" {
+		gitCmd.Dir = workDir
+	}
+	out, err := gitCmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get git root: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
 }

--- a/breaking/resolve.go
+++ b/breaking/resolve.go
@@ -1,0 +1,109 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package breaking
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	M "bennypowers.dev/cem/manifest"
+)
+
+func ResolveManifestFromGit(ref, manifestPath, workDir string) (*M.Package, error) {
+	gitPath := manifestPath
+	if workDir != "" {
+		rel, err := relativeToGitRoot(workDir, manifestPath)
+		if err == nil && rel != "" {
+			gitPath = rel
+		}
+	}
+
+	gitCmd := exec.Command("git", "show", ref+":"+gitPath)
+	if workDir != "" {
+		gitCmd.Dir = workDir
+	}
+	out, err := gitCmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read manifest at %s from git ref %q: %w", gitPath, ref, err)
+	}
+
+	var pkg M.Package
+	if err := json.Unmarshal(out, &pkg); err != nil {
+		return nil, fmt.Errorf("failed to parse manifest at %s from git ref %q: %w", gitPath, ref, err)
+	}
+
+	return &pkg, nil
+}
+
+func FindLatestSemverTag(workDir string) (string, error) {
+	gitCmd := exec.Command("git", "tag", "--list", "--sort=-v:refname")
+	if workDir != "" {
+		gitCmd.Dir = workDir
+	}
+	out, err := gitCmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to list git tags: %w", err)
+	}
+
+	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		tag := strings.TrimSpace(line)
+		if tag == "" {
+			continue
+		}
+		if isSemverTag(tag) {
+			return tag, nil
+		}
+	}
+
+	return "", fmt.Errorf("no semver tags found")
+}
+
+func isSemverTag(tag string) bool {
+	tag = strings.TrimPrefix(tag, "v")
+	parts := strings.SplitN(tag, ".", 3)
+	if len(parts) < 3 {
+		return false
+	}
+	for _, part := range parts {
+		p := strings.SplitN(part, "-", 2)[0]
+		if p == "" {
+			return false
+		}
+		for _, c := range p {
+			if c < '0' || c > '9' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func relativeToGitRoot(workDir, path string) (string, error) {
+	gitCmd := exec.Command("git", "rev-parse", "--show-prefix")
+	gitCmd.Dir = workDir
+	out, err := gitCmd.Output()
+	if err != nil {
+		return "", err
+	}
+	prefix := strings.TrimSpace(string(out))
+	if prefix == "" {
+		return path, nil
+	}
+	return prefix + path, nil
+}

--- a/breaking/resolve_test.go
+++ b/breaking/resolve_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package breaking
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSemverTag(t *testing.T) {
+	tests := []struct {
+		tag  string
+		want bool
+	}{
+		{"1.0.0", true},
+		{"v1.0.0", true},
+		{"v0.11.0", true},
+		{"v2.1.1", true},
+		{"1.2.3-alpha.1", true},
+		{"v1.0.0-rc.1", true},
+		{"v1.0.0-beta", true},
+		{"1.2", false},
+		{"v1", false},
+		{"", false},
+		{"latest", false},
+		{"v1.x.3", false},
+		{"v1.2.x", false},
+		{"release-1.0", false},
+		{"v.1.2.3", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			assert.Equal(t, tt.want, isSemverTag(tt.tag))
+		})
+	}
+}

--- a/breaking/resolve_test.go
+++ b/breaking/resolve_test.go
@@ -17,9 +17,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package breaking
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsSemverTag(t *testing.T) {
@@ -48,4 +50,24 @@ func TestIsSemverTag(t *testing.T) {
 			assert.Equal(t, tt.want, isSemverTag(tt.tag))
 		})
 	}
+}
+
+func TestResolveGitPath(t *testing.T) {
+	// inline assertions: testing path resolution logic with real git repo
+	root, err := gitTopLevel(".")
+	require.NoError(t, err)
+
+	t.Run("relative path", func(t *testing.T) {
+		got, err := resolveGitPath(".", "custom-elements.json")
+		require.NoError(t, err)
+		assert.NotEmpty(t, got)
+		assert.NotContains(t, got, root)
+	})
+
+	t.Run("absolute path within repo", func(t *testing.T) {
+		absPath := filepath.Join(root, "custom-elements.json")
+		got, err := resolveGitPath(".", absPath)
+		require.NoError(t, err)
+		assert.Equal(t, "custom-elements.json", got)
+	})
 }

--- a/breaking/resolve_test.go
+++ b/breaking/resolve_test.go
@@ -60,8 +60,7 @@ func TestResolveGitPath(t *testing.T) {
 	t.Run("relative path", func(t *testing.T) {
 		got, err := resolveGitPath(".", "custom-elements.json")
 		require.NoError(t, err)
-		assert.NotEmpty(t, got)
-		assert.NotContains(t, got, root)
+		assert.Equal(t, "breaking/custom-elements.json", got)
 	})
 
 	t.Run("absolute path within repo", func(t *testing.T) {

--- a/breaking/rules.go
+++ b/breaking/rules.go
@@ -1,0 +1,53 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package breaking
+
+import M "bennypowers.dev/cem/manifest"
+
+type BreakingRule interface {
+	ID() string
+	Check(base, head map[string]*M.CustomElementDeclaration) []Change
+}
+
+func AllRules() []BreakingRule {
+	return []BreakingRule{
+		&elementRemovedRule{},
+		&elementAddedRule{},
+		&attributeRemovedRule{},
+		&attributeAddedRule{},
+		&attributeTypeChangedRule{},
+		&attributeDefaultChangedRule{},
+		&slotRemovedRule{},
+		&slotAddedRule{},
+		&cssPropertyRemovedRule{},
+		&cssPropertyAddedRule{},
+		&cssPropertyDefaultChangedRule{},
+		&cssPartRemovedRule{},
+		&cssPartAddedRule{},
+		&cssStateRemovedRule{},
+		&cssStateAddedRule{},
+		&eventRemovedRule{},
+		&eventAddedRule{},
+		&eventTypeChangedRule{},
+		&methodRemovedRule{},
+		&methodAddedRule{},
+		&methodReturnTypeChangedRule{},
+		&methodParameterChangedRule{},
+		&fieldRemovedRule{},
+		&fieldTypeChangedRule{},
+	}
+}

--- a/breaking/rules.go
+++ b/breaking/rules.go
@@ -48,6 +48,7 @@ func AllRules() []BreakingRule {
 		&methodReturnTypeChangedRule{},
 		&methodParameterChangedRule{},
 		&fieldRemovedRule{},
+		&fieldAddedRule{},
 		&fieldTypeChangedRule{},
 	}
 }

--- a/breaking/rules_attributes.go
+++ b/breaking/rules_attributes.go
@@ -1,0 +1,141 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package breaking
+
+import (
+	"fmt"
+
+	M "bennypowers.dev/cem/manifest"
+)
+
+type attributeRemovedRule struct{}
+
+func (*attributeRemovedRule) ID() string { return "attribute-removed" }
+
+func (*attributeRemovedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, baseEl := range base {
+		headEl, ok := head[tag]
+		if !ok {
+			continue
+		}
+		headAttrs := indexByName(headEl.OwnAttributes(), attrName)
+		for _, attr := range baseEl.OwnAttributes() {
+			if _, ok := headAttrs[attr.Name]; !ok {
+				changes = append(changes, Change{
+					Rule:     "attribute-removed",
+					Severity: Breaking,
+					Element:  tag,
+					Subject:  attr.Name,
+					Message:  fmt.Sprintf("attribute %q removed from <%s>", attr.Name, tag),
+				})
+			}
+		}
+	}
+	return changes
+}
+
+type attributeAddedRule struct{}
+
+func (*attributeAddedRule) ID() string { return "attribute-added" }
+
+func (*attributeAddedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, headEl := range head {
+		baseEl, ok := base[tag]
+		if !ok {
+			continue
+		}
+		baseAttrs := indexByName(baseEl.OwnAttributes(), attrName)
+		for _, attr := range headEl.OwnAttributes() {
+			if _, ok := baseAttrs[attr.Name]; !ok {
+				changes = append(changes, Change{
+					Rule:     "attribute-added",
+					Severity: Safe,
+					Element:  tag,
+					Subject:  attr.Name,
+					Message:  fmt.Sprintf("attribute %q added to <%s>", attr.Name, tag),
+				})
+			}
+		}
+	}
+	return changes
+}
+
+type attributeTypeChangedRule struct{}
+
+func (*attributeTypeChangedRule) ID() string { return "attribute-type-changed" }
+
+func (*attributeTypeChangedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, baseEl := range base {
+		headEl, ok := head[tag]
+		if !ok {
+			continue
+		}
+		headAttrs := indexByName(headEl.OwnAttributes(), attrName)
+		for _, baseAttr := range baseEl.OwnAttributes() {
+			headAttr, ok := headAttrs[baseAttr.Name]
+			if !ok {
+				continue
+			}
+			baseType := typeText(baseAttr.Type)
+			headType := typeText(headAttr.Type)
+			if baseType != "" && headType != "" && baseType != headType {
+				changes = append(changes, Change{
+					Rule:     "attribute-type-changed",
+					Severity: Breaking,
+					Element:  tag,
+					Subject:  baseAttr.Name,
+					Message:  fmt.Sprintf("attribute %q type changed from %s to %s in <%s>", baseAttr.Name, baseType, headType, tag),
+				})
+			}
+		}
+	}
+	return changes
+}
+
+type attributeDefaultChangedRule struct{}
+
+func (*attributeDefaultChangedRule) ID() string { return "attribute-default-changed" }
+
+func (*attributeDefaultChangedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, baseEl := range base {
+		headEl, ok := head[tag]
+		if !ok {
+			continue
+		}
+		headAttrs := indexByName(headEl.OwnAttributes(), attrName)
+		for _, baseAttr := range baseEl.OwnAttributes() {
+			headAttr, ok := headAttrs[baseAttr.Name]
+			if !ok {
+				continue
+			}
+			if baseAttr.Default != "" && headAttr.Default != "" && baseAttr.Default != headAttr.Default {
+				changes = append(changes, Change{
+					Rule:     "attribute-default-changed",
+					Severity: Dangerous,
+					Element:  tag,
+					Subject:  baseAttr.Name,
+					Message:  fmt.Sprintf("attribute %q default changed from %s to %s in <%s>", baseAttr.Name, baseAttr.Default, headAttr.Default, tag),
+				})
+			}
+		}
+	}
+	return changes
+}

--- a/breaking/rules_attributes.go
+++ b/breaking/rules_attributes.go
@@ -126,13 +126,22 @@ func (*attributeDefaultChangedRule) Check(base, head map[string]*M.CustomElement
 			if !ok {
 				continue
 			}
-			if baseAttr.Default != "" && headAttr.Default != "" && baseAttr.Default != headAttr.Default {
+			if baseAttr.Default != headAttr.Default {
+				var msg string
+				switch {
+				case baseAttr.Default != "" && headAttr.Default != "":
+					msg = fmt.Sprintf("attribute %q default changed from %s to %s in <%s>", baseAttr.Name, baseAttr.Default, headAttr.Default, tag)
+				case baseAttr.Default != "":
+					msg = fmt.Sprintf("attribute %q default %s removed in <%s>", baseAttr.Name, baseAttr.Default, tag)
+				default:
+					msg = fmt.Sprintf("attribute %q default set to %s in <%s>", baseAttr.Name, headAttr.Default, tag)
+				}
 				changes = append(changes, Change{
 					Rule:     "attribute-default-changed",
 					Severity: Dangerous,
 					Element:  tag,
 					Subject:  baseAttr.Name,
-					Message:  fmt.Sprintf("attribute %q default changed from %s to %s in <%s>", baseAttr.Name, baseAttr.Default, headAttr.Default, tag),
+					Message:  msg,
 				})
 			}
 		}

--- a/breaking/rules_css.go
+++ b/breaking/rules_css.go
@@ -1,0 +1,222 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package breaking
+
+import (
+	"fmt"
+
+	M "bennypowers.dev/cem/manifest"
+)
+
+// CSS Custom Properties
+
+type cssPropertyRemovedRule struct{}
+
+func (*cssPropertyRemovedRule) ID() string { return "css-custom-property-removed" }
+
+func (*cssPropertyRemovedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, baseEl := range base {
+		headEl, ok := head[tag]
+		if !ok {
+			continue
+		}
+		headProps := indexByName(headEl.OwnCssProperties(), cssPropertyName)
+		for _, prop := range baseEl.OwnCssProperties() {
+			if _, ok := headProps[prop.Name]; !ok {
+				changes = append(changes, Change{
+					Rule:     "css-custom-property-removed",
+					Severity: Breaking,
+					Element:  tag,
+					Subject:  prop.Name,
+					Message:  fmt.Sprintf("CSS custom property %q removed from <%s>", prop.Name, tag),
+				})
+			}
+		}
+	}
+	return changes
+}
+
+type cssPropertyAddedRule struct{}
+
+func (*cssPropertyAddedRule) ID() string { return "css-custom-property-added" }
+
+func (*cssPropertyAddedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, headEl := range head {
+		baseEl, ok := base[tag]
+		if !ok {
+			continue
+		}
+		baseProps := indexByName(baseEl.OwnCssProperties(), cssPropertyName)
+		for _, prop := range headEl.OwnCssProperties() {
+			if _, ok := baseProps[prop.Name]; !ok {
+				changes = append(changes, Change{
+					Rule:     "css-custom-property-added",
+					Severity: Safe,
+					Element:  tag,
+					Subject:  prop.Name,
+					Message:  fmt.Sprintf("CSS custom property %q added to <%s>", prop.Name, tag),
+				})
+			}
+		}
+	}
+	return changes
+}
+
+type cssPropertyDefaultChangedRule struct{}
+
+func (*cssPropertyDefaultChangedRule) ID() string { return "css-custom-property-default-changed" }
+
+func (*cssPropertyDefaultChangedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, baseEl := range base {
+		headEl, ok := head[tag]
+		if !ok {
+			continue
+		}
+		headProps := indexByName(headEl.OwnCssProperties(), cssPropertyName)
+		for _, baseProp := range baseEl.OwnCssProperties() {
+			headProp, ok := headProps[baseProp.Name]
+			if !ok {
+				continue
+			}
+			if baseProp.Default != "" && headProp.Default != "" && baseProp.Default != headProp.Default {
+				changes = append(changes, Change{
+					Rule:     "css-custom-property-default-changed",
+					Severity: Dangerous,
+					Element:  tag,
+					Subject:  baseProp.Name,
+					Message:  fmt.Sprintf("CSS custom property %q default changed from %s to %s in <%s>", baseProp.Name, baseProp.Default, headProp.Default, tag),
+				})
+			}
+		}
+	}
+	return changes
+}
+
+// CSS Parts
+
+type cssPartRemovedRule struct{}
+
+func (*cssPartRemovedRule) ID() string { return "css-part-removed" }
+
+func (*cssPartRemovedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, baseEl := range base {
+		headEl, ok := head[tag]
+		if !ok {
+			continue
+		}
+		headParts := indexByName(headEl.OwnCssParts(), cssPartName)
+		for _, part := range baseEl.OwnCssParts() {
+			if _, ok := headParts[part.Name]; !ok {
+				changes = append(changes, Change{
+					Rule:     "css-part-removed",
+					Severity: Breaking,
+					Element:  tag,
+					Subject:  part.Name,
+					Message:  fmt.Sprintf("CSS part %q removed from <%s>", part.Name, tag),
+				})
+			}
+		}
+	}
+	return changes
+}
+
+type cssPartAddedRule struct{}
+
+func (*cssPartAddedRule) ID() string { return "css-part-added" }
+
+func (*cssPartAddedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, headEl := range head {
+		baseEl, ok := base[tag]
+		if !ok {
+			continue
+		}
+		baseParts := indexByName(baseEl.OwnCssParts(), cssPartName)
+		for _, part := range headEl.OwnCssParts() {
+			if _, ok := baseParts[part.Name]; !ok {
+				changes = append(changes, Change{
+					Rule:     "css-part-added",
+					Severity: Safe,
+					Element:  tag,
+					Subject:  part.Name,
+					Message:  fmt.Sprintf("CSS part %q added to <%s>", part.Name, tag),
+				})
+			}
+		}
+	}
+	return changes
+}
+
+// CSS States
+
+type cssStateRemovedRule struct{}
+
+func (*cssStateRemovedRule) ID() string { return "css-state-removed" }
+
+func (*cssStateRemovedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, baseEl := range base {
+		headEl, ok := head[tag]
+		if !ok {
+			continue
+		}
+		headStates := indexByName(headEl.OwnCssStates(), cssStateName)
+		for _, state := range baseEl.OwnCssStates() {
+			if _, ok := headStates[state.Name]; !ok {
+				changes = append(changes, Change{
+					Rule:     "css-state-removed",
+					Severity: Breaking,
+					Element:  tag,
+					Subject:  state.Name,
+					Message:  fmt.Sprintf("CSS state %q removed from <%s>", state.Name, tag),
+				})
+			}
+		}
+	}
+	return changes
+}
+
+type cssStateAddedRule struct{}
+
+func (*cssStateAddedRule) ID() string { return "css-state-added" }
+
+func (*cssStateAddedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, headEl := range head {
+		baseEl, ok := base[tag]
+		if !ok {
+			continue
+		}
+		baseStates := indexByName(baseEl.OwnCssStates(), cssStateName)
+		for _, state := range headEl.OwnCssStates() {
+			if _, ok := baseStates[state.Name]; !ok {
+				changes = append(changes, Change{
+					Rule:     "css-state-added",
+					Severity: Safe,
+					Element:  tag,
+					Subject:  state.Name,
+					Message:  fmt.Sprintf("CSS state %q added to <%s>", state.Name, tag),
+				})
+			}
+		}
+	}
+	return changes
+}

--- a/breaking/rules_css.go
+++ b/breaking/rules_css.go
@@ -95,13 +95,22 @@ func (*cssPropertyDefaultChangedRule) Check(base, head map[string]*M.CustomEleme
 			if !ok {
 				continue
 			}
-			if baseProp.Default != "" && headProp.Default != "" && baseProp.Default != headProp.Default {
+			if baseProp.Default != headProp.Default {
+				var msg string
+				switch {
+				case baseProp.Default != "" && headProp.Default != "":
+					msg = fmt.Sprintf("CSS custom property %q default changed from %s to %s in <%s>", baseProp.Name, baseProp.Default, headProp.Default, tag)
+				case baseProp.Default != "":
+					msg = fmt.Sprintf("CSS custom property %q default %s removed in <%s>", baseProp.Name, baseProp.Default, tag)
+				default:
+					msg = fmt.Sprintf("CSS custom property %q default set to %s in <%s>", baseProp.Name, headProp.Default, tag)
+				}
 				changes = append(changes, Change{
 					Rule:     "css-custom-property-default-changed",
 					Severity: Dangerous,
 					Element:  tag,
 					Subject:  baseProp.Name,
-					Message:  fmt.Sprintf("CSS custom property %q default changed from %s to %s in <%s>", baseProp.Name, baseProp.Default, headProp.Default, tag),
+					Message:  msg,
 				})
 			}
 		}

--- a/breaking/rules_elements.go
+++ b/breaking/rules_elements.go
@@ -1,0 +1,61 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package breaking
+
+import (
+	"fmt"
+
+	M "bennypowers.dev/cem/manifest"
+)
+
+type elementRemovedRule struct{}
+
+func (*elementRemovedRule) ID() string { return "element-removed" }
+
+func (*elementRemovedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag := range base {
+		if _, ok := head[tag]; !ok {
+			changes = append(changes, Change{
+				Rule:     "element-removed",
+				Severity: Breaking,
+				Element:  tag,
+				Message:  fmt.Sprintf("element <%s> removed", tag),
+			})
+		}
+	}
+	return changes
+}
+
+type elementAddedRule struct{}
+
+func (*elementAddedRule) ID() string { return "element-added" }
+
+func (*elementAddedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag := range head {
+		if _, ok := base[tag]; !ok {
+			changes = append(changes, Change{
+				Rule:     "element-added",
+				Severity: Safe,
+				Element:  tag,
+				Message:  fmt.Sprintf("element <%s> added", tag),
+			})
+		}
+	}
+	return changes
+}

--- a/breaking/rules_events.go
+++ b/breaking/rules_events.go
@@ -1,0 +1,110 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package breaking
+
+import (
+	"fmt"
+
+	M "bennypowers.dev/cem/manifest"
+)
+
+type eventRemovedRule struct{}
+
+func (*eventRemovedRule) ID() string { return "event-removed" }
+
+func (*eventRemovedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, baseEl := range base {
+		headEl, ok := head[tag]
+		if !ok {
+			continue
+		}
+		headEvents := indexByName(headEl.OwnEvents(), eventName)
+		for _, event := range baseEl.OwnEvents() {
+			if _, ok := headEvents[event.Name]; !ok {
+				changes = append(changes, Change{
+					Rule:     "event-removed",
+					Severity: Breaking,
+					Element:  tag,
+					Subject:  event.Name,
+					Message:  fmt.Sprintf("event %q removed from <%s>", event.Name, tag),
+				})
+			}
+		}
+	}
+	return changes
+}
+
+type eventAddedRule struct{}
+
+func (*eventAddedRule) ID() string { return "event-added" }
+
+func (*eventAddedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, headEl := range head {
+		baseEl, ok := base[tag]
+		if !ok {
+			continue
+		}
+		baseEvents := indexByName(baseEl.OwnEvents(), eventName)
+		for _, event := range headEl.OwnEvents() {
+			if _, ok := baseEvents[event.Name]; !ok {
+				changes = append(changes, Change{
+					Rule:     "event-added",
+					Severity: Safe,
+					Element:  tag,
+					Subject:  event.Name,
+					Message:  fmt.Sprintf("event %q added to <%s>", event.Name, tag),
+				})
+			}
+		}
+	}
+	return changes
+}
+
+type eventTypeChangedRule struct{}
+
+func (*eventTypeChangedRule) ID() string { return "event-type-changed" }
+
+func (*eventTypeChangedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, baseEl := range base {
+		headEl, ok := head[tag]
+		if !ok {
+			continue
+		}
+		headEvents := indexByName(headEl.OwnEvents(), eventName)
+		for _, baseEvent := range baseEl.OwnEvents() {
+			headEvent, ok := headEvents[baseEvent.Name]
+			if !ok {
+				continue
+			}
+			baseType := typeText(baseEvent.Type)
+			headType := typeText(headEvent.Type)
+			if baseType != "" && headType != "" && baseType != headType {
+				changes = append(changes, Change{
+					Rule:     "event-type-changed",
+					Severity: Breaking,
+					Element:  tag,
+					Subject:  baseEvent.Name,
+					Message:  fmt.Sprintf("event %q type changed from %s to %s in <%s>", baseEvent.Name, baseType, headType, tag),
+				})
+			}
+		}
+	}
+	return changes
+}

--- a/breaking/rules_members.go
+++ b/breaking/rules_members.go
@@ -1,0 +1,253 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package breaking
+
+import (
+	"fmt"
+	"strings"
+
+	M "bennypowers.dev/cem/manifest"
+)
+
+func publicMethods(ced *M.CustomElementDeclaration) map[string]*M.ClassMethod {
+	methods := make(map[string]*M.ClassMethod)
+	for _, member := range ced.Members {
+		if m, ok := member.(*M.ClassMethod); ok && isPublic(m.Privacy) {
+			methods[m.Name] = m
+		}
+	}
+	return methods
+}
+
+func publicFields(ced *M.CustomElementDeclaration) map[string]*M.ClassField {
+	fields := make(map[string]*M.ClassField)
+	for _, member := range ced.Members {
+		switch f := member.(type) {
+		case *M.ClassField:
+			if isPublic(f.Privacy) {
+				fields[f.Name] = f
+			}
+		case *M.CustomElementField:
+			if isPublic(f.Privacy) {
+				fields[f.Name] = &f.ClassField
+			}
+		}
+	}
+	return fields
+}
+
+func paramSignature(m *M.ClassMethod) string {
+	var params []string
+	for _, p := range m.Parameters {
+		s := p.Name
+		if p.Type != nil && p.Type.Text != "" {
+			s += ": " + p.Type.Text
+		}
+		params = append(params, s)
+	}
+	return "(" + strings.Join(params, ", ") + ")"
+}
+
+// Methods
+
+type methodRemovedRule struct{}
+
+func (*methodRemovedRule) ID() string { return "method-removed" }
+
+func (*methodRemovedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, baseEl := range base {
+		headEl, ok := head[tag]
+		if !ok {
+			continue
+		}
+		headMethods := publicMethods(headEl)
+		for name := range publicMethods(baseEl) {
+			if _, ok := headMethods[name]; !ok {
+				changes = append(changes, Change{
+					Rule:     "method-removed",
+					Severity: Breaking,
+					Element:  tag,
+					Subject:  name,
+					Message:  fmt.Sprintf("method %q removed from <%s>", name, tag),
+				})
+			}
+		}
+	}
+	return changes
+}
+
+type methodAddedRule struct{}
+
+func (*methodAddedRule) ID() string { return "method-added" }
+
+func (*methodAddedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, headEl := range head {
+		baseEl, ok := base[tag]
+		if !ok {
+			continue
+		}
+		baseMethods := publicMethods(baseEl)
+		for name := range publicMethods(headEl) {
+			if _, ok := baseMethods[name]; !ok {
+				changes = append(changes, Change{
+					Rule:     "method-added",
+					Severity: Safe,
+					Element:  tag,
+					Subject:  name,
+					Message:  fmt.Sprintf("method %q added to <%s>", name, tag),
+				})
+			}
+		}
+	}
+	return changes
+}
+
+type methodReturnTypeChangedRule struct{}
+
+func (*methodReturnTypeChangedRule) ID() string { return "method-return-type-changed" }
+
+func (*methodReturnTypeChangedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, baseEl := range base {
+		headEl, ok := head[tag]
+		if !ok {
+			continue
+		}
+		headMethods := publicMethods(headEl)
+		for name, baseMethod := range publicMethods(baseEl) {
+			headMethod, ok := headMethods[name]
+			if !ok {
+				continue
+			}
+			baseReturn := ""
+			headReturn := ""
+			if baseMethod.Return != nil && baseMethod.Return.Type != nil {
+				baseReturn = baseMethod.Return.Type.Text
+			}
+			if headMethod.Return != nil && headMethod.Return.Type != nil {
+				headReturn = headMethod.Return.Type.Text
+			}
+			if baseReturn != "" && headReturn != "" && baseReturn != headReturn {
+				changes = append(changes, Change{
+					Rule:     "method-return-type-changed",
+					Severity: Breaking,
+					Element:  tag,
+					Subject:  name,
+					Message:  fmt.Sprintf("method %q return type changed from %s to %s in <%s>", name, baseReturn, headReturn, tag),
+				})
+			}
+		}
+	}
+	return changes
+}
+
+type methodParameterChangedRule struct{}
+
+func (*methodParameterChangedRule) ID() string { return "method-parameter-changed" }
+
+func (*methodParameterChangedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, baseEl := range base {
+		headEl, ok := head[tag]
+		if !ok {
+			continue
+		}
+		headMethods := publicMethods(headEl)
+		for name, baseMethod := range publicMethods(baseEl) {
+			headMethod, ok := headMethods[name]
+			if !ok {
+				continue
+			}
+			baseSig := paramSignature(baseMethod)
+			headSig := paramSignature(headMethod)
+			if baseSig != headSig {
+				changes = append(changes, Change{
+					Rule:     "method-parameter-changed",
+					Severity: Breaking,
+					Element:  tag,
+					Subject:  name,
+					Message:  fmt.Sprintf("method %q parameters changed from %s to %s in <%s>", name, baseSig, headSig, tag),
+				})
+			}
+		}
+	}
+	return changes
+}
+
+// Fields
+
+type fieldRemovedRule struct{}
+
+func (*fieldRemovedRule) ID() string { return "field-removed" }
+
+func (*fieldRemovedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, baseEl := range base {
+		headEl, ok := head[tag]
+		if !ok {
+			continue
+		}
+		headFields := publicFields(headEl)
+		for name := range publicFields(baseEl) {
+			if _, ok := headFields[name]; !ok {
+				changes = append(changes, Change{
+					Rule:     "field-removed",
+					Severity: Breaking,
+					Element:  tag,
+					Subject:  name,
+					Message:  fmt.Sprintf("field %q removed from <%s>", name, tag),
+				})
+			}
+		}
+	}
+	return changes
+}
+
+type fieldTypeChangedRule struct{}
+
+func (*fieldTypeChangedRule) ID() string { return "field-type-changed" }
+
+func (*fieldTypeChangedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, baseEl := range base {
+		headEl, ok := head[tag]
+		if !ok {
+			continue
+		}
+		headFields := publicFields(headEl)
+		for name, baseField := range publicFields(baseEl) {
+			headField, ok := headFields[name]
+			if !ok {
+				continue
+			}
+			baseType := typeText(baseField.Type)
+			headType := typeText(headField.Type)
+			if baseType != "" && headType != "" && baseType != headType {
+				changes = append(changes, Change{
+					Rule:     "field-type-changed",
+					Severity: Dangerous,
+					Element:  tag,
+					Subject:  name,
+					Message:  fmt.Sprintf("field %q type changed from %s to %s in <%s>", name, baseType, headType, tag),
+				})
+			}
+		}
+	}
+	return changes
+}

--- a/breaking/rules_members.go
+++ b/breaking/rules_members.go
@@ -53,11 +53,7 @@ func publicFields(ced *M.CustomElementDeclaration) map[string]*M.ClassField {
 func paramSignature(m *M.ClassMethod) string {
 	var params []string
 	for _, p := range m.Parameters {
-		s := p.Name
-		if p.Type != nil && p.Type.Text != "" {
-			s += ": " + p.Type.Text
-		}
-		params = append(params, s)
+		params = append(params, typeText(p.Type))
 	}
 	return "(" + strings.Join(params, ", ") + ")"
 }
@@ -135,14 +131,8 @@ func (*methodReturnTypeChangedRule) Check(base, head map[string]*M.CustomElement
 			if !ok {
 				continue
 			}
-			baseReturn := ""
-			headReturn := ""
-			if baseMethod.Return != nil && baseMethod.Return.Type != nil {
-				baseReturn = baseMethod.Return.Type.Text
-			}
-			if headMethod.Return != nil && headMethod.Return.Type != nil {
-				headReturn = headMethod.Return.Type.Text
-			}
+			baseReturn := returnTypeText(baseMethod)
+			headReturn := returnTypeText(headMethod)
 			if baseReturn != "" && headReturn != "" && baseReturn != headReturn {
 				changes = append(changes, Change{
 					Rule:     "method-return-type-changed",
@@ -212,6 +202,33 @@ func (*fieldRemovedRule) Check(base, head map[string]*M.CustomElementDeclaration
 					Element:  tag,
 					Subject:  name,
 					Message:  fmt.Sprintf("field %q removed from <%s>", name, tag),
+				})
+			}
+		}
+	}
+	return changes
+}
+
+type fieldAddedRule struct{}
+
+func (*fieldAddedRule) ID() string { return "field-added" }
+
+func (*fieldAddedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, headEl := range head {
+		baseEl, ok := base[tag]
+		if !ok {
+			continue
+		}
+		baseFields := publicFields(baseEl)
+		for name := range publicFields(headEl) {
+			if _, ok := baseFields[name]; !ok {
+				changes = append(changes, Change{
+					Rule:     "field-added",
+					Severity: Safe,
+					Element:  tag,
+					Subject:  name,
+					Message:  fmt.Sprintf("field %q added to <%s>", name, tag),
 				})
 			}
 		}

--- a/breaking/rules_slots.go
+++ b/breaking/rules_slots.go
@@ -1,0 +1,85 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package breaking
+
+import (
+	"fmt"
+
+	M "bennypowers.dev/cem/manifest"
+)
+
+type slotRemovedRule struct{}
+
+func (*slotRemovedRule) ID() string { return "slot-removed" }
+
+func (*slotRemovedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, baseEl := range base {
+		headEl, ok := head[tag]
+		if !ok {
+			continue
+		}
+		headSlots := indexByName(headEl.OwnSlots(), slotName)
+		for _, slot := range baseEl.OwnSlots() {
+			if _, ok := headSlots[slot.Name]; !ok {
+				name := slot.Name
+				if name == "" {
+					name = "(default)"
+				}
+				changes = append(changes, Change{
+					Rule:     "slot-removed",
+					Severity: Breaking,
+					Element:  tag,
+					Subject:  slot.Name,
+					Message:  fmt.Sprintf("slot %q removed from <%s>", name, tag),
+				})
+			}
+		}
+	}
+	return changes
+}
+
+type slotAddedRule struct{}
+
+func (*slotAddedRule) ID() string { return "slot-added" }
+
+func (*slotAddedRule) Check(base, head map[string]*M.CustomElementDeclaration) []Change {
+	var changes []Change
+	for tag, headEl := range head {
+		baseEl, ok := base[tag]
+		if !ok {
+			continue
+		}
+		baseSlots := indexByName(baseEl.OwnSlots(), slotName)
+		for _, slot := range headEl.OwnSlots() {
+			if _, ok := baseSlots[slot.Name]; !ok {
+				name := slot.Name
+				if name == "" {
+					name = "(default)"
+				}
+				changes = append(changes, Change{
+					Rule:     "slot-added",
+					Severity: Safe,
+					Element:  tag,
+					Subject:  slot.Name,
+					Message:  fmt.Sprintf("slot %q added to <%s>", name, tag),
+				})
+			}
+		}
+	}
+	return changes
+}

--- a/breaking/rules_test.go
+++ b/breaking/rules_test.go
@@ -1,0 +1,455 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package breaking_test
+
+import (
+	"testing"
+
+	"bennypowers.dev/cem/breaking"
+	M "bennypowers.dev/cem/manifest"
+	"github.com/stretchr/testify/assert"
+)
+
+func makeElements(elements ...*M.CustomElementDeclaration) map[string]*M.CustomElementDeclaration {
+	m := make(map[string]*M.CustomElementDeclaration)
+	for _, el := range elements {
+		m[el.TagName] = el
+	}
+	return m
+}
+
+func ced(tagName string, opts ...func(*M.CustomElementDeclaration)) *M.CustomElementDeclaration {
+	el := &M.CustomElementDeclaration{}
+	el.TagName = tagName
+	el.CustomElement.CustomElement = true // named field, can't simplify
+	for _, opt := range opts {
+		opt(el)
+	}
+	return el
+}
+
+func withAttributes(attrs ...M.Attribute) func(*M.CustomElementDeclaration) {
+	return func(el *M.CustomElementDeclaration) {
+		el.CustomElement.Attributes = attrs
+	}
+}
+
+func withSlots(slots ...M.Slot) func(*M.CustomElementDeclaration) {
+	return func(el *M.CustomElementDeclaration) {
+		el.CustomElement.Slots = slots
+	}
+}
+
+func withEvents(events ...M.Event) func(*M.CustomElementDeclaration) {
+	return func(el *M.CustomElementDeclaration) {
+		el.CustomElement.Events = events
+	}
+}
+
+func withCssProperties(props ...M.CssCustomProperty) func(*M.CustomElementDeclaration) {
+	return func(el *M.CustomElementDeclaration) {
+		el.CustomElement.CssProperties = props
+	}
+}
+
+func withCssParts(parts ...M.CssPart) func(*M.CustomElementDeclaration) {
+	return func(el *M.CustomElementDeclaration) {
+		el.CustomElement.CssParts = parts
+	}
+}
+
+func withCssStates(states ...M.CssCustomState) func(*M.CustomElementDeclaration) {
+	return func(el *M.CustomElementDeclaration) {
+		el.CustomElement.CssStates = states
+	}
+}
+
+func withMembers(members ...M.ClassMember) func(*M.CustomElementDeclaration) {
+	return func(el *M.CustomElementDeclaration) {
+		el.Members = members
+	}
+}
+
+func attr(name string, opts ...func(*M.Attribute)) M.Attribute {
+	a := M.Attribute{}
+	a.Name = name
+	for _, opt := range opts {
+		opt(&a)
+	}
+	return a
+}
+
+func withType(text string) func(*M.Attribute) {
+	return func(a *M.Attribute) {
+		a.Type = &M.Type{Text: text}
+	}
+}
+
+func withDefault(val string) func(*M.Attribute) {
+	return func(a *M.Attribute) {
+		a.Default = val
+	}
+}
+
+func slot(name string) M.Slot {
+	s := M.Slot{}
+	s.Name = name
+	return s
+}
+
+func event(name string, typeText ...string) M.Event {
+	e := M.Event{}
+	e.Name = name
+	if len(typeText) > 0 {
+		e.Type = &M.Type{Text: typeText[0]}
+	}
+	return e
+}
+
+func cssProp(name string, defaultVal ...string) M.CssCustomProperty {
+	p := M.CssCustomProperty{}
+	p.Name = name
+	if len(defaultVal) > 0 {
+		p.Default = defaultVal[0]
+	}
+	return p
+}
+
+func cssPart(name string) M.CssPart {
+	p := M.CssPart{}
+	p.Name = name
+	return p
+}
+
+func cssState(name string) M.CssCustomState {
+	s := M.CssCustomState{}
+	s.Name = name
+	return s
+}
+
+func method(name string, privacy M.Privacy, params []M.Parameter, ret *M.Return) *M.ClassMethod {
+	m := &M.ClassMethod{
+		Kind:    "method",
+		Privacy: privacy,
+	}
+	m.Name = name
+	m.Parameters = params
+	m.Return = ret
+	return m
+}
+
+func field(name string, privacy M.Privacy, typeText string) *M.ClassField {
+	f := &M.ClassField{
+		Kind:    "field",
+		Privacy: privacy,
+	}
+	f.Name = name
+	if typeText != "" {
+		f.Type = &M.Type{Text: typeText}
+	}
+	return f
+}
+
+func param(name string, typeText string) M.Parameter {
+	p := M.Parameter{}
+	p.Name = name
+	if typeText != "" {
+		p.Type = &M.Type{Text: typeText}
+	}
+	return p
+}
+
+func TestElementRules(t *testing.T) {
+	t.Run("element-removed", func(t *testing.T) {
+		base := makeElements(ced("my-element"))
+		head := makeElements()
+		rule := findRule("element-removed")
+		changes := rule.Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Breaking, changes[0].Severity)
+		assert.Equal(t, "my-element", changes[0].Element)
+	})
+
+	t.Run("element-added", func(t *testing.T) {
+		base := makeElements()
+		head := makeElements(ced("my-element"))
+		rule := findRule("element-added")
+		changes := rule.Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Safe, changes[0].Severity)
+		assert.Equal(t, "my-element", changes[0].Element)
+	})
+
+	t.Run("no changes", func(t *testing.T) {
+		base := makeElements(ced("my-element"))
+		head := makeElements(ced("my-element"))
+		removed := findRule("element-removed")
+		added := findRule("element-added")
+		assert.Empty(t, removed.Check(base, head))
+		assert.Empty(t, added.Check(base, head))
+	})
+}
+
+func TestAttributeRules(t *testing.T) {
+	t.Run("attribute-removed", func(t *testing.T) {
+		base := makeElements(ced("my-el", withAttributes(attr("variant"))))
+		head := makeElements(ced("my-el"))
+		changes := findRule("attribute-removed").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Breaking, changes[0].Severity)
+		assert.Equal(t, "variant", changes[0].Subject)
+	})
+
+	t.Run("attribute-added", func(t *testing.T) {
+		base := makeElements(ced("my-el"))
+		head := makeElements(ced("my-el", withAttributes(attr("color"))))
+		changes := findRule("attribute-added").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Safe, changes[0].Severity)
+	})
+
+	t.Run("attribute-type-changed", func(t *testing.T) {
+		base := makeElements(ced("my-el", withAttributes(attr("size", withType("string")))))
+		head := makeElements(ced("my-el", withAttributes(attr("size", withType("number")))))
+		changes := findRule("attribute-type-changed").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Breaking, changes[0].Severity)
+	})
+
+	t.Run("attribute-type-unchanged", func(t *testing.T) {
+		base := makeElements(ced("my-el", withAttributes(attr("size", withType("string")))))
+		head := makeElements(ced("my-el", withAttributes(attr("size", withType("string")))))
+		changes := findRule("attribute-type-changed").Check(base, head)
+		assert.Empty(t, changes)
+	})
+
+	t.Run("attribute-default-changed", func(t *testing.T) {
+		base := makeElements(ced("my-el", withAttributes(attr("size", withDefault(`"medium"`)))))
+		head := makeElements(ced("my-el", withAttributes(attr("size", withDefault(`"large"`)))))
+		changes := findRule("attribute-default-changed").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Dangerous, changes[0].Severity)
+	})
+
+	t.Run("skips removed element", func(t *testing.T) {
+		base := makeElements(ced("my-el", withAttributes(attr("variant"))))
+		head := makeElements()
+		assert.Empty(t, findRule("attribute-removed").Check(base, head))
+	})
+}
+
+func TestSlotRules(t *testing.T) {
+	t.Run("slot-removed", func(t *testing.T) {
+		base := makeElements(ced("my-el", withSlots(slot("header"))))
+		head := makeElements(ced("my-el"))
+		changes := findRule("slot-removed").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Breaking, changes[0].Severity)
+	})
+
+	t.Run("slot-added", func(t *testing.T) {
+		base := makeElements(ced("my-el"))
+		head := makeElements(ced("my-el", withSlots(slot("footer"))))
+		changes := findRule("slot-added").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Safe, changes[0].Severity)
+	})
+
+	t.Run("default slot removed", func(t *testing.T) {
+		base := makeElements(ced("my-el", withSlots(slot(""))))
+		head := makeElements(ced("my-el"))
+		changes := findRule("slot-removed").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Contains(t, changes[0].Message, "(default)")
+	})
+}
+
+func TestEventRules(t *testing.T) {
+	t.Run("event-removed", func(t *testing.T) {
+		base := makeElements(ced("my-el", withEvents(event("change"))))
+		head := makeElements(ced("my-el"))
+		changes := findRule("event-removed").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Breaking, changes[0].Severity)
+	})
+
+	t.Run("event-added", func(t *testing.T) {
+		base := makeElements(ced("my-el"))
+		head := makeElements(ced("my-el", withEvents(event("input"))))
+		changes := findRule("event-added").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Safe, changes[0].Severity)
+	})
+
+	t.Run("event-type-changed", func(t *testing.T) {
+		base := makeElements(ced("my-el", withEvents(event("change", "CustomEvent"))))
+		head := makeElements(ced("my-el", withEvents(event("change", "Event"))))
+		changes := findRule("event-type-changed").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Breaking, changes[0].Severity)
+	})
+}
+
+func TestCssRules(t *testing.T) {
+	t.Run("css-custom-property-removed", func(t *testing.T) {
+		base := makeElements(ced("my-el", withCssProperties(cssProp("--bg"))))
+		head := makeElements(ced("my-el"))
+		changes := findRule("css-custom-property-removed").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Breaking, changes[0].Severity)
+	})
+
+	t.Run("css-custom-property-added", func(t *testing.T) {
+		base := makeElements(ced("my-el"))
+		head := makeElements(ced("my-el", withCssProperties(cssProp("--color"))))
+		changes := findRule("css-custom-property-added").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Safe, changes[0].Severity)
+	})
+
+	t.Run("css-custom-property-default-changed", func(t *testing.T) {
+		base := makeElements(ced("my-el", withCssProperties(cssProp("--bg", "red"))))
+		head := makeElements(ced("my-el", withCssProperties(cssProp("--bg", "blue"))))
+		changes := findRule("css-custom-property-default-changed").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Dangerous, changes[0].Severity)
+	})
+
+	t.Run("css-part-removed", func(t *testing.T) {
+		base := makeElements(ced("my-el", withCssParts(cssPart("button"))))
+		head := makeElements(ced("my-el"))
+		changes := findRule("css-part-removed").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Breaking, changes[0].Severity)
+	})
+
+	t.Run("css-part-added", func(t *testing.T) {
+		base := makeElements(ced("my-el"))
+		head := makeElements(ced("my-el", withCssParts(cssPart("icon"))))
+		changes := findRule("css-part-added").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Safe, changes[0].Severity)
+	})
+
+	t.Run("css-state-removed", func(t *testing.T) {
+		base := makeElements(ced("my-el", withCssStates(cssState("active"))))
+		head := makeElements(ced("my-el"))
+		changes := findRule("css-state-removed").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Breaking, changes[0].Severity)
+	})
+
+	t.Run("css-state-added", func(t *testing.T) {
+		base := makeElements(ced("my-el"))
+		head := makeElements(ced("my-el", withCssStates(cssState("focused"))))
+		changes := findRule("css-state-added").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Safe, changes[0].Severity)
+	})
+}
+
+func TestMemberRules(t *testing.T) {
+	t.Run("method-removed", func(t *testing.T) {
+		base := makeElements(ced("my-el", withMembers(method("doStuff", M.Public, nil, nil))))
+		head := makeElements(ced("my-el"))
+		changes := findRule("method-removed").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Breaking, changes[0].Severity)
+	})
+
+	t.Run("private method removed is not breaking", func(t *testing.T) {
+		base := makeElements(ced("my-el", withMembers(method("_internal", M.Private, nil, nil))))
+		head := makeElements(ced("my-el"))
+		changes := findRule("method-removed").Check(base, head)
+		assert.Empty(t, changes)
+	})
+
+	t.Run("method-added", func(t *testing.T) {
+		base := makeElements(ced("my-el"))
+		head := makeElements(ced("my-el", withMembers(method("doStuff", M.Public, nil, nil))))
+		changes := findRule("method-added").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Safe, changes[0].Severity)
+	})
+
+	t.Run("method-return-type-changed", func(t *testing.T) {
+		base := makeElements(ced("my-el", withMembers(
+			method("getValue", M.Public, nil, &M.Return{Type: &M.Type{Text: "string"}}),
+		)))
+		head := makeElements(ced("my-el", withMembers(
+			method("getValue", M.Public, nil, &M.Return{Type: &M.Type{Text: "number"}}),
+		)))
+		changes := findRule("method-return-type-changed").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Breaking, changes[0].Severity)
+	})
+
+	t.Run("method-parameter-changed", func(t *testing.T) {
+		base := makeElements(ced("my-el", withMembers(
+			method("doStuff", M.Public, []M.Parameter{param("name", "string")}, nil),
+		)))
+		head := makeElements(ced("my-el", withMembers(
+			method("doStuff", M.Public, []M.Parameter{param("name", "string"), param("value", "number")}, nil),
+		)))
+		changes := findRule("method-parameter-changed").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Breaking, changes[0].Severity)
+	})
+
+	t.Run("return-type-only change does not trigger parameter-changed", func(t *testing.T) {
+		base := makeElements(ced("my-el", withMembers(
+			method("doStuff", M.Public, []M.Parameter{param("name", "string")}, &M.Return{Type: &M.Type{Text: "void"}}),
+		)))
+		head := makeElements(ced("my-el", withMembers(
+			method("doStuff", M.Public, []M.Parameter{param("name", "string")}, &M.Return{Type: &M.Type{Text: "Promise<void>"}}),
+		)))
+		changes := findRule("method-parameter-changed").Check(base, head)
+		assert.Empty(t, changes)
+	})
+
+	t.Run("field-removed", func(t *testing.T) {
+		base := makeElements(ced("my-el", withMembers(field("value", M.Public, "string"))))
+		head := makeElements(ced("my-el"))
+		changes := findRule("field-removed").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Breaking, changes[0].Severity)
+	})
+
+	t.Run("field-type-changed", func(t *testing.T) {
+		base := makeElements(ced("my-el", withMembers(field("value", M.Public, "string"))))
+		head := makeElements(ced("my-el", withMembers(field("value", M.Public, "number"))))
+		changes := findRule("field-type-changed").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Dangerous, changes[0].Severity)
+	})
+
+	t.Run("private field removed is not breaking", func(t *testing.T) {
+		base := makeElements(ced("my-el", withMembers(field("_data", M.Private, "string"))))
+		head := makeElements(ced("my-el"))
+		changes := findRule("field-removed").Check(base, head)
+		assert.Empty(t, changes)
+	})
+}
+
+func findRule(id string) breaking.BreakingRule {
+	for _, r := range breaking.AllRules() {
+		if r.ID() == id {
+			return r
+		}
+	}
+	panic("rule not found: " + id)
+}

--- a/breaking/rules_test.go
+++ b/breaking/rules_test.go
@@ -173,6 +173,7 @@ func param(name string, typeText string) M.Parameter {
 	return p
 }
 
+// Tier 1 pure-function tests: inline assertions validate individual rule logic
 func TestElementRules(t *testing.T) {
 	t.Run("element-removed", func(t *testing.T) {
 		base := makeElements(ced("my-element"))
@@ -419,6 +420,14 @@ func TestMemberRules(t *testing.T) {
 		)))
 		changes := findRule("method-parameter-changed").Check(base, head)
 		assert.Empty(t, changes)
+	})
+
+	t.Run("field-added", func(t *testing.T) {
+		base := makeElements(ced("my-el"))
+		head := makeElements(ced("my-el", withMembers(field("value", M.Public, "string"))))
+		changes := findRule("field-added").Check(base, head)
+		assert.Len(t, changes, 1)
+		assert.Equal(t, breaking.Safe, changes[0].Severity)
 	})
 
 	t.Run("field-removed", func(t *testing.T) {

--- a/breaking/rules_test.go
+++ b/breaking/rules_test.go
@@ -173,7 +173,7 @@ func param(name string, typeText string) M.Parameter {
 	return p
 }
 
-// Tier 1 pure-function tests: inline assertions validate individual rule logic
+// Tier 1: inline assertions on pure rule logic
 func TestElementRules(t *testing.T) {
 	t.Run("element-removed", func(t *testing.T) {
 		base := makeElements(ced("my-element"))
@@ -205,6 +205,7 @@ func TestElementRules(t *testing.T) {
 	})
 }
 
+// Tier 1: inline assertions on pure rule logic
 func TestAttributeRules(t *testing.T) {
 	t.Run("attribute-removed", func(t *testing.T) {
 		base := makeElements(ced("my-el", withAttributes(attr("variant"))))
@@ -253,6 +254,7 @@ func TestAttributeRules(t *testing.T) {
 	})
 }
 
+// Tier 1: inline assertions on pure rule logic
 func TestSlotRules(t *testing.T) {
 	t.Run("slot-removed", func(t *testing.T) {
 		base := makeElements(ced("my-el", withSlots(slot("header"))))
@@ -279,6 +281,7 @@ func TestSlotRules(t *testing.T) {
 	})
 }
 
+// Tier 1: inline assertions on pure rule logic
 func TestEventRules(t *testing.T) {
 	t.Run("event-removed", func(t *testing.T) {
 		base := makeElements(ced("my-el", withEvents(event("change"))))
@@ -305,6 +308,7 @@ func TestEventRules(t *testing.T) {
 	})
 }
 
+// Tier 1: inline assertions on pure rule logic
 func TestCssRules(t *testing.T) {
 	t.Run("css-custom-property-removed", func(t *testing.T) {
 		base := makeElements(ced("my-el", withCssProperties(cssProp("--bg"))))
@@ -363,6 +367,7 @@ func TestCssRules(t *testing.T) {
 	})
 }
 
+// Tier 1: inline assertions on pure rule logic
 func TestMemberRules(t *testing.T) {
 	t.Run("method-removed", func(t *testing.T) {
 		base := makeElements(ced("my-el", withMembers(method("doStuff", M.Public, nil, nil))))

--- a/breaking/templates/report.md.tmpl
+++ b/breaking/templates/report.md.tmpl
@@ -16,7 +16,7 @@ No breaking changes detected.
 | Element | Change |
 |---------|--------|
 {{- range $items}}
-| `<{{.Element}}>` | {{.Message}} |
+| `<{{.Element}}>` | {{escapeCell .Message}} |
 {{- end}}
 {{- end}}{{end}}
 {{- end}}

--- a/breaking/templates/report.md.tmpl
+++ b/breaking/templates/report.md.tmpl
@@ -1,0 +1,22 @@
+### Breaking Change Report
+{{- if not .Changes}}
+
+No breaking changes detected.
+{{- else}}
+
+| Severity | Count |
+|----------|------:|
+| Breaking | {{.Breaking}} |
+| Dangerous | {{.Dangerous}} |
+| Safe | {{.Safe}} |
+{{- range $sev := severities}}{{$items := filterBySeverity $.Changes $sev}}{{if $items}}
+
+#### {{severityTitle $sev}} ({{len $items}})
+
+| Element | Change |
+|---------|--------|
+{{- range $items}}
+| `<{{.Element}}>` | {{.Message}} |
+{{- end}}
+{{- end}}{{end}}
+{{- end}}

--- a/breaking/testdata/fixtures/attribute-changes/base.json
+++ b/breaking/testdata/fixtures/attribute-changes/base.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "customElement": true,
+          "tagName": "my-element",
+          "name": "MyElement",
+          "attributes": [
+            { "name": "variant", "type": { "text": "string" }, "default": "\"primary\"" },
+            { "name": "size", "type": { "text": "string" }, "default": "\"medium\"" },
+            { "name": "disabled", "type": { "text": "boolean" } }
+          ]
+        }
+      ],
+      "exports": []
+    }
+  ]
+}

--- a/breaking/testdata/fixtures/attribute-changes/head.json
+++ b/breaking/testdata/fixtures/attribute-changes/head.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "customElement": true,
+          "tagName": "my-element",
+          "name": "MyElement",
+          "attributes": [
+            { "name": "size", "type": { "text": "number" }, "default": "\"large\"" },
+            { "name": "disabled", "type": { "text": "boolean" } },
+            { "name": "color", "type": { "text": "string" } }
+          ]
+        }
+      ],
+      "exports": []
+    }
+  ]
+}

--- a/breaking/testdata/fixtures/element-removed/base.json
+++ b/breaking/testdata/fixtures/element-removed/base.json
@@ -1,0 +1,37 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "customElement": true,
+          "tagName": "my-element",
+          "name": "MyElement",
+          "attributes": [
+            { "name": "variant", "type": { "text": "string" } }
+          ],
+          "slots": [
+            { "name": "", "description": "Default slot" }
+          ]
+        }
+      ],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/other-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "customElement": true,
+          "tagName": "other-element",
+          "name": "OtherElement"
+        }
+      ],
+      "exports": []
+    }
+  ]
+}

--- a/breaking/testdata/fixtures/element-removed/head.json
+++ b/breaking/testdata/fixtures/element-removed/head.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/other-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "customElement": true,
+          "tagName": "other-element",
+          "name": "OtherElement"
+        }
+      ],
+      "exports": []
+    }
+  ]
+}

--- a/breaking/testdata/fixtures/mixed-changes/base.json
+++ b/breaking/testdata/fixtures/mixed-changes/base.json
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "customElement": true,
+          "tagName": "my-element",
+          "name": "MyElement",
+          "attributes": [
+            { "name": "variant", "type": { "text": "string" } }
+          ],
+          "slots": [
+            { "name": "header" },
+            { "name": "" }
+          ],
+          "events": [
+            { "name": "change", "type": { "text": "CustomEvent" } }
+          ],
+          "cssProperties": [
+            { "name": "--bg-color", "default": "white" }
+          ],
+          "cssParts": [
+            { "name": "button" }
+          ],
+          "members": [
+            {
+              "kind": "method",
+              "name": "doStuff",
+              "privacy": "public",
+              "parameters": [
+                { "name": "name", "type": { "text": "string" } }
+              ],
+              "return": { "type": { "text": "void" } }
+            },
+            {
+              "kind": "field",
+              "name": "value",
+              "privacy": "public",
+              "type": { "text": "string" }
+            }
+          ]
+        }
+      ],
+      "exports": []
+    }
+  ]
+}

--- a/breaking/testdata/fixtures/mixed-changes/head.json
+++ b/breaking/testdata/fixtures/mixed-changes/head.json
@@ -1,0 +1,73 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "customElement": true,
+          "tagName": "my-element",
+          "name": "MyElement",
+          "attributes": [
+            { "name": "variant", "type": { "text": "string" } },
+            { "name": "color", "type": { "text": "string" } }
+          ],
+          "slots": [
+            { "name": "" }
+          ],
+          "events": [
+            { "name": "change", "type": { "text": "Event" } },
+            { "name": "input", "type": { "text": "InputEvent" } }
+          ],
+          "cssProperties": [
+            { "name": "--bg-color", "default": "black" },
+            { "name": "--text-color" }
+          ],
+          "cssParts": [
+            { "name": "button" },
+            { "name": "icon" }
+          ],
+          "members": [
+            {
+              "kind": "method",
+              "name": "doStuff",
+              "privacy": "public",
+              "parameters": [
+                { "name": "name", "type": { "text": "string" } },
+                { "name": "value", "type": { "text": "number" } }
+              ],
+              "return": { "type": { "text": "Promise<void>" } }
+            },
+            {
+              "kind": "field",
+              "name": "value",
+              "privacy": "public",
+              "type": { "text": "number" }
+            },
+            {
+              "kind": "method",
+              "name": "reset",
+              "privacy": "public"
+            }
+          ]
+        }
+      ],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/new-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "customElement": true,
+          "tagName": "new-element",
+          "name": "NewElement"
+        }
+      ],
+      "exports": []
+    }
+  ]
+}

--- a/breaking/testdata/fixtures/no-changes/base.json
+++ b/breaking/testdata/fixtures/no-changes/base.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "customElement": true,
+          "tagName": "my-element",
+          "name": "MyElement",
+          "attributes": [
+            { "name": "variant", "type": { "text": "string" } }
+          ]
+        }
+      ],
+      "exports": []
+    }
+  ]
+}

--- a/breaking/testdata/fixtures/no-changes/head.json
+++ b/breaking/testdata/fixtures/no-changes/head.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "2.1.0",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "src/my-element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "customElement": true,
+          "tagName": "my-element",
+          "name": "MyElement",
+          "attributes": [
+            { "name": "variant", "type": { "text": "string" } }
+          ]
+        }
+      ],
+      "exports": []
+    }
+  ]
+}

--- a/breaking/testdata/goldens/attribute-changes.json
+++ b/breaking/testdata/goldens/attribute-changes.json
@@ -1,0 +1,35 @@
+{
+  "changes": [
+    {
+      "rule": "attribute-removed",
+      "severity": "breaking",
+      "element": "my-element",
+      "subject": "variant",
+      "message": "attribute \"variant\" removed from \u003cmy-element\u003e"
+    },
+    {
+      "rule": "attribute-type-changed",
+      "severity": "breaking",
+      "element": "my-element",
+      "subject": "size",
+      "message": "attribute \"size\" type changed from string to number in \u003cmy-element\u003e"
+    },
+    {
+      "rule": "attribute-default-changed",
+      "severity": "dangerous",
+      "element": "my-element",
+      "subject": "size",
+      "message": "attribute \"size\" default changed from \"medium\" to \"large\" in \u003cmy-element\u003e"
+    },
+    {
+      "rule": "attribute-added",
+      "severity": "safe",
+      "element": "my-element",
+      "subject": "color",
+      "message": "attribute \"color\" added to \u003cmy-element\u003e"
+    }
+  ],
+  "breaking": 2,
+  "dangerous": 1,
+  "safe": 1
+}

--- a/breaking/testdata/goldens/element-removed.json
+++ b/breaking/testdata/goldens/element-removed.json
@@ -1,0 +1,13 @@
+{
+  "changes": [
+    {
+      "rule": "element-removed",
+      "severity": "breaking",
+      "element": "my-element",
+      "message": "element \u003cmy-element\u003e removed"
+    }
+  ],
+  "breaking": 1,
+  "dangerous": 0,
+  "safe": 0
+}

--- a/breaking/testdata/goldens/markdown-attribute-changes.md
+++ b/breaking/testdata/goldens/markdown-attribute-changes.md
@@ -1,0 +1,26 @@
+### Breaking Change Report
+
+| Severity | Count |
+|----------|------:|
+| Breaking | 2 |
+| Dangerous | 1 |
+| Safe | 1 |
+
+#### Breaking (2)
+
+| Element | Change |
+|---------|--------|
+| `<my-element>` | attribute "variant" removed from <my-element> |
+| `<my-element>` | attribute "size" type changed from string to number in <my-element> |
+
+#### Dangerous (1)
+
+| Element | Change |
+|---------|--------|
+| `<my-element>` | attribute "size" default changed from "medium" to "large" in <my-element> |
+
+#### Safe (1)
+
+| Element | Change |
+|---------|--------|
+| `<my-element>` | attribute "color" added to <my-element> |

--- a/breaking/testdata/goldens/markdown-element-removed.md
+++ b/breaking/testdata/goldens/markdown-element-removed.md
@@ -1,0 +1,13 @@
+### Breaking Change Report
+
+| Severity | Count |
+|----------|------:|
+| Breaking | 1 |
+| Dangerous | 0 |
+| Safe | 0 |
+
+#### Breaking (1)
+
+| Element | Change |
+|---------|--------|
+| `<my-element>` | element <my-element> removed |

--- a/breaking/testdata/goldens/markdown-mixed-changes.md
+++ b/breaking/testdata/goldens/markdown-mixed-changes.md
@@ -1,0 +1,34 @@
+### Breaking Change Report
+
+| Severity | Count |
+|----------|------:|
+| Breaking | 4 |
+| Dangerous | 2 |
+| Safe | 6 |
+
+#### Breaking (4)
+
+| Element | Change |
+|---------|--------|
+| `<my-element>` | event "change" type changed from CustomEvent to Event in <my-element> |
+| `<my-element>` | method "doStuff" parameters changed from (name: string) to (name: string, value: number) in <my-element> |
+| `<my-element>` | method "doStuff" return type changed from void to Promise<void> in <my-element> |
+| `<my-element>` | slot "header" removed from <my-element> |
+
+#### Dangerous (2)
+
+| Element | Change |
+|---------|--------|
+| `<my-element>` | CSS custom property "--bg-color" default changed from white to black in <my-element> |
+| `<my-element>` | field "value" type changed from string to number in <my-element> |
+
+#### Safe (6)
+
+| Element | Change |
+|---------|--------|
+| `<my-element>` | attribute "color" added to <my-element> |
+| `<my-element>` | CSS custom property "--text-color" added to <my-element> |
+| `<my-element>` | CSS part "icon" added to <my-element> |
+| `<my-element>` | event "input" added to <my-element> |
+| `<my-element>` | method "reset" added to <my-element> |
+| `<new-element>` | element <new-element> added |

--- a/breaking/testdata/goldens/markdown-mixed-changes.md
+++ b/breaking/testdata/goldens/markdown-mixed-changes.md
@@ -11,7 +11,7 @@
 | Element | Change |
 |---------|--------|
 | `<my-element>` | event "change" type changed from CustomEvent to Event in <my-element> |
-| `<my-element>` | method "doStuff" parameters changed from (name: string) to (name: string, value: number) in <my-element> |
+| `<my-element>` | method "doStuff" parameters changed from (string) to (string, number) in <my-element> |
 | `<my-element>` | method "doStuff" return type changed from void to Promise<void> in <my-element> |
 | `<my-element>` | slot "header" removed from <my-element> |
 

--- a/breaking/testdata/goldens/markdown-no-changes.md
+++ b/breaking/testdata/goldens/markdown-no-changes.md
@@ -1,0 +1,3 @@
+### Breaking Change Report
+
+No breaking changes detected.

--- a/breaking/testdata/goldens/mixed-changes.json
+++ b/breaking/testdata/goldens/mixed-changes.json
@@ -1,0 +1,90 @@
+{
+  "changes": [
+    {
+      "rule": "event-type-changed",
+      "severity": "breaking",
+      "element": "my-element",
+      "subject": "change",
+      "message": "event \"change\" type changed from CustomEvent to Event in \u003cmy-element\u003e"
+    },
+    {
+      "rule": "method-parameter-changed",
+      "severity": "breaking",
+      "element": "my-element",
+      "subject": "doStuff",
+      "message": "method \"doStuff\" parameters changed from (name: string) to (name: string, value: number) in \u003cmy-element\u003e"
+    },
+    {
+      "rule": "method-return-type-changed",
+      "severity": "breaking",
+      "element": "my-element",
+      "subject": "doStuff",
+      "message": "method \"doStuff\" return type changed from void to Promise\u003cvoid\u003e in \u003cmy-element\u003e"
+    },
+    {
+      "rule": "slot-removed",
+      "severity": "breaking",
+      "element": "my-element",
+      "subject": "header",
+      "message": "slot \"header\" removed from \u003cmy-element\u003e"
+    },
+    {
+      "rule": "css-custom-property-default-changed",
+      "severity": "dangerous",
+      "element": "my-element",
+      "subject": "--bg-color",
+      "message": "CSS custom property \"--bg-color\" default changed from white to black in \u003cmy-element\u003e"
+    },
+    {
+      "rule": "field-type-changed",
+      "severity": "dangerous",
+      "element": "my-element",
+      "subject": "value",
+      "message": "field \"value\" type changed from string to number in \u003cmy-element\u003e"
+    },
+    {
+      "rule": "attribute-added",
+      "severity": "safe",
+      "element": "my-element",
+      "subject": "color",
+      "message": "attribute \"color\" added to \u003cmy-element\u003e"
+    },
+    {
+      "rule": "css-custom-property-added",
+      "severity": "safe",
+      "element": "my-element",
+      "subject": "--text-color",
+      "message": "CSS custom property \"--text-color\" added to \u003cmy-element\u003e"
+    },
+    {
+      "rule": "css-part-added",
+      "severity": "safe",
+      "element": "my-element",
+      "subject": "icon",
+      "message": "CSS part \"icon\" added to \u003cmy-element\u003e"
+    },
+    {
+      "rule": "event-added",
+      "severity": "safe",
+      "element": "my-element",
+      "subject": "input",
+      "message": "event \"input\" added to \u003cmy-element\u003e"
+    },
+    {
+      "rule": "method-added",
+      "severity": "safe",
+      "element": "my-element",
+      "subject": "reset",
+      "message": "method \"reset\" added to \u003cmy-element\u003e"
+    },
+    {
+      "rule": "element-added",
+      "severity": "safe",
+      "element": "new-element",
+      "message": "element \u003cnew-element\u003e added"
+    }
+  ],
+  "breaking": 4,
+  "dangerous": 2,
+  "safe": 6
+}

--- a/breaking/testdata/goldens/mixed-changes.json
+++ b/breaking/testdata/goldens/mixed-changes.json
@@ -12,7 +12,7 @@
       "severity": "breaking",
       "element": "my-element",
       "subject": "doStuff",
-      "message": "method \"doStuff\" parameters changed from (name: string) to (name: string, value: number) in \u003cmy-element\u003e"
+      "message": "method \"doStuff\" parameters changed from (string) to (string, number) in \u003cmy-element\u003e"
     },
     {
       "rule": "method-return-type-changed",

--- a/breaking/testdata/goldens/no-changes.json
+++ b/breaking/testdata/goldens/no-changes.json
@@ -1,0 +1,6 @@
+{
+  "changes": null,
+  "breaking": 0,
+  "dangerous": 0,
+  "safe": 0
+}

--- a/breaking/testdata/goldens/text-attribute-changes.txt
+++ b/breaking/testdata/goldens/text-attribute-changes.txt
@@ -1,0 +1,10 @@
+Breaking Changes (2)
+  ✗ attribute "variant" removed from <my-element>
+  ✗ attribute "size" type changed from string to number in <my-element>
+
+Dangerous Changes (1)
+  ⚠ attribute "size" default changed from "medium" to "large" in <my-element>
+
+Safe Changes (1)
+  ✓ attribute "color" added to <my-element>
+

--- a/breaking/testdata/goldens/text-element-removed.txt
+++ b/breaking/testdata/goldens/text-element-removed.txt
@@ -1,0 +1,3 @@
+Breaking Changes (1)
+  ✗ element <my-element> removed
+

--- a/breaking/testdata/goldens/text-mixed-changes.txt
+++ b/breaking/testdata/goldens/text-mixed-changes.txt
@@ -1,0 +1,18 @@
+Breaking Changes (4)
+  ✗ event "change" type changed from CustomEvent to Event in <my-element>
+  ✗ method "doStuff" parameters changed from (name: string) to (name: string, value: number) in <my-element>
+  ✗ method "doStuff" return type changed from void to Promise<void> in <my-element>
+  ✗ slot "header" removed from <my-element>
+
+Dangerous Changes (2)
+  ⚠ CSS custom property "--bg-color" default changed from white to black in <my-element>
+  ⚠ field "value" type changed from string to number in <my-element>
+
+Safe Changes (6)
+  ✓ attribute "color" added to <my-element>
+  ✓ CSS custom property "--text-color" added to <my-element>
+  ✓ CSS part "icon" added to <my-element>
+  ✓ event "input" added to <my-element>
+  ✓ method "reset" added to <my-element>
+  ✓ element <new-element> added
+

--- a/breaking/testdata/goldens/text-mixed-changes.txt
+++ b/breaking/testdata/goldens/text-mixed-changes.txt
@@ -1,6 +1,6 @@
 Breaking Changes (4)
   ✗ event "change" type changed from CustomEvent to Event in <my-element>
-  ✗ method "doStuff" parameters changed from (name: string) to (name: string, value: number) in <my-element>
+  ✗ method "doStuff" parameters changed from (string) to (string, number) in <my-element>
   ✗ method "doStuff" return type changed from void to Promise<void> in <my-element>
   ✗ slot "header" removed from <my-element>
 

--- a/breaking/testdata/goldens/text-no-changes.txt
+++ b/breaking/testdata/goldens/text-no-changes.txt
@@ -1,0 +1,1 @@
+No breaking changes detected

--- a/cmd/breaking.go
+++ b/cmd/breaking.go
@@ -47,7 +47,15 @@ in component APIs. Changes are classified as breaking, dangerous, or safe.
 When given two file arguments, compares them directly. When given --base
 (and optionally --head), resolves manifests from git refs. With no arguments,
 auto-detects the baseline from the latest semver tag.`,
-	Args:         cobra.MaximumNArgs(2),
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 1 {
+			return fmt.Errorf("expected 0 or 2 manifest files, got 1")
+		}
+		if len(args) > 2 {
+			return fmt.Errorf("expected at most 2 manifest files, got %d", len(args))
+		}
+		return nil
+	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		format, _ := cmd.Flags().GetString("format")
@@ -67,6 +75,16 @@ auto-detects the baseline from the latest semver tag.`,
 		allDisabled := make([]string, 0, len(configDisabled)+len(disableFlags))
 		allDisabled = append(allDisabled, configDisabled...)
 		allDisabled = append(allDisabled, disableFlags...)
+
+		validRules := make(map[string]bool)
+		for _, r := range breaking.AllRules() {
+			validRules[r.ID()] = true
+		}
+		for _, id := range allDisabled {
+			if !validRules[id] {
+				return fmt.Errorf("unknown breaking rule %q; run 'cem breaking --help' for available rules", id)
+			}
+		}
 
 		var basePkg, headPkg *M.Package
 		var err error

--- a/cmd/breaking.go
+++ b/cmd/breaking.go
@@ -1,0 +1,156 @@
+/*
+Copyright © 2026 Benny Powers <web@bennypowers.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"bennypowers.dev/cem/breaking"
+	"bennypowers.dev/cem/internal/logging"
+	"bennypowers.dev/cem/internal/platform"
+	"bennypowers.dev/cem/internal/workspace"
+	M "bennypowers.dev/cem/manifest"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func init() {
+	breakingCmd.Flags().String("base", "", "Git ref for baseline (default: latest semver tag)")
+	breakingCmd.Flags().String("head", "", "Git ref for head (default: working tree manifest)")
+	breakingCmd.Flags().String("format", "text", "Output format: text, json, or markdown")
+	breakingCmd.Flags().String("fail-on", "", "Exit 1 if changes at this severity or above: breaking or dangerous")
+	breakingCmd.Flags().StringArray("disable", []string{}, "Disable specific breaking change rules (can be repeated)")
+	rootCmd.AddCommand(breakingCmd)
+}
+
+var breakingCmd = &cobra.Command{
+	Use:   "breaking [old-manifest.json new-manifest.json]",
+	Short: "Detect breaking API changes between two custom-elements manifests",
+	Long: `Compare two custom-elements.json manifests and detect breaking changes
+in component APIs. Changes are classified as breaking, dangerous, or safe.
+
+When given two file arguments, compares them directly. When given --base
+(and optionally --head), resolves manifests from git refs. With no arguments,
+auto-detects the baseline from the latest semver tag.`,
+	Args:         cobra.MaximumNArgs(2),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		format, _ := cmd.Flags().GetString("format")
+		switch format {
+		case "text", "json", "markdown":
+		default:
+			return fmt.Errorf("invalid format %q: must be text, json, or markdown", format)
+		}
+
+		failOn, _ := cmd.Flags().GetString("fail-on")
+		if failOn != "" && failOn != "breaking" && failOn != "dangerous" {
+			return fmt.Errorf("invalid --fail-on value %q: must be breaking or dangerous", failOn)
+		}
+
+		disableFlags, _ := cmd.Flags().GetStringArray("disable")
+		configDisabled := viper.GetStringSlice("breaking.disable")
+		allDisabled := make([]string, 0, len(configDisabled)+len(disableFlags))
+		allDisabled = append(allDisabled, configDisabled...)
+		allDisabled = append(allDisabled, disableFlags...)
+
+		var basePkg, headPkg *M.Package
+		var err error
+
+		fsys := platform.NewOSFileSystem()
+
+		switch {
+		case len(args) == 2:
+			basePkg, err = loadManifestFile(fsys, args[0])
+			if err != nil {
+				return fmt.Errorf("failed to load base manifest: %w", err)
+			}
+			headPkg, err = loadManifestFile(fsys, args[1])
+			if err != nil {
+				return fmt.Errorf("failed to load head manifest: %w", err)
+			}
+
+		default:
+			ctx, err := workspace.GetWorkspaceContext(cmd)
+			if err != nil {
+				return err
+			}
+			manifestPath := ctx.CustomElementsManifestPath()
+			if manifestPath == "" {
+				return fmt.Errorf("could not find custom-elements.json")
+			}
+			workDir := ctx.Root()
+
+			baseRef, _ := cmd.Flags().GetString("base")
+			headRef, _ := cmd.Flags().GetString("head")
+
+			if baseRef == "" {
+				baseRef, err = breaking.FindLatestSemverTag(workDir)
+				if err != nil {
+					return fmt.Errorf("no --base specified and %w; provide --base or pass two manifest files", err)
+				}
+				logging.Info("Using baseline: %s", baseRef)
+			}
+
+			basePkg, err = breaking.ResolveManifestFromGit(baseRef, manifestPath, workDir)
+			if err != nil {
+				return err
+			}
+
+			if headRef != "" {
+				headPkg, err = breaking.ResolveManifestFromGit(headRef, manifestPath, workDir)
+				if err != nil {
+					return err
+				}
+			} else {
+				headPkg, err = loadManifestFile(fsys, manifestPath)
+				if err != nil {
+					return fmt.Errorf("failed to load current manifest: %w", err)
+				}
+			}
+		}
+
+		result := breaking.Compare(basePkg, headPkg, breaking.Options{
+			Disable: allDisabled,
+		})
+
+		if err := breaking.PrintResult(cmd.OutOrStdout(), result, breaking.DisplayOptions{Format: format}); err != nil {
+			return err
+		}
+
+		if failOn == "breaking" && result.Breaking > 0 {
+			return fmt.Errorf("%d breaking change(s) detected", result.Breaking)
+		}
+		if failOn == "dangerous" && (result.Breaking > 0 || result.Dangerous > 0) {
+			return fmt.Errorf("%d breaking and %d dangerous change(s) detected", result.Breaking, result.Dangerous)
+		}
+
+		return nil
+	},
+}
+
+func loadManifestFile(fsys platform.FileSystem, path string) (*M.Package, error) {
+	data, err := fsys.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var pkg M.Package
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return nil, fmt.Errorf("failed to parse manifest %s: %w", path, err)
+	}
+	return &pkg, nil
+}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -36,6 +36,7 @@ type DemosConfig = IC.DemosConfig
 type URLRewrite = IC.URLRewrite
 type FrameworkExportConfig = IC.FrameworkExportConfig
 type HealthConfig = IC.HealthConfig
+type BreakingConfig = IC.BreakingConfig
 
 // Validate validates the configuration and returns an error if invalid.
 func Validate(c *CemConfig) error {

--- a/cmd/config_init.go
+++ b/cmd/config_init.go
@@ -413,6 +413,30 @@ func runConfigInit(cmd *cobra.Command, args []string) error {
 		failBelowFV.gate = func() bool { return configureHealth }
 		groups = append(groups, failBelowFV.Groups()...)
 
+		// === Breaking ===
+		existingBreakingDisable := ""
+		if len(cfg.Breaking.Disable) > 0 {
+			existingBreakingDisable = strings.Join(cfg.Breaking.Disable, ", ")
+		}
+		breakingDisableFV := fieldValue{
+			Title: "Disabled breaking change rules",
+			Description: "Comma-separated list of rule IDs to skip when running `cem breaking`.\n" +
+				"Examples: element-removed, attribute-removed, css-custom-property-removed",
+			Existing: existingBreakingDisable,
+		}
+		configureBreaking := len(cfg.Breaking.Disable) > 0
+		groups = append(groups, huh.NewGroup(
+			huh.NewConfirm().
+				Title("Do you want to configure breaking change detection?").
+				Value(&configureBreaking),
+		).Title("Breaking Changes").
+			Description("CEM detects breaking API changes between manifest versions.\n"+
+				"You can disable specific rules here.\n"+
+				"Learn more: https://bennypowers.dev/cem/docs/reference/configuration/"))
+
+		breakingDisableFV.gate = func() bool { return configureBreaking }
+		groups = append(groups, breakingDisableFV.Groups()...)
+
 		// === Export ===
 		configureExport := len(cfg.Export) > 0
 		groups = append(groups, huh.NewGroup(
@@ -642,6 +666,20 @@ func runConfigInit(cmd *cobra.Command, args []string) error {
 					return fmt.Errorf("invalid health score %d: must be 0-100", v)
 				}
 				cfg.Health.FailBelow = v
+			}
+		}
+
+		if configureBreaking {
+			bd := breakingDisableFV.Resolve()
+			if bd != "" {
+				var rules []string
+				for r := range strings.SplitSeq(bd, ",") {
+					r = strings.TrimSpace(r)
+					if r != "" {
+						rules = append(rules, r)
+					}
+				}
+				cfg.Breaking.Disable = rules
 			}
 		}
 

--- a/docs/content/docs/reference/commands/breaking.md
+++ b/docs/content/docs/reference/commands/breaking.md
@@ -1,0 +1,127 @@
+---
+title: Breaking
+description: Detect breaking API changes between two custom-elements manifests
+---
+
+{{< tip >}}
+**TL;DR**: Run `cem breaking` to detect breaking API changes between manifest versions. Use `--fail-on breaking` in CI to block breaking changes, `--format markdown` for PR comments.
+{{< /tip >}}
+
+The `cem breaking` command compares two `custom-elements.json` manifests and detects breaking changes in component APIs. Changes are classified as **breaking**, **dangerous**, or **safe**.
+
+```bash
+cem breaking [old-manifest.json new-manifest.json] [flags]
+```
+
+## Options
+
+| Flag | Type | Description |
+| ---- | ---- | ----------- |
+| `--base` | string | Git ref for baseline (default: latest semver tag) |
+| `--head` | string | Git ref for head (default: working tree manifest) |
+| `--format` | string | Output format: `text` (default), `json`, or `markdown` |
+| `--fail-on` | string | Exit 1 if changes at this severity or above: `breaking` or `dangerous` |
+| `--disable` | string (repeatable) | Disable specific breaking change rules |
+| `--package`, `-p` | string | Path to a package directory |
+
+## Severity Classification
+
+| Severity | Meaning | Examples |
+|----------|---------|----------|
+| **Breaking** | Downstream consumers will break | Removed element, removed attribute, changed type |
+| **Dangerous** | May break depending on usage | Changed default value, narrowed type |
+| **Safe** | Non-breaking additions | New element, new attribute, new slot |
+
+## Detection Rules
+
+| Rule ID | Severity | Detects |
+|---------|----------|---------|
+| `element-removed` | Breaking | Tag name removed from manifest |
+| `element-added` | Safe | New tag name added |
+| `attribute-removed` | Breaking | Attribute removed from element |
+| `attribute-added` | Safe | New attribute added |
+| `attribute-type-changed` | Breaking | Attribute type changed |
+| `attribute-default-changed` | Dangerous | Attribute default value changed |
+| `slot-removed` | Breaking | Named slot removed |
+| `slot-added` | Safe | New slot added |
+| `css-custom-property-removed` | Breaking | CSS custom property removed |
+| `css-custom-property-added` | Safe | New CSS custom property |
+| `css-custom-property-default-changed` | Dangerous | CSS property default changed |
+| `css-part-removed` | Breaking | CSS part removed |
+| `css-part-added` | Safe | New CSS part added |
+| `css-state-removed` | Breaking | CSS state removed |
+| `css-state-added` | Safe | New CSS state added |
+| `event-removed` | Breaking | Event removed |
+| `event-added` | Safe | New event added |
+| `event-type-changed` | Breaking | Event type changed |
+| `method-removed` | Breaking | Public method removed |
+| `method-added` | Safe | New public method |
+| `method-return-type-changed` | Breaking | Method return type changed |
+| `method-parameter-changed` | Breaking | Method parameters changed |
+| `field-removed` | Breaking | Public field removed |
+| `field-type-changed` | Dangerous | Public field type changed |
+
+## Examples
+
+### Compare against latest git tag
+
+```bash
+cem breaking
+```
+
+### Compare against specific git ref
+
+```bash
+cem breaking --base v1.0.0
+```
+
+### Compare two manifest files directly
+
+```bash
+cem breaking old-manifest.json new-manifest.json
+```
+
+### CI mode: fail on breaking changes
+
+```bash
+cem breaking --base v1.0.0 --fail-on breaking
+```
+
+### Machine-readable output
+
+```bash
+cem breaking --base v1.0.0 --format json
+```
+
+### Markdown for PR comments
+
+```bash
+cem breaking --base v1.0.0 --format markdown
+```
+
+### Disable specific rules
+
+```bash
+cem breaking --disable css-custom-property-removed --disable slot-removed
+```
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | No breaking changes (or `--fail-on` not triggered) |
+| 1 | Breaking changes detected (when `--fail-on` is set) |
+| 2 | Input error (missing files, invalid manifests, etc.) |
+
+## Configuration
+
+Rules can be disabled via `.cem.yaml`:
+
+```yaml
+breaking:
+  disable:
+    - css-custom-property-removed
+    - slot-removed
+```
+
+CLI `--disable` flags are merged with config-file rules.

--- a/docs/content/docs/reference/commands/breaking.md
+++ b/docs/content/docs/reference/commands/breaking.md
@@ -109,8 +109,8 @@ cem breaking --disable css-custom-property-removed --disable slot-removed
 
 | Code | Meaning |
 |------|---------|
-| 0 | No breaking changes (or `--fail-on` not triggered) |
-| 1 | Breaking changes detected (when `--fail-on` is set) |
+| 0 | No breaking changes (or `--fail-on` threshold not reached) |
+| 1 | Changes detected at or above `--fail-on` severity (breaking or dangerous) |
 | 2 | Input error (missing files, invalid manifests, etc.) |
 
 ## Configuration

--- a/docs/content/docs/reference/configuration.md
+++ b/docs/content/docs/reference/configuration.md
@@ -108,6 +108,21 @@ warnings:
     - "lifecycle-lit-render"
     - "implementation-static-styles"
 
+# Configuration for breaking change detection.
+breaking:
+  disable:
+    # Disable specific breaking change rules
+    - "css-custom-property-removed"
+    - "slot-removed"
+
+# Health check configuration.
+health:
+  # Minimum health score percentage (0-100).
+  failBelow: 60
+  # Health check rule IDs to skip.
+  disable:
+    - "demos"
+
 # Configuration for the `serve` command.
 serve:
   # Port to listen on
@@ -205,7 +220,7 @@ its values take precedence, and any unset fields fall back to the root config.
 
 Cascaded fields include `generate.files`, `generate.exclude`,
 `generate.designTokens`, `generate.demoDiscovery`, `health.failBelow`,
-`health.disable`, and `export.*`.
+`health.disable`, `breaking.disable`, and `export.*`.
 
 ### Single-package override
 

--- a/internal/config/cem-config.schema.json
+++ b/internal/config/cem-config.schema.json
@@ -273,6 +273,18 @@
         }
       }
     },
+    "breaking": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Configures cem breaking change detection rules.",
+      "properties": {
+        "disable": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Breaking change rule IDs to skip. Examples: element-removed, attribute-removed, css-custom-property-removed."
+        }
+      }
+    },
     "export": {
       "type": "object",
       "description": "Named framework export configurations. Each key is an export name, and its value defines how to generate framework-specific wrappers from the manifest.",

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -20,6 +20,7 @@ type CemConfig struct {
 	Generate     GenerateConfig                `mapstructure:"generate" yaml:"generate" json:"generate"`
 	MCP          MCPConfig                     `mapstructure:"mcp" yaml:"mcp" json:"mcp"`
 	Health       HealthConfig                  `mapstructure:"health" yaml:"health" json:"health"`
+	Breaking     BreakingConfig                `mapstructure:"breaking" yaml:"breaking" json:"breaking"`
 	Serve        ServeConfig                   `mapstructure:"serve" yaml:"serve" json:"serve"`
 	Export       map[string]FrameworkExportConfig `mapstructure:"export" yaml:"export" json:"export"`
 	SourceControlRootUrl string `mapstructure:"sourceControlRootUrl" yaml:"sourceControlRootUrl" json:"sourceControlRootUrl"`
@@ -96,6 +97,10 @@ type FrameworkExportConfig struct {
 type HealthConfig struct {
 	FailBelow int      `mapstructure:"failBelow" yaml:"failBelow" json:"failBelow"`
 	Disable   []string `mapstructure:"disable" yaml:"disable" json:"disable"`
+}
+
+type BreakingConfig struct {
+	Disable []string `mapstructure:"disable" yaml:"disable" json:"disable"`
 }
 
 // LoadConfig reads and parses a CEM config file. The format is detected from


### PR DESCRIPTION
## Summary

- Add `cem breaking` command that compares two custom-elements manifests and detects breaking API changes -- the first tool of its kind in the CEM ecosystem
- 24 detection rules across elements, attributes, slots, CSS properties/parts/states, events, methods, and fields, classified into breaking/dangerous/safe severity tiers
- Three input modes: direct file comparison, git ref resolution (via `git show`), and auto-detection from latest semver tag
- Text, JSON, and markdown output formats; `--fail-on` flag for CI gating; `--disable` flag and config-file rule suppression
- Reusable GitHub Action and workflow for PR comment integration
- Full docs page and configuration reference

Closes #217

## Test plan

- [ ] `make lint` passes with zero issues
- [ ] `go test -race ./breaking/... -count=1` -- 40+ tests pass (rules, Compare goldens, display goldens, isSemverTag, severity round-trip)
- [ ] `go test -race ./... -count=1` -- full suite green, no regressions
- [ ] `dist/cem breaking breaking/testdata/fixtures/mixed-changes/base.json breaking/testdata/fixtures/mixed-changes/head.json` -- text output
- [ ] Same with `--format json` and `--format markdown`
- [ ] `--fail-on breaking` exits 1 with breaking changes present
- [ ] `--disable element-added` suppresses element-added changes
- [ ] `actionlint .github/workflows/cem-breaking-report.yml` passes

Assisted-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `cem breaking` command with rule-based detection across elements, attributes, slots, events, CSS parts/properties/states, methods, and fields, with `--disable` and `--fail-on` thresholds.
* **CI & Automation**
  * Added a reusable workflow/action that generates `breaking_report.md`, updates a PR comment, and can fail based on detected severity; supports `fail-on`.
* **Documentation**
  * Expanded command reference and config docs, including the new `breaking.disable` setting.
* **Tests**
  * Added comprehensive unit + golden tests covering text, Markdown, JSON outputs, and rule disabling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->