### PR TITLE
fix(lsp): use tree-sitter for import insertion position

### DIFF
--- a/lsp/methods/textDocument/codeAction/missingImportCodeActions.go
+++ b/lsp/methods/textDocument/codeAction/missingImportCodeActions.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"strings"
 
+	"bennypowers.dev/cem/internal/languages/typescript"
 	"bennypowers.dev/cem/lsp/types"
 	protocol "github.com/bennypowers/glsp/protocol_3_17"
 )
@@ -282,93 +283,124 @@ func detectScriptTagIndentation(doc types.Document, scriptPosition protocol.Posi
 	return baseIndent
 }
 
-// findLastImportPosition finds the position after the last import statement in a script tag
+// findLastImportPosition finds the position after the last import statement
+// in an inline script tag by parsing the script content as TypeScript.
 func findLastImportPosition(doc types.Document, scriptPosition protocol.Position) protocol.Position {
 	if doc == nil {
-		return scriptPosition // Fallback to the original position
+		return scriptPosition
+	}
+
+	// Find the matching inline module script tag
+	var scriptTag *types.ScriptTag
+	for _, st := range doc.ScriptTags() {
+		if st.IsModule && st.Src == "" {
+			scriptTag = &st
+			break
+		}
+	}
+	if scriptTag == nil {
+		return scriptPosition
 	}
 
 	content, err := doc.Content()
 	if err != nil {
-		return scriptPosition // Fallback to the original position
+		return scriptPosition
 	}
 
+	// Extract script content using ContentRange
 	lines := strings.Split(content, "\n")
-	var lastImportLine = -1
-
-	// Find the script start line by searching backwards from scriptPosition
-	scriptStartLine := 0
-	for i := int(scriptPosition.Line); i >= 0; i-- {
-		if strings.Contains(lines[i], "<script") {
-			scriptStartLine = i
-			break
-		}
+	startLine := int(scriptTag.ContentRange.Start.Line)
+	endLine := int(scriptTag.ContentRange.End.Line)
+	if startLine >= len(lines) {
+		return scriptPosition
 	}
-
-	// Find the script end line by searching forwards
-	scriptEndLine := len(lines) - 1
-	for i := scriptStartLine; i < len(lines); i++ {
-		if strings.Contains(lines[i], "</script>") {
-			scriptEndLine = i
-			break
-		}
-	}
-
-	// Find the last import statement within the script tag
-	for i := scriptStartLine; i < scriptEndLine; i++ {
+	var scriptContent strings.Builder
+	for i := startLine; i <= endLine && i < len(lines); i++ {
 		line := lines[i]
-		trimmedLine := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmedLine, "import ") {
-			lastImportLine = i
+		if i == startLine && i == endLine {
+			startChar := min(int(scriptTag.ContentRange.Start.Character), len(line))
+			endChar := min(int(scriptTag.ContentRange.End.Character), len(line))
+			line = line[startChar:endChar]
+		} else if i == startLine {
+			startChar := min(int(scriptTag.ContentRange.Start.Character), len(line))
+			line = line[startChar:]
+		} else if i == endLine {
+			endChar := min(int(scriptTag.ContentRange.End.Character), len(line))
+			line = line[:endChar]
+		}
+		if i > startLine {
+			scriptContent.WriteByte('\n')
+		}
+		scriptContent.WriteString(line)
+	}
+
+	// Parse as TypeScript to find import_statement nodes
+	parser := typescript.BorrowParser()
+	defer typescript.ReturnParser(parser)
+
+	tree := parser.Parse([]byte(scriptContent.String()), nil)
+	if tree == nil {
+		return scriptPosition
+	}
+	defer tree.Close()
+
+	root := tree.RootNode()
+	var lastImportEnd protocol.Position
+	found := false
+
+	for i := range root.ChildCount() {
+		child := root.Child(i)
+		if child == nil {
+			continue
+		}
+		if child.Kind() == "import_statement" {
+			end := child.EndPosition()
+			lastImportEnd = protocol.Position{
+				Line:      uint32(startLine) + uint32(end.Row) + 1,
+				Character: 0,
+			}
+			found = true
 		}
 	}
 
-	// If we found import statements, position after the last one
-	if lastImportLine >= 0 {
-		return protocol.Position{
-			Line:      uint32(lastImportLine + 1), // Next line after the last import
-			Character: 0,                          // Beginning of the line
-		}
+	if found {
+		return lastImportEnd
 	}
 
-	// No imports found, use the original script position
 	return scriptPosition
 }
 
-// findImportInsertionPosition finds the position to insert new imports after existing imports
+// findImportInsertionPosition finds the position to insert new imports after
+// existing imports using tree-sitter to correctly handle multi-line imports.
 func findImportInsertionPosition(doc types.Document) protocol.Position {
-	content, err := doc.Content()
-	if err != nil {
+	tree, release := doc.AcquireTree()
+	if tree == nil {
 		return protocol.Position{Line: 0, Character: 0}
 	}
+	defer release()
 
-	lines := strings.Split(content, "\n")
+	root := tree.RootNode()
+	var lastImportEnd protocol.Position
+	found := false
 
-	// Find the last import statement
-	lastImportLine := -1
-	for i, line := range lines {
-		trimmedLine := strings.TrimSpace(line)
-		// Look for import statements (both ES6 and CommonJS style)
-		if strings.HasPrefix(trimmedLine, "import ") || strings.HasPrefix(trimmedLine, "from ") {
-			lastImportLine = i
+	for i := range root.ChildCount() {
+		child := root.Child(i)
+		if child == nil {
+			continue
 		}
-		// Stop scanning when we hit the first non-import, non-comment, non-empty line
-		if trimmedLine != "" &&
-			!strings.HasPrefix(trimmedLine, "import ") &&
-			!strings.HasPrefix(trimmedLine, "from ") &&
-			!strings.HasPrefix(trimmedLine, "//") &&
-			!strings.HasPrefix(trimmedLine, "/*") &&
-			!strings.HasPrefix(trimmedLine, "*") &&
-			!strings.HasPrefix(trimmedLine, "*/") {
-			break
+		if child.Kind() == "import_statement" {
+			end := child.EndPosition()
+			lastImportEnd = protocol.Position{
+				Line:      uint32(end.Row + 1),
+				Character: 0,
+			}
+			found = true
 		}
 	}
 
-	if lastImportLine >= 0 {
-		// Insert after the last import, with a blank line
-		return protocol.Position{Line: uint32(lastImportLine + 1), Character: 0}
+	if found {
+		return lastImportEnd
 	}
 
-	// No imports found, insert at the beginning
 	return protocol.Position{Line: 0, Character: 0}
 }

--- a/lsp/methods/textDocument/codeAction/missingImportCodeActions.go
+++ b/lsp/methods/textDocument/codeAction/missingImportCodeActions.go
@@ -54,12 +54,29 @@ func CreateMissingImportAction(
 			// 1. Try to find existing inline module script (not external src)
 			scriptPosition, hasInlineScript := doc.FindInlineModuleScript()
 			if hasInlineScript {
-				// Amend existing inline script tag by adding import statement inside it
-				// Find the position after the last import statement
-				lastImportPosition := findLastImportPosition(doc, scriptPosition)
+				result := findLastImportPosition(doc, scriptPosition)
 				scriptContentIndent := detectScriptTagIndentation(doc, scriptPosition)
+				if result.sameLineScript && result.scriptTag != nil {
+					st := result.scriptTag
+					tagRange := st.Range
+					docContent, _ := doc.Content()
+					docLines := strings.Split(docContent, "\n")
+					tagLine := docLines[tagRange.Start.Line]
+					// Extract opening tag including > from ContentRange boundary
+					openTag := tagLine[tagRange.Start.Character:st.ContentRange.Start.Character]
+					existingContent := strings.TrimSpace(
+						tagLine[st.ContentRange.Start.Character:st.ContentRange.End.Character])
+					tagIndent := strings.Repeat(" ", int(tagRange.Start.Character))
+					replacement := fmt.Sprintf("%s\n%s%s\n%simport \"%s\";\n%s</script>",
+						openTag, scriptContentIndent, existingContent,
+						scriptContentIndent, autofixData.ImportPath,
+						tagIndent)
+					action := buildCodeAction(autofixData.TagName, documentURI, diagnostic,
+						tagRange, replacement)
+					return &action, nil
+				}
 				importStatement = fmt.Sprintf(`%simport "%s";`, scriptContentIndent, autofixData.ImportPath)
-				insertPosition = lastImportPosition
+				insertPosition = result.position
 			} else {
 				// 2. Try to find head section for new script placement
 				dm, err := ctx.DocumentManager()
@@ -109,31 +126,29 @@ import "%s";`, autofixData.ImportPath)
 		}
 	}
 
-	title := fmt.Sprintf("Add import for '%s'", autofixData.TagName)
+	editRange := protocol.Range{Start: insertPosition, End: insertPosition}
+	action := buildCodeAction(autofixData.TagName, documentURI, diagnostic,
+		editRange, importStatement+"\n")
+	return &action, nil
+}
+
+func buildCodeAction(tagName, documentURI string, diagnostic *protocol.Diagnostic,
+	editRange protocol.Range, newText string,
+) protocol.CodeAction {
+	title := fmt.Sprintf("Add import for '%s'", tagName)
 	kind := protocol.CodeActionKindQuickFix
 	preferred := true
-
-	action := protocol.CodeAction{
+	return protocol.CodeAction{
 		Title:       title,
 		Kind:        &kind,
 		IsPreferred: &preferred,
 		Edit: &protocol.WorkspaceEdit{
 			Changes: map[string][]protocol.TextEdit{
-				documentURI: {
-					{
-						Range: protocol.Range{
-							Start: insertPosition,
-							End:   insertPosition,
-						},
-						NewText: importStatement + "\n",
-					},
-				},
+				documentURI: {{Range: editRange, NewText: newText}},
 			},
 		},
 		Diagnostics: []protocol.Diagnostic{*diagnostic},
 	}
-
-	return &action, nil
 }
 
 // detectIndentation analyzes the document content to determine the indentation pattern
@@ -283,14 +298,21 @@ func detectScriptTagIndentation(doc types.Document, scriptPosition protocol.Posi
 	return baseIndent
 }
 
+// importInsertionResult holds the result of finding the import insertion point.
+type importInsertionResult struct {
+	position       protocol.Position
+	sameLineScript bool
+	scriptTag      *types.ScriptTag
+}
+
 // findLastImportPosition finds the position after the last import statement
 // in an inline script tag by parsing the script content as TypeScript.
-func findLastImportPosition(doc types.Document, scriptPosition protocol.Position) protocol.Position {
+func findLastImportPosition(doc types.Document, scriptPosition protocol.Position) importInsertionResult {
+	fallback := importInsertionResult{position: scriptPosition}
 	if doc == nil {
-		return scriptPosition
+		return fallback
 	}
 
-	// Find the matching inline module script tag
 	var scriptTag *types.ScriptTag
 	for _, st := range doc.ScriptTags() {
 		if st.IsModule && st.Src == "" {
@@ -299,21 +321,22 @@ func findLastImportPosition(doc types.Document, scriptPosition protocol.Position
 		}
 	}
 	if scriptTag == nil {
-		return scriptPosition
+		return fallback
 	}
 
 	content, err := doc.Content()
 	if err != nil {
-		return scriptPosition
+		return fallback
 	}
 
-	// Extract script content using ContentRange
 	lines := strings.Split(content, "\n")
 	startLine := int(scriptTag.ContentRange.Start.Line)
 	endLine := int(scriptTag.ContentRange.End.Line)
 	if startLine >= len(lines) {
-		return scriptPosition
+		return fallback
 	}
+	sameLineScript := startLine == endLine
+
 	var scriptContent strings.Builder
 	for i := startLine; i <= endLine && i < len(lines); i++ {
 		line := lines[i]
@@ -334,13 +357,12 @@ func findLastImportPosition(doc types.Document, scriptPosition protocol.Position
 		scriptContent.WriteString(line)
 	}
 
-	// Parse as TypeScript to find import_statement nodes
 	parser := typescript.BorrowParser()
 	defer typescript.ReturnParser(parser)
 
 	tree := parser.Parse([]byte(scriptContent.String()), nil)
 	if tree == nil {
-		return scriptPosition
+		return fallback
 	}
 	defer tree.Close()
 
@@ -355,19 +377,30 @@ func findLastImportPosition(doc types.Document, scriptPosition protocol.Position
 		}
 		if child.Kind() == "import_statement" {
 			end := child.EndPosition()
-			lastImportEnd = protocol.Position{
-				Line:      uint32(startLine) + uint32(end.Row) + 1,
-				Character: 0,
+			if sameLineScript {
+				lastImportEnd = protocol.Position{
+					Line:      uint32(startLine),
+					Character: scriptTag.ContentRange.Start.Character + uint32(end.Column),
+				}
+			} else {
+				lastImportEnd = protocol.Position{
+					Line:      uint32(startLine) + uint32(end.Row) + 1,
+					Character: 0,
+				}
 			}
 			found = true
 		}
 	}
 
 	if found {
-		return lastImportEnd
+		return importInsertionResult{
+			position:       lastImportEnd,
+			sameLineScript: sameLineScript,
+			scriptTag:      scriptTag,
+		}
 	}
 
-	return scriptPosition
+	return fallback
 }
 
 // findImportInsertionPosition finds the position to insert new imports after

--- a/lsp/methods/textDocument/codeAction/missingImportCodeActions.go
+++ b/lsp/methods/textDocument/codeAction/missingImportCodeActions.go
@@ -62,15 +62,26 @@ func CreateMissingImportAction(
 					docContent, _ := doc.Content()
 					docLines := strings.Split(docContent, "\n")
 					tagLine := docLines[tagRange.Start.Line]
-					// Extract opening tag including > from ContentRange boundary
 					openTag := tagLine[tagRange.Start.Character:st.ContentRange.Start.Character]
-					existingContent := strings.TrimSpace(
-						tagLine[st.ContentRange.Start.Character:st.ContentRange.End.Character])
+					contentStart := int(st.ContentRange.Start.Character)
+					contentEnd := int(st.ContentRange.End.Character)
+					insertChar := int(result.position.Character)
+					beforeImport := strings.TrimSpace(tagLine[contentStart:insertChar])
+					afterImport := strings.TrimSpace(tagLine[insertChar:contentEnd])
 					tagIndent := strings.Repeat(" ", int(tagRange.Start.Character))
-					replacement := fmt.Sprintf("%s\n%s%s\n%simport \"%s\";\n%s</script>",
-						openTag, scriptContentIndent, existingContent,
-						scriptContentIndent, autofixData.ImportPath,
-						tagIndent)
+					var replacement string
+					if afterImport == "" {
+						replacement = fmt.Sprintf("%s\n%s%s\n%simport \"%s\";\n%s</script>",
+							openTag, scriptContentIndent, beforeImport,
+							scriptContentIndent, autofixData.ImportPath,
+							tagIndent)
+					} else {
+						replacement = fmt.Sprintf("%s\n%s%s\n%simport \"%s\";\n%s%s\n%s</script>",
+							openTag, scriptContentIndent, beforeImport,
+							scriptContentIndent, autofixData.ImportPath,
+							scriptContentIndent, afterImport,
+							tagIndent)
+					}
 					action := buildCodeAction(autofixData.TagName, documentURI, diagnostic,
 						tagRange, replacement)
 					return &action, nil
@@ -314,9 +325,12 @@ func findLastImportPosition(doc types.Document, scriptPosition protocol.Position
 	}
 
 	var scriptTag *types.ScriptTag
-	for _, st := range doc.ScriptTags() {
-		if st.IsModule && st.Src == "" {
-			scriptTag = &st
+	scriptTags := doc.ScriptTags()
+	for i := range scriptTags {
+		st := &scriptTags[i]
+		if st.IsModule && st.Src == "" &&
+			scriptPosition.Line >= st.Range.Start.Line && scriptPosition.Line <= st.Range.End.Line {
+			scriptTag = st
 			break
 		}
 	}

--- a/lsp/methods/textDocument/codeAction/missingImportCodeActions_test.go
+++ b/lsp/methods/textDocument/codeAction/missingImportCodeActions_test.go
@@ -229,28 +229,41 @@ func TestCreateMissingImportActionErrors(t *testing.T) {
 func applyTextEdit(content string, edit protocol.TextEdit) string {
 	lines := strings.Split(content, "\n")
 
-	// Insert at the specified position
-	insertLine := int(edit.Range.Start.Line)
-	insertChar := int(edit.Range.Start.Character)
+	startLine := int(edit.Range.Start.Line)
+	startChar := int(edit.Range.Start.Character)
+	endLine := int(edit.Range.End.Line)
+	endChar := int(edit.Range.End.Character)
 
-	if insertLine >= len(lines) {
-		// Insert at end of file
+	if startLine >= len(lines) {
 		return content + edit.NewText
 	}
 
-	if insertLine == 0 && insertChar == 0 {
-		// Insert at beginning of file
-		return edit.NewText + content
+	if startChar > len(lines[startLine]) {
+		startChar = len(lines[startLine])
+	}
+	if endLine >= len(lines) {
+		endLine = len(lines) - 1
+		endChar = len(lines[endLine])
+	}
+	if endChar > len(lines[endLine]) {
+		endChar = len(lines[endLine])
 	}
 
-	// Insert at specific line/character
-	line := lines[insertLine]
-	if insertChar > len(line) {
-		insertChar = len(line)
+	before := lines[startLine][:startChar]
+	after := lines[endLine][endChar:]
+
+	var result strings.Builder
+	for _, line := range lines[:startLine] {
+		result.WriteString(line)
+		result.WriteByte('\n')
+	}
+	result.WriteString(before)
+	result.WriteString(edit.NewText)
+	result.WriteString(after)
+	for _, line := range lines[endLine+1:] {
+		result.WriteByte('\n')
+		result.WriteString(line)
 	}
 
-	newLine := line[:insertChar] + edit.NewText + line[insertChar:]
-	lines[insertLine] = newLine
-
-	return strings.Join(lines, "\n")
+	return result.String()
 }

--- a/lsp/methods/textDocument/codeAction/testdata/missing-import/html-existing-script-multiline-import-last.golden.html
+++ b/lsp/methods/textDocument/codeAction/testdata/missing-import/html-existing-script-multiline-import-last.golden.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script type="module">
+    import { css, html, LitElement } from 'lit';
+    import {
+      customElement,
+      property,
+      query,
+    } from 'lit/decorators.js';
+    import "./my-element.js";
+  </script>
+</head>
+<body>
+  <my-element></my-element>
+</body>
+</html>

--- a/lsp/methods/textDocument/codeAction/testdata/missing-import/html-existing-script-multiline-import-last.html
+++ b/lsp/methods/textDocument/codeAction/testdata/missing-import/html-existing-script-multiline-import-last.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script type="module">
+    import { css, html, LitElement } from 'lit';
+    import {
+      customElement,
+      property,
+      query,
+    } from 'lit/decorators.js';
+  </script>
+</head>
+<body>
+  <my-element></my-element>
+</body>
+</html>

--- a/lsp/methods/textDocument/codeAction/testdata/missing-import/html-existing-script-multiline-import.golden.html
+++ b/lsp/methods/textDocument/codeAction/testdata/missing-import/html-existing-script-multiline-import.golden.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script type="module">
+    import { css, html, LitElement } from 'lit';
+    import {
+      customElement,
+      property,
+      query,
+    } from 'lit/decorators.js';
+    import './other-element.js';
+    import "./my-element.js";
+  </script>
+</head>
+<body>
+  <my-element></my-element>
+</body>
+</html>

--- a/lsp/methods/textDocument/codeAction/testdata/missing-import/html-existing-script-multiline-import.html
+++ b/lsp/methods/textDocument/codeAction/testdata/missing-import/html-existing-script-multiline-import.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script type="module">
+    import { css, html, LitElement } from 'lit';
+    import {
+      customElement,
+      property,
+      query,
+    } from 'lit/decorators.js';
+    import './other-element.js';
+  </script>
+</head>
+<body>
+  <my-element></my-element>
+</body>
+</html>

--- a/lsp/methods/textDocument/codeAction/testdata/missing-import/html-existing-script-sameline.golden.html
+++ b/lsp/methods/textDocument/codeAction/testdata/missing-import/html-existing-script-sameline.golden.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script type="module">
+  import './existing.js';
+  import "./my-element.js";
+  </script>
+</head>
+<body>
+  <my-element></my-element>
+</body>
+</html>

--- a/lsp/methods/textDocument/codeAction/testdata/missing-import/html-existing-script-sameline.html
+++ b/lsp/methods/textDocument/codeAction/testdata/missing-import/html-existing-script-sameline.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script type="module">import './existing.js';</script>
+</head>
+<body>
+  <my-element></my-element>
+</body>
+</html>

--- a/lsp/methods/textDocument/codeAction/testdata/missing-import/html-multiple-module-scripts.golden.html
+++ b/lsp/methods/textDocument/codeAction/testdata/missing-import/html-multiple-module-scripts.golden.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script type="module">
+  import './alpha.js';
+  import "./my-element.js";
+  </script>
+  <script type="module">
+    import './beta.js';
+    import './gamma.js';
+  </script>
+</head>
+<body>
+  <my-element></my-element>
+  <script type="module">import './delta.js';</script>
+</body>
+</html>

--- a/lsp/methods/textDocument/codeAction/testdata/missing-import/html-multiple-module-scripts.html
+++ b/lsp/methods/textDocument/codeAction/testdata/missing-import/html-multiple-module-scripts.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script type="module">import './alpha.js';</script>
+  <script type="module">
+    import './beta.js';
+    import './gamma.js';
+  </script>
+</head>
+<body>
+  <my-element></my-element>
+  <script type="module">import './delta.js';</script>
+</body>
+</html>

--- a/lsp/methods/textDocument/codeAction/testdata/missing-import/test-config.json
+++ b/lsp/methods/textDocument/codeAction/testdata/missing-import/test-config.json
@@ -58,5 +58,55 @@
     "importPath": "@my-org/components",
     "tagName": "ui-button",
     "expectAction": true
+  },
+  {
+    "name": "typescript-multiline-import",
+    "description": "TypeScript file with multi-line import block",
+    "inputFile": "typescript-multiline-import.ts",
+    "goldenFile": "typescript-multiline-import.golden.ts",
+    "documentURI": "file:///test.ts",
+    "importPath": "./my-element.js",
+    "tagName": "my-element",
+    "expectAction": true
+  },
+  {
+    "name": "html-existing-script-multiline-import",
+    "description": "HTML file with existing script tag containing multi-line import",
+    "inputFile": "html-existing-script-multiline-import.html",
+    "goldenFile": "html-existing-script-multiline-import.golden.html",
+    "documentURI": "file:///test.html",
+    "importPath": "./my-element.js",
+    "tagName": "my-element",
+    "expectAction": true
+  },
+  {
+    "name": "html-existing-script-multiline-import-last",
+    "description": "HTML file where multi-line import is the last import in script",
+    "inputFile": "html-existing-script-multiline-import-last.html",
+    "goldenFile": "html-existing-script-multiline-import-last.golden.html",
+    "documentURI": "file:///test.html",
+    "importPath": "./my-element.js",
+    "tagName": "my-element",
+    "expectAction": true
+  },
+  {
+    "name": "typescript-multiline-import-with-comments",
+    "description": "TypeScript file with comments containing 'from' inside multi-line import",
+    "inputFile": "typescript-multiline-import-with-comments.ts",
+    "goldenFile": "typescript-multiline-import-with-comments.golden.ts",
+    "documentURI": "file:///test.ts",
+    "importPath": "./my-element.js",
+    "tagName": "my-element",
+    "expectAction": true
+  },
+  {
+    "name": "typescript-lit-template-script",
+    "description": "TypeScript file with script tag inside Lit template literal",
+    "inputFile": "typescript-lit-template-script.ts",
+    "goldenFile": "typescript-lit-template-script.golden.ts",
+    "documentURI": "file:///test.ts",
+    "importPath": "./my-element.js",
+    "tagName": "my-element",
+    "expectAction": true
   }
 ]

--- a/lsp/methods/textDocument/codeAction/testdata/missing-import/test-config.json
+++ b/lsp/methods/textDocument/codeAction/testdata/missing-import/test-config.json
@@ -108,5 +108,25 @@
     "importPath": "./my-element.js",
     "tagName": "my-element",
     "expectAction": true
+  },
+  {
+    "name": "html-existing-script-sameline",
+    "description": "HTML file with single-line module script tag",
+    "inputFile": "html-existing-script-sameline.html",
+    "goldenFile": "html-existing-script-sameline.golden.html",
+    "documentURI": "file:///test.html",
+    "importPath": "./my-element.js",
+    "tagName": "my-element",
+    "expectAction": true
+  },
+  {
+    "name": "html-multiple-module-scripts",
+    "description": "HTML file with multiple inline module scripts",
+    "inputFile": "html-multiple-module-scripts.html",
+    "goldenFile": "html-multiple-module-scripts.golden.html",
+    "documentURI": "file:///test.html",
+    "importPath": "./my-element.js",
+    "tagName": "my-element",
+    "expectAction": true
   }
 ]

--- a/lsp/methods/textDocument/codeAction/testdata/missing-import/typescript-lit-template-script.golden.ts
+++ b/lsp/methods/textDocument/codeAction/testdata/missing-import/typescript-lit-template-script.golden.ts
@@ -1,0 +1,16 @@
+import { html } from 'lit';
+import './other-element.js';
+
+import "./my-element.js";
+
+const tpl = html`
+  <script type="module">
+    import './inner-element.js';
+  </script>
+`;
+
+export class MyComponent {
+  render() {
+    return html`<my-element></my-element>`;
+  }
+}

--- a/lsp/methods/textDocument/codeAction/testdata/missing-import/typescript-lit-template-script.ts
+++ b/lsp/methods/textDocument/codeAction/testdata/missing-import/typescript-lit-template-script.ts
@@ -1,0 +1,14 @@
+import { html } from 'lit';
+import './other-element.js';
+
+const tpl = html`
+  <script type="module">
+    import './inner-element.js';
+  </script>
+`;
+
+export class MyComponent {
+  render() {
+    return html`<my-element></my-element>`;
+  }
+}

--- a/lsp/methods/textDocument/codeAction/testdata/missing-import/typescript-multiline-import-with-comments.golden.ts
+++ b/lsp/methods/textDocument/codeAction/testdata/missing-import/typescript-multiline-import-with-comments.golden.ts
@@ -1,0 +1,15 @@
+import { css, html, LitElement } from 'lit';
+import {
+	customElement, // imported from lit/decorators
+	property,
+	query,
+} from 'lit/decorators.js';
+import './other-element.js';
+
+import "./my-element.js";
+
+export class MyComponent {
+  render() {
+    return html`<my-element></my-element>`;
+  }
+}

--- a/lsp/methods/textDocument/codeAction/testdata/missing-import/typescript-multiline-import-with-comments.ts
+++ b/lsp/methods/textDocument/codeAction/testdata/missing-import/typescript-multiline-import-with-comments.ts
@@ -1,0 +1,13 @@
+import { css, html, LitElement } from 'lit';
+import {
+	customElement, // imported from lit/decorators
+	property,
+	query,
+} from 'lit/decorators.js';
+import './other-element.js';
+
+export class MyComponent {
+  render() {
+    return html`<my-element></my-element>`;
+  }
+}

--- a/lsp/methods/textDocument/codeAction/testdata/missing-import/typescript-multiline-import.golden.ts
+++ b/lsp/methods/textDocument/codeAction/testdata/missing-import/typescript-multiline-import.golden.ts
@@ -1,0 +1,31 @@
+import { css, html, LitElement } from 'lit';
+import { customElement, property, query, state } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+import { when } from 'lit/directives/when.js';
+import Sortable from 'sortablejs';
+import type { AIModel } from '@gitlens/ai/models/model.js';
+import type { ComposerBaseCommit, ComposerCommit, ComposerHunk } from '../../../../plus/composer/protocol.js';
+import {
+	getCommitChanges,
+	getFileChanges,
+	getFileCountForCommit,
+	getUnassignedHunks,
+	getUniqueFileNames,
+} from '../../../../plus/composer/utils/composer.utils.js';
+import { focusableBaseStyles } from '../../../shared/components/styles/lit/a11y.css.js';
+import { boxSizingBase, inlineCode, scrollableBase } from '../../../shared/components/styles/lit/base.css.js';
+import { ruleStyles } from '../../shared/components/vscode.css.js';
+import { composerItemCommitStyles, composerItemContentStyles, composerItemStyles } from './composer.css.js';
+import '../../../shared/components/button.js';
+import '../../../shared/components/button-container.js';
+import '../../../shared/components/code-icon.js';
+import '../../../shared/components/overlays/popover.js';
+import './commit-item.js';
+
+import "./my-element.js";
+
+export class MyComponent {
+  render() {
+    return html`<my-element></my-element>`;
+  }
+}

--- a/lsp/methods/textDocument/codeAction/testdata/missing-import/typescript-multiline-import.golden.ts
+++ b/lsp/methods/textDocument/codeAction/testdata/missing-import/typescript-multiline-import.golden.ts
@@ -3,24 +3,24 @@ import { customElement, property, query, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { when } from 'lit/directives/when.js';
 import Sortable from 'sortablejs';
-import type { AIModel } from '@gitlens/ai/models/model.js';
-import type { ComposerBaseCommit, ComposerCommit, ComposerHunk } from '../../../../plus/composer/protocol.js';
+import type { Config } from '@example/core/config.js';
+import type { BaseItem, DetailItem, ItemGroup } from '../../models/items.js';
 import {
-	getCommitChanges,
+	getItemChanges,
 	getFileChanges,
-	getFileCountForCommit,
-	getUnassignedHunks,
-	getUniqueFileNames,
-} from '../../../../plus/composer/utils/composer.utils.js';
-import { focusableBaseStyles } from '../../../shared/components/styles/lit/a11y.css.js';
-import { boxSizingBase, inlineCode, scrollableBase } from '../../../shared/components/styles/lit/base.css.js';
-import { ruleStyles } from '../../shared/components/vscode.css.js';
-import { composerItemCommitStyles, composerItemContentStyles, composerItemStyles } from './composer.css.js';
-import '../../../shared/components/button.js';
-import '../../../shared/components/button-container.js';
-import '../../../shared/components/code-icon.js';
-import '../../../shared/components/overlays/popover.js';
-import './commit-item.js';
+	getItemCount,
+	getUnassignedItems,
+	getUniqueNames,
+} from '../../utils/item.utils.js';
+import { focusableBaseStyles } from '../styles/a11y.css.js';
+import { boxSizingBase, inlineCode, scrollableBase } from '../styles/base.css.js';
+import { ruleStyles } from '../styles/rules.css.js';
+import { itemStyles, itemContentStyles, itemListStyles } from './item-list.css.js';
+import '../components/button.js';
+import '../components/button-container.js';
+import '../components/code-icon.js';
+import '../components/overlays/popover.js';
+import './list-item.js';
 
 import "./my-element.js";
 

--- a/lsp/methods/textDocument/codeAction/testdata/missing-import/typescript-multiline-import.ts
+++ b/lsp/methods/textDocument/codeAction/testdata/missing-import/typescript-multiline-import.ts
@@ -3,24 +3,24 @@ import { customElement, property, query, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { when } from 'lit/directives/when.js';
 import Sortable from 'sortablejs';
-import type { AIModel } from '@gitlens/ai/models/model.js';
-import type { ComposerBaseCommit, ComposerCommit, ComposerHunk } from '../../../../plus/composer/protocol.js';
+import type { Config } from '@example/core/config.js';
+import type { BaseItem, DetailItem, ItemGroup } from '../../models/items.js';
 import {
-	getCommitChanges,
+	getItemChanges,
 	getFileChanges,
-	getFileCountForCommit,
-	getUnassignedHunks,
-	getUniqueFileNames,
-} from '../../../../plus/composer/utils/composer.utils.js';
-import { focusableBaseStyles } from '../../../shared/components/styles/lit/a11y.css.js';
-import { boxSizingBase, inlineCode, scrollableBase } from '../../../shared/components/styles/lit/base.css.js';
-import { ruleStyles } from '../../shared/components/vscode.css.js';
-import { composerItemCommitStyles, composerItemContentStyles, composerItemStyles } from './composer.css.js';
-import '../../../shared/components/button.js';
-import '../../../shared/components/button-container.js';
-import '../../../shared/components/code-icon.js';
-import '../../../shared/components/overlays/popover.js';
-import './commit-item.js';
+	getItemCount,
+	getUnassignedItems,
+	getUniqueNames,
+} from '../../utils/item.utils.js';
+import { focusableBaseStyles } from '../styles/a11y.css.js';
+import { boxSizingBase, inlineCode, scrollableBase } from '../styles/base.css.js';
+import { ruleStyles } from '../styles/rules.css.js';
+import { itemStyles, itemContentStyles, itemListStyles } from './item-list.css.js';
+import '../components/button.js';
+import '../components/button-container.js';
+import '../components/code-icon.js';
+import '../components/overlays/popover.js';
+import './list-item.js';
 
 export class MyComponent {
   render() {

--- a/lsp/methods/textDocument/codeAction/testdata/missing-import/typescript-multiline-import.ts
+++ b/lsp/methods/textDocument/codeAction/testdata/missing-import/typescript-multiline-import.ts
@@ -1,0 +1,29 @@
+import { css, html, LitElement } from 'lit';
+import { customElement, property, query, state } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+import { when } from 'lit/directives/when.js';
+import Sortable from 'sortablejs';
+import type { AIModel } from '@gitlens/ai/models/model.js';
+import type { ComposerBaseCommit, ComposerCommit, ComposerHunk } from '../../../../plus/composer/protocol.js';
+import {
+	getCommitChanges,
+	getFileChanges,
+	getFileCountForCommit,
+	getUnassignedHunks,
+	getUniqueFileNames,
+} from '../../../../plus/composer/utils/composer.utils.js';
+import { focusableBaseStyles } from '../../../shared/components/styles/lit/a11y.css.js';
+import { boxSizingBase, inlineCode, scrollableBase } from '../../../shared/components/styles/lit/base.css.js';
+import { ruleStyles } from '../../shared/components/vscode.css.js';
+import { composerItemCommitStyles, composerItemContentStyles, composerItemStyles } from './composer.css.js';
+import '../../../shared/components/button.js';
+import '../../../shared/components/button-container.js';
+import '../../../shared/components/code-icon.js';
+import '../../../shared/components/overlays/popover.js';
+import './commit-item.js';
+
+export class MyComponent {
+  render() {
+    return html`<my-element></my-element>`;
+  }
+}


### PR DESCRIPTION
## Summary

- Fix "add missing import" code action breaking syntax when multi-line `import { ... } from '...'` blocks are present
- Replace string-based import position scanning with tree-sitter `import_statement` node walking in both TS/JS and HTML code paths
- For HTML, extract script content via `ContentRange`, parse as TypeScript with pooled parser, map positions back to HTML coordinates

## Test plan

- [x] Existing 6 test cases pass (no regressions)
- [x] New fixture: multi-line TS import block (exact repro from #405)
- [x] New fixture: HTML multi-line import in middle of import list
- [x] New fixture: HTML multi-line import as last import in script
- [x] New fixture: multi-line import with comments containing `from` inside braces
- [x] New fixture: Lit template with embedded `<script type="module">` (not confused by template content)
- [x] 4692 unit tests pass, lint clean

Closes #405

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved missing-import code actions to place new `import` statements correctly within HTML inline `type="module"` scripts, including multiline and “last import” cases.
  * Fixed text edit application for missing-import actions so replacements occur over the intended range (including multiline edits), avoiding incorrect insertion behavior.
* **Tests**
  * Added new and expanded golden fixtures covering multiline imports, comment-heavy imports, HTML single-line vs multiline module scripts, multiple inline module scripts, and template-embedded script scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->