### PR TITLE
fix(lsp): expression binding diagnostics and completion filtering

### DIFF
--- a/lsp/document/typescript/document.go
+++ b/lsp/document/typescript/document.go
@@ -502,25 +502,11 @@ func (d *TypeScriptDocument) collectTemplateAttributes(
 
 // classifyExpression analyzes a template expression (${...}) from the TS tree
 // and populates ExpressionKind/ExpressionDetail on the attribute match.
-// Uses the attribute value's ${...} content to locate the expression in the TS AST.
+// Finds the first template_substitution within the template's byte range
+// and classifies its expression child node.
 func classifyExpression(match *types.AttributeMatch, template TemplateContext, tsRoot *ts.Node, docContent []byte) {
-	value := match.Value
-	dollarIdx := strings.Index(value, "${")
-	if dollarIdx < 0 {
-		return
-	}
-
-	// The expression text between ${ and } -- used to find matching TS node
-	closeIdx := strings.LastIndex(value, "}")
-	if closeIdx <= dollarIdx+2 {
-		match.ExpressionKind = "complex"
-		return
-	}
-	exprText := value[dollarIdx+2 : closeIdx]
-
-	// Search for the template_substitution containing this expression text
-	// within the template's byte range in the TS document
-	sub := findSubstitutionByContent(tsRoot, docContent, template.startByte, exprText)
+	templateEnd := template.startByte + uint(len(match.Value)+100)
+	sub := findFirstSubstitution(tsRoot, template.startByte, templateEnd)
 	if sub == nil {
 		match.ExpressionKind = "complex"
 		return
@@ -534,7 +520,10 @@ func classifyExpression(match *types.AttributeMatch, template TemplateContext, t
 		return
 	}
 
-	expr := children[0]
+	classifyExpressionNode(&children[0], match, docContent)
+}
+
+func classifyExpressionNode(expr *ts.Node, match *types.AttributeMatch, docContent []byte) {
 	switch expr.GrammarName() {
 	case "string", "template_string":
 		match.ExpressionKind = "literal"
@@ -565,28 +554,24 @@ func classifyExpression(match *types.AttributeMatch, template TemplateContext, t
 	}
 }
 
-// findSubstitutionByContent finds a template_substitution node whose
-// expression text matches, within the template's byte range.
-func findSubstitutionByContent(node *ts.Node, docContent []byte, templateStart uint, exprText string) *ts.Node {
-	start, _ := node.ByteRange()
-	if start < templateStart && node.GrammarName() != "program" && node.GrammarName() != "template_string" && node.GrammarName() != "call_expression" {
+// findFirstSubstitution finds the first template_substitution node
+// whose byte range overlaps [minByte, maxByte].
+func findFirstSubstitution(node *ts.Node, minByte, maxByte uint) *ts.Node {
+	_, end := node.ByteRange()
+	if end < minByte {
 		return nil
 	}
-	if node.GrammarName() == "template_substitution" {
-		cursor := node.Walk()
-		children := node.NamedChildren(cursor)
-		cursor.Close()
-		if len(children) > 0 {
-			text := strings.TrimSpace(children[0].Utf8Text(docContent))
-			if text == exprText {
-				return node
-			}
-		}
+	start, _ := node.ByteRange()
+	if start > maxByte {
+		return nil
+	}
+	if node.GrammarName() == "template_substitution" && start >= minByte {
+		return node
 	}
 	cursor := node.Walk()
 	defer cursor.Close()
 	for _, child := range node.NamedChildren(cursor) {
-		if found := findSubstitutionByContent(&child, docContent, templateStart, exprText); found != nil {
+		if found := findFirstSubstitution(&child, minByte, maxByte); found != nil {
 			return found
 		}
 	}

--- a/lsp/document/typescript/document.go
+++ b/lsp/document/typescript/document.go
@@ -282,8 +282,9 @@ func (d *TypeScriptDocument) findCustomElements(handler *Handler) ([]types.Custo
 		return nil, fmt.Errorf("failed to find HTML templates: %w", err)
 	}
 
+	tsRoot := tree.RootNode()
 	for _, template := range templates {
-		templateElements, err := d.parseHTMLInTemplate(template, handler, docContent)
+		templateElements, err := d.parseHTMLInTemplate(template, handler, docContent, tsRoot)
 		if err != nil {
 			helpers.SafeDebugLog("[TypeScript] Failed to parse template: %v", err)
 			continue
@@ -368,7 +369,7 @@ func (d *TypeScriptDocument) findHTMLTemplates(handler *Handler) ([]TemplateCont
 	return templates, nil
 }
 
-func (d *TypeScriptDocument) parseHTMLInTemplate(template TemplateContext, handler *Handler, docContent string) ([]types.CustomElementMatch, error) {
+func (d *TypeScriptDocument) parseHTMLInTemplate(template TemplateContext, handler *Handler, docContent string, tsRoot *ts.Node) ([]types.CustomElementMatch, error) {
 	templateContent, err := template.Content()
 	if err != nil {
 		return nil, err
@@ -406,7 +407,7 @@ func (d *TypeScriptDocument) parseHTMLInTemplate(template TemplateContext, handl
 					element := types.CustomElementMatch{
 						TagName:    capture.Text,
 						Range:      d.adjustRangeToTemplate(capture, template, docContent),
-						Attributes: d.collectTemplateAttributes(captureMap, contentBytes, template, docContent),
+						Attributes: d.collectTemplateAttributes(captureMap, contentBytes, template, docContent, tsRoot),
 					}
 					elements = append(elements, element)
 				}
@@ -433,6 +434,7 @@ func (d *TypeScriptDocument) collectTemplateAttributes(
 	contentBytes []byte,
 	template TemplateContext,
 	docContent string,
+	tsRoot *ts.Node,
 ) map[string]types.AttributeMatch {
 	attributes := make(map[string]types.AttributeMatch)
 	attrNames, ok := captureMap["attr.name"]
@@ -487,12 +489,108 @@ func (d *TypeScriptDocument) collectTemplateAttributes(
 		}
 		if closestValue != "" {
 			attrMatch.Value = closestValue
+			if strings.Contains(closestValue, "${") && tsRoot != nil {
+				classifyExpression(&attrMatch, template, tsRoot, []byte(docContent))
+			}
 		}
 
 		attributes[attrName.Text] = attrMatch
 	}
 
 	return attributes
+}
+
+// classifyExpression analyzes a template expression (${...}) from the TS tree
+// and populates ExpressionKind/ExpressionDetail on the attribute match.
+// Uses the attribute value's ${...} content to locate the expression in the TS AST.
+func classifyExpression(match *types.AttributeMatch, template TemplateContext, tsRoot *ts.Node, docContent []byte) {
+	value := match.Value
+	dollarIdx := strings.Index(value, "${")
+	if dollarIdx < 0 {
+		return
+	}
+
+	// The expression text between ${ and } -- used to find matching TS node
+	closeIdx := strings.LastIndex(value, "}")
+	if closeIdx <= dollarIdx+2 {
+		match.ExpressionKind = "complex"
+		return
+	}
+	exprText := value[dollarIdx+2 : closeIdx]
+
+	// Search for the template_substitution containing this expression text
+	// within the template's byte range in the TS document
+	sub := findSubstitutionByContent(tsRoot, docContent, template.startByte, exprText)
+	if sub == nil {
+		match.ExpressionKind = "complex"
+		return
+	}
+
+	cursor := sub.Walk()
+	defer cursor.Close()
+	children := sub.NamedChildren(cursor)
+	if len(children) == 0 {
+		match.ExpressionKind = "complex"
+		return
+	}
+
+	expr := children[0]
+	switch expr.GrammarName() {
+	case "string", "template_string":
+		match.ExpressionKind = "literal"
+		text := expr.Utf8Text(docContent)
+		if len(text) >= 2 {
+			match.ExpressionDetail = text[1 : len(text)-1]
+		}
+	case "number":
+		match.ExpressionKind = "literal"
+		match.ExpressionDetail = expr.Utf8Text(docContent)
+	case "true", "false":
+		match.ExpressionKind = "literal"
+		match.ExpressionDetail = expr.GrammarName()
+	case "member_expression":
+		objNode := expr.ChildByFieldName("object")
+		propNode := expr.ChildByFieldName("property")
+		if objNode != nil && propNode != nil && objNode.GrammarName() == "this" {
+			match.ExpressionKind = "this-member"
+			match.ExpressionDetail = propNode.Utf8Text(docContent)
+		} else {
+			match.ExpressionKind = "complex"
+		}
+	case "identifier":
+		match.ExpressionKind = "identifier"
+		match.ExpressionDetail = expr.Utf8Text(docContent)
+	default:
+		match.ExpressionKind = "complex"
+	}
+}
+
+// findSubstitutionByContent finds a template_substitution node whose
+// expression text matches, within the template's byte range.
+func findSubstitutionByContent(node *ts.Node, docContent []byte, templateStart uint, exprText string) *ts.Node {
+	start, _ := node.ByteRange()
+	if start < templateStart && node.GrammarName() != "program" && node.GrammarName() != "template_string" && node.GrammarName() != "call_expression" {
+		return nil
+	}
+	if node.GrammarName() == "template_substitution" {
+		cursor := node.Walk()
+		children := node.NamedChildren(cursor)
+		cursor.Close()
+		if len(children) > 0 {
+			text := strings.TrimSpace(children[0].Utf8Text(docContent))
+			if text == exprText {
+				return node
+			}
+		}
+	}
+	cursor := node.Walk()
+	defer cursor.Close()
+	for _, child := range node.NamedChildren(cursor) {
+		if found := findSubstitutionByContent(&child, docContent, templateStart, exprText); found != nil {
+			return found
+		}
+	}
+	return nil
 }
 
 func (d *TypeScriptDocument) analyzeCompletionContext(

--- a/lsp/document/typescript/document.go
+++ b/lsp/document/typescript/document.go
@@ -473,6 +473,7 @@ func (d *TypeScriptDocument) collectTemplateAttributes(
 		}
 
 		var closestValue string
+		var closestValuePos uint
 		var closestDistance = ^uint(0)
 		for valuePos, value := range valuesByPosition {
 			if valuePos > attrName.EndByte {
@@ -483,6 +484,7 @@ func (d *TypeScriptDocument) collectTemplateAttributes(
 					if len(trimmed) > 0 && trimmed[0] == '=' {
 						closestDistance = distance
 						closestValue = value
+						closestValuePos = valuePos
 					}
 				}
 			}
@@ -490,7 +492,8 @@ func (d *TypeScriptDocument) collectTemplateAttributes(
 		if closestValue != "" {
 			attrMatch.Value = closestValue
 			if strings.Contains(closestValue, "${") && tsRoot != nil {
-				classifyExpression(&attrMatch, template, tsRoot, []byte(docContent))
+				valueTSOffset := template.startByte + closestValuePos
+				classifyExpression(&attrMatch, valueTSOffset, tsRoot, []byte(docContent))
 			}
 		}
 
@@ -502,11 +505,10 @@ func (d *TypeScriptDocument) collectTemplateAttributes(
 
 // classifyExpression analyzes a template expression (${...}) from the TS tree
 // and populates ExpressionKind/ExpressionDetail on the attribute match.
-// Finds the first template_substitution within the template's byte range
-// and classifies its expression child node.
-func classifyExpression(match *types.AttributeMatch, template TemplateContext, tsRoot *ts.Node, docContent []byte) {
-	templateEnd := template.startByte + uint(len(match.Value)+100)
-	sub := findFirstSubstitution(tsRoot, template.startByte, templateEnd)
+// valueTSOffset is the attribute value's byte position in the TS document.
+func classifyExpression(match *types.AttributeMatch, valueTSOffset uint, tsRoot *ts.Node, docContent []byte) {
+	searchEnd := valueTSOffset + uint(len(match.Value))
+	sub := findFirstSubstitution(tsRoot, valueTSOffset, searchEnd)
 	if sub == nil {
 		match.ExpressionKind = "complex"
 		return

--- a/lsp/methods/textDocument/completion/completion.go
+++ b/lsp/methods/textDocument/completion/completion.go
@@ -446,14 +446,25 @@ func getDefaultValueCompletion(attr *M.Attribute) *protocol.CompletionItem {
 	}
 }
 
-// parseUnionType parses union types like "red" | "green" | "blue" into completion items
+// parseUnionType extracts concrete value completions from union types.
+// Only suggests quoted string literals and boolean literals; drops bare
+// identifiers (unresolved type names), null, undefined, and primitives.
 func parseUnionType(typeText string) []protocol.CompletionItem {
 	var items []protocol.CompletionItem
 	valueKind := protocol.CompletionItemKindValue
 
 	for _, part := range tstype.SplitTopLevelUnion(typeText) {
-		part = strings.Trim(part, `"'`)
-		if part != "" {
+		if isQuotedLiteral(part) {
+			value := part[1 : len(part)-1]
+			if value != "" {
+				items = append(items, protocol.CompletionItem{
+					Label:      value,
+					Kind:       &valueKind,
+					Detail:     &[]string{"Union type value"}[0],
+					InsertText: &[]string{value}[0],
+				})
+			}
+		} else if part == "true" || part == "false" {
 			items = append(items, protocol.CompletionItem{
 				Label:      part,
 				Kind:       &valueKind,
@@ -464,6 +475,12 @@ func parseUnionType(typeText string) []protocol.CompletionItem {
 	}
 
 	return items
+}
+
+func isQuotedLiteral(s string) bool {
+	return len(s) >= 2 &&
+		((s[0] == '\'' && s[len(s)-1] == '\'') ||
+			(s[0] == '"' && s[len(s)-1] == '"'))
 }
 
 // deduplicateCompletionItems removes duplicate completion items by label,

--- a/lsp/methods/textDocument/completion/completion_type_parsing_test.go
+++ b/lsp/methods/textDocument/completion/completion_type_parsing_test.go
@@ -23,6 +23,84 @@ import (
 	M "bennypowers.dev/cem/manifest"
 )
 
+// Inline: pure function, table-driven cases test completion output filtering
+
+// TestTypeBasedCompletions_FiltersUnresolvedIdentifiers verifies that bare
+// type identifiers (unresolved aliases) are not suggested as attribute values.
+func TestTypeBasedCompletions_FiltersUnresolvedIdentifiers(t *testing.T) {
+	tests := []struct {
+		name          string
+		typeText      string
+		wantLabels    []string
+		wantCount     int
+		description   string
+	}{
+		{
+			"mixed literal and identifier",
+			"'primary' | NavigationPrimaryPalette",
+			[]string{"primary"},
+			1,
+			"Should suggest only the resolved literal, not the bare identifier",
+		},
+		{
+			"all literals",
+			"'a' | 'b' | 'c'",
+			[]string{"a", "b", "c"},
+			3,
+			"All quoted literals should be suggested",
+		},
+		{
+			"literals with null and undefined",
+			"'red' | 'blue' | undefined | null",
+			[]string{"red", "blue"},
+			2,
+			"null and undefined should be filtered out",
+		},
+		{
+			"only identifiers",
+			"SomeType | AnotherType",
+			nil,
+			0,
+			"Pure unresolved identifiers should produce no completions",
+		},
+		{
+			"primitive string",
+			"string",
+			[]string{`""`},
+			1,
+			"string type suggests empty-string placeholder",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attr := &M.Attribute{
+				FullyQualified: M.FullyQualified{Name: "test"},
+				Type:           &M.Type{Text: tt.typeText},
+			}
+			completions := completion.GetTypeBasedCompletions(attr)
+			var labels []string
+			for _, c := range completions {
+				labels = append(labels, c.Label)
+			}
+			if len(labels) != tt.wantCount {
+				t.Errorf("%s: expected %d completions, got %d: %v", tt.description, tt.wantCount, len(labels), labels)
+			}
+			for _, want := range tt.wantLabels {
+				found := false
+				for _, l := range labels {
+					if l == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("%s: expected label %q not found in %v", tt.description, want, labels)
+				}
+			}
+		})
+	}
+}
+
 // TestTypeBasedCompletions tests completion for literal types and unions
 // This covers both single literal types (e.g., 'promo') and union types (e.g., 'promo' | 'standard')
 // Consolidated from TestSingleLiteralTypeCompletion and TestUnionTypeParser

--- a/lsp/methods/textDocument/completion/completion_type_parsing_test.go
+++ b/lsp/methods/textDocument/completion/completion_type_parsing_test.go
@@ -70,6 +70,27 @@ func TestTypeBasedCompletions_FiltersUnresolvedIdentifiers(t *testing.T) {
 			1,
 			"string type suggests empty-string placeholder",
 		},
+		{
+			"boolean union",
+			"true | false",
+			[]string{"true", "false"},
+			2,
+			"Boolean literals should be suggested",
+		},
+		{
+			"double-quoted literals",
+			`"primary" | "secondary"`,
+			[]string{"primary", "secondary"},
+			2,
+			"Double-quoted literals should be suggested",
+		},
+		{
+			"mixed quotes with boolean",
+			"'auto' | true | false",
+			[]string{"auto", "true", "false"},
+			3,
+			"Mixed quoted literal and boolean literals",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/lsp/methods/textDocument/publishDiagnostics/attributeDiagnostics.go
+++ b/lsp/methods/textDocument/publishDiagnostics/attributeDiagnostics.go
@@ -31,13 +31,16 @@ import (
 
 // AttributeMatch represents a found attribute in the document
 type AttributeMatch struct {
-	Name     string
-	TagName  string // The tag this attribute belongs to
-	Value    string // The attribute value (empty if no value)
-	HasValue bool   // Whether attribute has an explicit value
-	Line     uint32
-	StartCol uint32
-	EndCol   uint32
+	Name             string
+	TagName          string // The tag this attribute belongs to
+	Value            string // The attribute value (empty if no value)
+	HasValue         bool   // Whether attribute has an explicit value
+	Line             uint32
+	StartCol         uint32
+	EndCol           uint32
+	BindingPrefix    string // Lit binding prefix: ".", "?", "@", or ""
+	ExpressionKind   string // "literal", "this-member", "identifier", "complex", or ""
+	ExpressionDetail string
 }
 
 // analyzeAttributeDiagnostics finds unknown attributes and suggests corrections
@@ -70,9 +73,11 @@ func AnalyzeAttributeDiagnosticsForTest(ctx types.ServerContext, doc types.Docum
 	helpers.SafeDebugLog("[DIAGNOSTICS] Found %d attributes", len(attributeMatches))
 
 	for _, match := range attributeMatches {
-		// For custom elements, validate all their attributes
 		if helpers.IsCustomElementTag(match.TagName) {
-			// Skip if it's a global HTML attribute (valid on all elements)
+			// Event bindings (@click) are not manifest attributes
+			if match.BindingPrefix == "@" {
+				continue
+			}
 			if validations.IsGlobalAttribute(match.Name) {
 				continue
 			}
@@ -201,13 +206,17 @@ func processTagCaptures(captureMap Q.CaptureMap, content string, matches *[]Attr
 	// Process each attribute
 	for i, attrNameInfo := range attrNames {
 		attrName := attrNameInfo.Text
+		var bindingPrefix string
+		if len(attrName) > 1 && (attrName[0] == '.' || attrName[0] == '?' || attrName[0] == '@') {
+			bindingPrefix = attrName[:1]
+			attrName = attrName[1:]
+		}
+
 		attrValue := ""
 		hasValue := false
 
-		// Check for quoted value
 		if i < len(quotedValues) {
 			rawValue := quotedValues[i].Text
-			// Strip quotes
 			if len(rawValue) >= 2 {
 				attrValue = rawValue[1 : len(rawValue)-1]
 			}
@@ -217,7 +226,6 @@ func processTagCaptures(captureMap Q.CaptureMap, content string, matches *[]Attr
 			hasValue = true
 		}
 
-		// Convert byte positions to line/column
 		lines := strings.Split(content[:attrNameInfo.StartByte], "\n")
 		line := uint32(len(lines) - 1)
 		startCol := uint32(len(lines[len(lines)-1]))
@@ -226,13 +234,14 @@ func processTagCaptures(captureMap Q.CaptureMap, content string, matches *[]Attr
 		endCol := uint32(len(endLines[len(endLines)-1]))
 
 		match := AttributeMatch{
-			Name:     attrName,
-			TagName:  tagName,
-			Value:    attrValue,
-			HasValue: hasValue,
-			Line:     line,
-			StartCol: startCol,
-			EndCol:   endCol,
+			Name:          attrName,
+			TagName:       tagName,
+			Value:         attrValue,
+			HasValue:      hasValue,
+			Line:          line,
+			StartCol:      startCol,
+			EndCol:        endCol,
+			BindingPrefix: bindingPrefix,
 		}
 
 		*matches = append(*matches, match)

--- a/lsp/methods/textDocument/publishDiagnostics/attributeValueDiagnostics.go
+++ b/lsp/methods/textDocument/publishDiagnostics/attributeValueDiagnostics.go
@@ -75,32 +75,58 @@ func AnalyzeAttributeValueDiagnosticsForTest(ctx types.ServerContext, doc types.
 func validateAttributeValue(attr *M.Attribute, match AttributeMatch) []protocol.Diagnostic {
 	var diagnostics []protocol.Diagnostic
 
-	// Skip validation if no type information
 	if attr.Type == nil || attr.Type.Text == "" {
 		return diagnostics
 	}
 
+	// Property bindings pass JS values, not HTML attribute strings
+	if match.BindingPrefix == "." {
+		return diagnostics
+	}
+	// Event bindings are function handlers
+	if match.BindingPrefix == "@" {
+		return diagnostics
+	}
+	// Boolean bindings control attribute presence via expression truthiness
+	if match.BindingPrefix == "?" {
+		return diagnostics
+	}
+	// Expression values can't be validated as static strings
+	if match.ExpressionKind != "" {
+		return diagnostics
+	}
+
 	typeText := strings.TrimSpace(attr.Type.Text)
-	lowerTypeText := strings.ToLower(typeText)
 
 	helpers.SafeDebugLog("[VALUE_DIAGNOSTICS] Validating attribute %s.%s with type '%s', value='%s', hasValue=%t",
 		match.TagName, match.Name, typeText, match.Value, match.HasValue)
 
-	switch {
-	case lowerTypeText == "boolean":
-		diagnostics = append(diagnostics, validateBooleanAttribute(match)...)
-	case lowerTypeText == "number":
-		diagnostics = append(diagnostics, validateNumberAttribute(match)...)
-	case lowerTypeText == "string":
-		// String attributes are very permissive - almost any value is valid
-	case strings.Contains(typeText, "|"):
+	valueNode, _, tree, parsed := tstype.ParseTypeValue(typeText)
+	if !parsed {
+		return diagnostics
+	}
+	defer tree.Close()
+
+	switch valueNode.GrammarName() {
+	case "predefined_type":
+		switch typeText {
+		case "boolean":
+			diagnostics = append(diagnostics, validateBooleanAttribute(match)...)
+		case "number":
+			diagnostics = append(diagnostics, validateNumberAttribute(match)...)
+		}
+	case "union_type":
 		diagnostics = append(diagnostics, validateUnionType(typeText, match)...)
-	case isLiteralType(typeText):
+	case "literal_type":
 		diagnostics = append(diagnostics, validateLiteralType(typeText, match)...)
-	case isArrayType(typeText):
+	case "array_type":
 		diagnostics = append(diagnostics, createArrayTypeInfo(match)...)
+	case "generic_type":
+		if isArrayType(typeText) {
+			diagnostics = append(diagnostics, createArrayTypeInfo(match)...)
+		}
 	default:
-		helpers.SafeDebugLog("[VALUE_DIAGNOSTICS] Skipping validation for unknown type: %s", typeText)
+		helpers.SafeDebugLog("[VALUE_DIAGNOSTICS] Skipping validation for type: %s (%s)", typeText, valueNode.GrammarName())
 	}
 
 	return diagnostics
@@ -461,13 +487,16 @@ func findAttributesWithValues(doc types.Document, ctx types.ServerContext) []Att
 	for _, element := range elements {
 		for attrName, attr := range element.Attributes {
 			match := AttributeMatch{
-				Name:     attrName,
-				TagName:  element.TagName,
-				Value:    attr.Value,
-				HasValue: true,
-				Line:     attr.Range.Start.Line,
-				StartCol: attr.Range.Start.Character,
-				EndCol:   attr.Range.End.Character,
+				Name:             attrName,
+				TagName:          element.TagName,
+				Value:            attr.Value,
+				HasValue:         true,
+				Line:             attr.Range.Start.Line,
+				StartCol:         attr.Range.Start.Character,
+				EndCol:           attr.Range.End.Character,
+				BindingPrefix:    attr.BindingPrefix,
+				ExpressionKind:   attr.ExpressionKind,
+				ExpressionDetail: attr.ExpressionDetail,
 			}
 			matches = append(matches, match)
 		}

--- a/lsp/methods/textDocument/publishDiagnostics/attributeValueDiagnostics_test.go
+++ b/lsp/methods/textDocument/publishDiagnostics/attributeValueDiagnostics_test.go
@@ -532,6 +532,36 @@ func TestAttributeValueDiagnostics_ArrayTypes(t *testing.T) {
 	}
 }
 
+// Inline: validates that plain HTML attribute values still produce diagnostics
+// (regression guard for binding prefix / expression skipping)
+
+func TestAttributeValueDiagnostics_PlainHTMLStillValidated(t *testing.T) {
+	ctx := testhelpers.NewMockServerContext()
+	content := `<my-element variant="invalid-value">Content</my-element>`
+
+	dm, err := document.NewDocumentManager()
+	if err != nil {
+		t.Fatalf("Failed to create DocumentManager: %v", err)
+	}
+	defer dm.Close()
+	ctx.SetDocumentManager(dm)
+	doc := dm.OpenDocument("test.html", content, 1)
+	ctx.AddDocument("test.html", doc)
+
+	ctx.AddAttributes("my-element", map[string]*M.Attribute{
+		"variant": {
+			FullyQualified: M.FullyQualified{Name: "variant"},
+			Type:           &M.Type{Text: "'primary' | 'secondary'"},
+		},
+	})
+
+	diagnostics := publishDiagnostics.AnalyzeAttributeValueDiagnosticsForTest(ctx, doc)
+
+	if len(diagnostics) == 0 {
+		t.Error("Expected diagnostics for invalid attribute value in plain HTML, got none")
+	}
+}
+
 func TestAttributeValueDiagnostics_StringTypes(t *testing.T) {
 	ctx := testhelpers.NewMockServerContext()
 	content := `<my-element label="Hello World" description="">Content</my-element>`

--- a/lsp/types/document.go
+++ b/lsp/types/document.go
@@ -113,10 +113,12 @@ type CustomElementMatch struct {
 
 // AttributeMatch represents a found attribute
 type AttributeMatch struct {
-	Name          string
-	Value         string
-	Range         protocol.Range
-	BindingPrefix string // Lit binding prefix: ".", "?", "@", or "" for plain attributes
+	Name             string
+	Value            string
+	Range            protocol.Range
+	BindingPrefix    string // Lit binding prefix: ".", "?", "@", or "" for plain attributes
+	ExpressionKind   string // "literal", "this-member", "identifier", "complex", or "" (not an expression)
+	ExpressionDetail string // member name, identifier name, or literal value depending on kind
 }
 
 // ElementDefinition represents a custom element with its source information


### PR DESCRIPTION
## Summary

- Filter unresolved type identifiers from completion suggestions (silence > noise)
- Classify template expression types (`${expr}`) in the TS document layer
- Skip value diagnostics for Lit binding prefixes (`.prop`, `@event`, `?bool`)
- Skip value diagnostics for expression-valued attributes
- Use tree-sitter grammar dispatch in `validateAttributeValue` instead of string matching
- Strip binding prefix in attribute name diagnostics before manifest lookup

## Details

Completion filtering: `parseUnionType` now only suggests quoted string literals
and boolean literals. Bare identifiers like `NavigationPrimaryPalette` (unresolved
type aliases), `null`, `undefined`, and primitives are silently dropped.

Expression classification: when a TS template attribute value contains `${...}`,
the TS tree is walked to find the matching `template_substitution` node and classify
the expression as literal, this-member, identifier, or complex. Classification
happens in the document layer; diagnostics layer consumes it.

Diagnostics: property bindings (`.prop`) pass JS values not HTML strings, event
bindings (`@event`) are function handlers, boolean bindings (`?attr`) control
presence via expression truthiness. All skip value validation. Expression-valued
attributes (`ExpressionKind != ""`) also skip validation since we cannot type-check
the expression without a full type checker.

Attribute name diagnostics now strip `.`/`?`/`@` prefixes before manifest lookup
and skip unknown-attribute diagnostics for `@` event bindings.

## Test plan

- [x] Red-first tests for completion filtering (5 cases)
- [x] Regression test: plain HTML attributes still validated
- [x] All existing LSP tests pass
- [x] `make lint` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced parsing of template expressions in custom-element attribute values, capturing expression kind and details.
  - Attribute diagnostics now interpret binding prefixes (e.g., property/event bindings) and use this context to decide validation.
  - Type-based completions now target quoted string literals and boolean (`true`/`false`) union members.

- **Bug Fixes**
  - Plain (non-binding) HTML attribute values continue to produce validation diagnostics.
  - Completion suggestions no longer include unresolved identifiers, `null`, or `undefined` when mixed with valid quoted literals/booleans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->