### PR TITLE
fix(serve): skip bad demo paths and strip urlTemplate prefix from local routes

### DIFF
--- a/serve/middleware/routes/helpers_test.go
+++ b/serve/middleware/routes/helpers_test.go
@@ -225,41 +225,11 @@ func TestExtractLocalRoute_PrefixStripping(t *testing.T) {
 			prefix: "/cem/examples",
 			want:   "/other/path/demo/",
 		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := extractLocalRoute(tt.url, tt.prefix)
-			if got != tt.want {
-				t.Errorf("extractLocalRoute(%q, %q) = %q, want %q", tt.url, tt.prefix, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestExtractLocalRoute_PrefixStripping(t *testing.T) {
-	tests := []struct {
-		name   string
-		url    string
-		prefix string
-		want   string
-	}{
 		{
-			name:   "strips deployment prefix from full URL",
-			url:    "https://example.com/cem/examples/kitchen-sink/demo-button/variants/",
+			name:   "prefix partial segment match not stripped",
+			url:    "https://example.com/cem/examples/kitchen-sink-extra/demo/",
 			prefix: "/cem/examples/kitchen-sink",
-			want:   "/demo-button/variants/",
-		},
-		{
-			name:   "no prefix leaves path unchanged",
-			url:    "https://example.com/demo-button/variants/",
-			prefix: "",
-			want:   "/demo-button/variants/",
-		},
-		{
-			name:   "prefix that does not match leaves path unchanged",
-			url:    "/other/path/demo/",
-			prefix: "/cem/examples",
-			want:   "/other/path/demo/",
+			want:   "/cem/examples/kitchen-sink-extra/demo/",
 		},
 	}
 	for _, tt := range tests {

--- a/serve/middleware/routes/helpers_test.go
+++ b/serve/middleware/routes/helpers_test.go
@@ -236,6 +236,42 @@ func TestExtractLocalRoute_PrefixStripping(t *testing.T) {
 	}
 }
 
+func TestExtractLocalRoute_PrefixStripping(t *testing.T) {
+	tests := []struct {
+		name   string
+		url    string
+		prefix string
+		want   string
+	}{
+		{
+			name:   "strips deployment prefix from full URL",
+			url:    "https://example.com/cem/examples/kitchen-sink/demo-button/variants/",
+			prefix: "/cem/examples/kitchen-sink",
+			want:   "/demo-button/variants/",
+		},
+		{
+			name:   "no prefix leaves path unchanged",
+			url:    "https://example.com/demo-button/variants/",
+			prefix: "",
+			want:   "/demo-button/variants/",
+		},
+		{
+			name:   "prefix that does not match leaves path unchanged",
+			url:    "/other/path/demo/",
+			prefix: "/cem/examples",
+			want:   "/other/path/demo/",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractLocalRoute(tt.url, tt.prefix)
+			if got != tt.want {
+				t.Errorf("extractLocalRoute(%q, %q) = %q, want %q", tt.url, tt.prefix, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSlugify(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/serve/middleware/routes/listing.go
+++ b/serve/middleware/routes/listing.go
@@ -200,7 +200,10 @@ func extractLocalRoute(demoURL string, demoURLPrefix string) string {
 
 	// Strip deployment prefix from urlTemplate (e.g. /cem/examples/kitchen-sink)
 	if demoURLPrefix != "" {
-		localRoute = strings.TrimPrefix(localRoute, demoURLPrefix)
+		after, found := strings.CutPrefix(localRoute, demoURLPrefix)
+		if found && (after == "" || after[0] == '/') {
+			localRoute = after
+		}
 	}
 
 	if strings.HasPrefix(localRoute, "./") {


### PR DESCRIPTION
## Summary

- Skip invalid demo paths (directory traversal) instead of failing the entire routing table
- Strip `urlTemplate` deployment prefix from local demo routes so links resolve on the dev server

## Problem

Two bugs caused all demo routes to 404 when using `cem serve -p`:

1. One invalid demo path (e.g. `../../patterns/feedback-card.html`) blocked the entire routing table. `BuildDemoRoutingTable` returned an error on the first bad entry, causing the caller to set `demoRoutes = nil`, which made every subsequent demo request fall through to 404.

2. Demo URLs generated from `urlTemplate` (e.g. `https://bennypowers.dev/cem/examples/kitchen-sink/demo-button/variants/`) kept the deployment path prefix in local routes. The landing page rendered links like `/cem/examples/kitchen-sink/demo-button/variants/` that didn't match any registered route on the local server.

## Changes

- `BuildDemoRoutingTable` and `buildPackageRoutingTable` now `continue` on path traversal errors instead of returning
- Added `DemoURLPrefixFromTemplate()` to extract the static prefix from a `urlTemplate` string
- `extractLocalRoute()` strips the deployment prefix before normalizing
- `DemoURLPrefix` threaded through `DevServerContext` interface, `Config`, and all callers
- Removed duplicate trailing-slash normalization in `BuildDemoRoutingTable`

## Test plan

- [x] `TestDemoURLPrefixFromTemplate` -- prefix extraction from various template shapes
- [x] `TestExtractLocalRoute_PrefixStripping` -- deployment prefix stripped from full URLs
- [x] `TestBuildDemoRoutingTable_DirectoryTraversalPrevention` -- bad entries skipped (not errored)
- [x] Existing duplicate detection and source href tests pass
- [x] All mock contexts updated with `DemoURLPrefix()` method
- [x] Visual verification: `cem serve -p examples/kitchen-sink` serves 24 demo routes, landing page links resolve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “CSS Custom States” section for demos that define CSS custom states, with toggle controls to apply or clear those states.
  * Updated default knob behavior to include CSS states when no knob selection is specified.
* **Bug Fixes**
  * Improved demo URL handling when the server runs behind a configured local route prefix.
  * Demo links and navigation (including listings and error views) now resolve to correct local routes.
  * Invalid demo paths are skipped during route generation so one malformed entry doesn’t prevent other demos from loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->